### PR TITLE
Centralize action-menu row injection behind a single declarative registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloFlairColors.xm \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
     $(SRC_DIR)/ApolloContextMenuPreviewTheme.xm \
+    $(SRC_DIR)/ApolloActionMenu.xm \
     $(SRC_DIR)/ApolloHostedVideo.m \
     $(SRC_DIR)/ApolloSportsClipResolver.m \
     $(SRC_DIR)/ApolloSportsClips.xm \

--- a/src/ApolloActionMenu.h
+++ b/src/ApolloActionMenu.h
@@ -1,0 +1,140 @@
+// ApolloActionMenu — feature-neutral single owner of Apollo's "..." action-menu
+// geometry, on BOTH rendering paths:
+//   - Liquid Glass (iOS 26): ApolloNativeActionMenus.xm converts Apollo's private
+//     ActionController sheet into a real UIKit UIMenu. This module supplies the
+//     extra UIMenuElements to splice into that menu's children.
+//   - Everything else: Apollo presents _TtC6Apollo16ActionController, a plain
+//     UIViewController+UITableView bottom sheet. This module owns EVERY hook on
+//     that class's table methods and on
+//     _TtC6Apollo38ActionControllerPresentationController's geometry.
+//
+// Exactly ONE module may hook _TtC6Apollo16ActionController's table delegate/
+// dataSource methods or ActionControllerPresentationController's
+// frameOfPresentedViewInContainerView. THIS IS THAT OWNER. A second module
+// hooking either of those on the same class re-enters the chain in an index
+// space the first module has already shifted — see src/settings/README.md's
+// "one remapper per screen, always" rule and PR #570 for why. Feature modules
+// never touch the table; they register WHAT they mean at %ctor time via
+// ApolloActionMenuRegister(). Registration order — and Makefile link order — is
+// irrelevant; slots are computed lazily, per controller, the first time any of
+// them is asked about.
+//
+// Additive only: this owns injecting/replacing rows, not hiding native ones.
+// A feature that needs to remove a native row (e.g. ApolloTranslation.xm's
+// bulk-translate row removal) mutates Apollo's raw Swift `actions` buffer
+// directly, in native index space, before presentation — that's a disjoint
+// concern this module doesn't need to know about (it composes cleanly: the
+// owner only ever sees the post-mutation native row count).
+//
+// See ApolloActionMenu.xm for the registry, the per-controller slot memoization,
+// and the shared lookalike row cell.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Where a declarative spec's row lands in the Liquid Glass UIMenu's children.
+// Legacy-sheet placement is NOT configurable here: every injected row is always
+// appended after the last native row on that path, ordered by `order`/
+// `identifier` — Apollo's own cellForRow dequeues with the index path it's
+// handed and UIKit asserts if a native row's index shifts, so native rows can
+// never move on the legacy path regardless of glass placement.
+typedef NS_ENUM(NSInteger, ApolloActionMenuPlacement) {
+    // End of the menu's children (DeletedComments' "Show/Hide Deleted Comments").
+    ApolloActionMenuPlacementAppend = 0,
+    // Immediately after the leading "Submit Post" row/post-type group, before
+    // everything else (Gallery View — reads as its own group right under the
+    // composer, never above it).
+    ApolloActionMenuPlacementAfterLeadingSubmitAffordance,
+};
+
+// One potential row. Register from a feature's %ctor via
+// ApolloActionMenuRegister(). Every block may be called multiple times across
+// the lifetime of a single sheet/menu presentation; `matches` is the only one
+// memoized per actionController (see ApolloActionMenu.xm), so it is safe (and
+// intended) for a feature to do one-shot claiming/disarming work inside it.
+@interface ApolloActionMenuSpec : NSObject
+
+// Required. Used as the legacy-sheet reuse identifier, the log prefix, and the
+// `order` tiebreak.
+@property (nonatomic, copy) NSString *identifier;
+
+// Tiebreak among multiple injected rows on the SAME sheet, ascending; ties break
+// on `identifier`. Independent of %ctor/Makefile link order. Default 0.
+@property (nonatomic, assign) NSInteger order;
+
+// Does this spec apply to this presentation? `menuTitle` is Apollo's own
+// actionsDescription string for the sheet (read once by the owner and handed to
+// every spec — see the header note on ApolloActionMenuInjectMenuElements).
+// Called once per controller and memoized; do any one-shot arm-claiming or
+// disarming here, not in `perform`.
+@property (nonatomic, copy) BOOL (^matches)(id actionController, NSString *menuTitle);
+
+// Row title/image, re-evaluated on every call (NOT memoized) so state that
+// changes between builds (DeletedComments' Show <-> Hide) stays correct. `donor`
+// is the live, already-built row-0 cell on the legacy path (for deriving text
+// styled the way Apollo's own rows are, e.g. PublicSticky's "<row 0's label> +
+// suffix"); nil on the glass path, where there is no cell to donate from.
+@property (nonatomic, copy) NSString *(^title)(id actionController, UITableViewCell *_Nullable donor);
+@property (nonatomic, copy) UIImage *_Nullable (^image)(id actionController, UITableViewCell *_Nullable donor);
+
+// Glass-menu insertion point for the declarative title/image path. Ignored if
+// `buildElement` is set.
+@property (nonatomic, assign) ApolloActionMenuPlacement placement;
+
+// Wrap the declarative row in its own UIMenuOptionsDisplayInline single-item
+// section (Gallery: YES, reads as a separated group; DeletedComments: NO).
+@property (nonatomic, assign) BOOL inlineSection;
+
+// Tap handler, shared by both paths.
+@property (nonatomic, copy) void (^perform)(id actionController);
+
+// Legacy path only: dismiss the sheet before running `perform`? Default YES
+// (Gallery, DeletedComments both dismiss then act). PublicSticky needs NO: its
+// `perform` forwards into the NATIVE row's own handler via
+// ApolloActionMenuInvokeNativeRow(), which drives Apollo's own compose flow and
+// dismisses itself. On the glass path this is never relevant — there's no
+// sheet, and ApolloNativeActionMenus.xm already swallows an ActionController's
+// self-dismiss while its "invoking" flag is set.
+@property (nonatomic, assign) BOOL legacyDismissesSheet;
+
+// Escape hatch for the glass path, for specs whose row can't be expressed
+// declaratively (PublicSticky clones a NATIVE UIMenuElement's title/image/
+// attributes/handler rather than building a new one, and inserts at an index it
+// discovers mid-scan rather than a fixed placement). Takes the live children
+// array so the block owns its own placement; return by mutating `children`, not
+// a return value. When set, `title`/`image`/`placement`/`inlineSection` are
+// ignored on the glass path (still used for the legacy row, since the legacy
+// path has no equivalent escape hatch — the shared row cell covers it).
+@property (nonatomic, copy, nullable) void (^buildElement)(id actionController, NSMutableArray<UIMenuElement *> *children);
+
+@end
+
+// Register a spec. Call from a feature's %ctor, after %init.
+void ApolloActionMenuRegister(ApolloActionMenuSpec *spec);
+
+// Glass path entry point, called once by ApolloNativeActionMenuBuildMenu while
+// assembling a sheet's UIMenu children, after Apollo's own native actions have
+// been appended and before the array is wrapped into the final UIMenu.
+void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *children,
+                                        NSString *menuTitle,
+                                        id actionController);
+
+// A donor cell's rendered label text (first non-empty UILabel found by walking
+// the cell's content tree). Apollo's action-sheet rows are custom-drawn, not
+// built on UITableViewCell.textLabel, so a spec deriving its legacy-path title
+// from the native row's own text (e.g. "<row 0's label> + suffix") must go
+// through this rather than reading donor.textLabel directly. nil when `donor`
+// is nil (the glass path never has one) or no label is found.
+NSString *_Nullable ApolloActionMenuDonorLabelText(UITableViewCell *_Nullable donor);
+
+// Legacy path: run a NATIVE row's own didSelectRowAtIndexPath: handler as if it
+// had been tapped directly, for a spec whose `perform` forwards into existing
+// Apollo behavior (PublicSticky re-running "Public Sticky"'s own compose flow).
+// Deliberately does NOT flag the controller as "invoking" the way
+// ApolloNativeActionMenuSelectRow (ApolloNativeActionMenus.xm, glass-only) does:
+// on the legacy path the sheet is genuinely on screen and must actually
+// dismiss when the native handler dismisses it, not have that swallowed.
+void ApolloActionMenuInvokeNativeRow(id actionController, NSInteger row);
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloActionMenu.xm
+++ b/src/ApolloActionMenu.xm
@@ -454,7 +454,13 @@ void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *childre
     }
 
     NSInteger slotIndex = indexPath.row - nativeCount;
-    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) { %orig; return; } // fail-soft
+    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) {
+        // Keep the Logos directive on its own line. Logos 2.4.1 consumes the
+        // remainder of a line containing %orig, which previously dropped the
+        // return and closing brace from generated Objective-C++.
+        %orig;
+        return;
+    }
 
     ApolloActionMenuSpec *spec = state.specs[(NSUInteger)slotIndex];
     [tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/src/ApolloActionMenu.xm
+++ b/src/ApolloActionMenu.xm
@@ -1,0 +1,499 @@
+// ApolloActionMenu — see ApolloActionMenu.h for the ownership contract this
+// module exists to enforce (single owner of _TtC6Apollo16ActionController's
+// table geometry and ActionControllerPresentationController's frame, on both
+// the Liquid Glass and legacy-sheet rendering paths).
+//
+// THE REGISTRY: feature modules call ApolloActionMenuRegister() from their
+// %ctor with an ApolloActionMenuSpec. Read lazily, so %ctor/Makefile link order
+// never matters (mirrors src/settings/ApolloSettingsGeneralTable.xm's registry).
+//
+// PER-CONTROLLER SLOTS: ApolloActionMenuSlotsForController() runs every spec's
+// `matches` exactly once per actionController instance, on whichever call site
+// asks first (glass's ApolloActionMenuInjectMenuElements, or any of the legacy
+// table hooks below), and memoizes the result via an associated object. This is
+// deliberately NOT a side effect of tableView:numberOfRowsInSection: — the
+// presentation-controller frame hook needs the matched spec count before the
+// table has necessarily reloaded, and computing on demand instead of on that
+// one call site removes the order dependency entirely.
+//
+// THE DONOR CELL: an injected row's declarative title/image blocks receive the
+// LIVE row-0 cell as `donor` on the legacy path, fetched by calling the
+// controller's own (real, un-hooked-for-row-0) cellForRowAtIndexPath: — never
+// captured opportunistically off whatever row happened to build first. Same
+// technique as ApolloSettingsGeneralTable.xm's factory(vc, donor).
+//
+// GEOMETRY: legacy rows are always appended after the last native row (Apollo's
+// own cellForRow dequeues with the index path it's handed; UIKit asserts if a
+// native row's index shifts) and the presented sheet's frame grows by
+// rowHeight * matchedSpecCount. Nothing here grows the inner tableView's own
+// frame — an earlier version of this feature set (ApolloPublicStickyAsSubreddit)
+// did that via viewDidLayoutSubviews and it visibly ate the gap Apollo leaves
+// between the rows card and the Cancel button (confirmed on-device); Gallery's
+// and DeletedComments' outer-frame-only growth was correct all along.
+
+#import "ApolloActionMenu.h"
+#import "ApolloCommon.h"
+#import "ApolloSwiftRuntime.h"
+#import "ApolloThemeRuntime.h"
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#pragma mark - Registry
+
+@implementation ApolloActionMenuSpec
+@end
+
+static NSMutableArray<ApolloActionMenuSpec *> *sApolloActionMenuRegistry;
+
+void ApolloActionMenuRegister(ApolloActionMenuSpec *spec) {
+    if (!spec.identifier.length || !spec.matches || !spec.perform) {
+        ApolloLog(@"[ActionMenu] Refusing to register an incomplete spec (%@)", spec.identifier);
+        return;
+    }
+    if (!sApolloActionMenuRegistry) sApolloActionMenuRegistry = [NSMutableArray array];
+    [sApolloActionMenuRegistry addObject:spec];
+}
+
+#pragma mark - Per-controller slot memoization
+
+@interface ApolloActionMenuSlotState : NSObject
+@property (nonatomic, copy) NSArray<ApolloActionMenuSpec *> *specs; // matched, ordered
+@property (nonatomic, assign) NSInteger nativeRowCount; // -1 until numberOfRows(section 0) has run
+// A standalone (never dequeued, never added to any table) snapshot cell
+// carrying row 0's captured text/font/color/frame, rebuilt every time row 0
+// naturally renders. NOT a live cell — see ApolloActionMenuCaptureDonorSnapshot
+// for why an injected row's cellForRow can never fetch row 0 "live".
+@property (nonatomic, strong) UITableViewCell *donorSnapshot;
+@end
+@implementation ApolloActionMenuSlotState
+- (instancetype)init {
+    self = [super init];
+    if (self) _nativeRowCount = -1;
+    return self;
+}
+@end
+
+static const void *kApolloActionMenuSlotStateKey = &kApolloActionMenuSlotStateKey;
+
+// Apollo's own actionsDescription Swift string for the sheet, falling back to
+// probing titleForHeaderInSection: the way ApolloPublicStickyAsSubreddit used to
+// on every delegate call — here it only runs once, at memoization time.
+static NSString *ApolloActionMenuTitleForController(id controller) {
+    NSString *title = ApolloReadSwiftStringIvar(controller, "actionsDescription");
+    if (title.length > 0) return title;
+
+    if ([controller respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
+        UITableView *tableView = ApolloReadObjectIvar(controller, "tableView");
+        @try {
+            NSString *header = [(id<UITableViewDataSource>)controller tableView:tableView
+                                                       titleForHeaderInSection:0];
+            if ([header isKindOfClass:[NSString class]]) return header;
+        } @catch (__unused NSException *exception) {
+        }
+    }
+    return @"";
+}
+
+// menuTitleHint: pass the already-known title from the glass path to skip the
+// re-derivation above; pass nil from the legacy hooks (memoized either way, so
+// this only ever runs once per controller regardless).
+static ApolloActionMenuSlotState *ApolloActionMenuSlotsForController(id controller, NSString *menuTitleHint) {
+    if (!controller) return nil;
+
+    ApolloActionMenuSlotState *state = objc_getAssociatedObject(controller, kApolloActionMenuSlotStateKey);
+    if (state) return state;
+
+    NSString *menuTitle = menuTitleHint.length > 0 ? menuTitleHint : ApolloActionMenuTitleForController(controller);
+
+    NSMutableArray<ApolloActionMenuSpec *> *matched = [NSMutableArray array];
+    for (ApolloActionMenuSpec *spec in sApolloActionMenuRegistry) {
+        BOOL (^matches)(id, NSString *) = spec.matches;
+        if (!matches) continue;
+        @try {
+            if (matches(controller, menuTitle)) [matched addObject:spec];
+        } @catch (NSException *exception) {
+            ApolloLog(@"[ActionMenu] spec '%@' matches: threw %@", spec.identifier, exception);
+        }
+    }
+    [matched sortUsingComparator:^NSComparisonResult(ApolloActionMenuSpec *a, ApolloActionMenuSpec *b) {
+        if (a.order != b.order) return a.order < b.order ? NSOrderedAscending : NSOrderedDescending;
+        return [a.identifier compare:b.identifier];
+    }];
+
+    state = [ApolloActionMenuSlotState new];
+    state.specs = matched;
+    objc_setAssociatedObject(controller, kApolloActionMenuSlotStateKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (matched.count > 0) {
+        ApolloLog(@"[ActionMenu] %lu spec(s) matched '%@': %@", (unsigned long)matched.count, menuTitle,
+                  [matched valueForKey:@"identifier"]);
+    }
+    return state;
+}
+
+static CGFloat ApolloActionMenuNativeRowHeight(id controller) {
+    id tableView = ApolloReadObjectIvar(controller, "tableView");
+    if (![tableView isKindOfClass:[UITableView class]]) return 0.0;
+    if (![controller respondsToSelector:@selector(tableView:heightForRowAtIndexPath:)]) return 0.0;
+    @try {
+        return [(id<UITableViewDelegate>)controller tableView:(UITableView *)tableView
+                                    heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    } @catch (__unused NSException *exception) {
+        return 0.0;
+    }
+}
+
+#pragma mark - Legacy path: donor-styled lookalike cell
+
+static UIView *ApolloActionMenuFirstSubviewOfClass(UIView *root, Class cls, BOOL requireLabelText) {
+    for (UIView *subview in root.subviews) {
+        if ([subview isKindOfClass:cls]) {
+            if (!requireLabelText) return subview;
+            if ([subview isKindOfClass:[UILabel class]] && ((UILabel *)subview).text.length > 0) return subview;
+        }
+        UIView *nested = ApolloActionMenuFirstSubviewOfClass(subview, cls, requireLabelText);
+        if (nested) return nested;
+    }
+    return nil;
+}
+
+@interface ApolloActionMenuRowCell : UITableViewCell
+@property (nonatomic, strong) UILabel *apolloTitleLabel;
+@property (nonatomic, strong) UIImageView *apolloIconView;
+@property (nonatomic, assign) CGRect apolloTitleFrame;
+@property (nonatomic, assign) CGRect apolloIconFrame;
+@end
+
+@implementation ApolloActionMenuRowCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.backgroundColor = UIColor.clearColor;
+        self.contentView.backgroundColor = UIColor.clearColor;
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+
+        _apolloIconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _apolloIconView.contentMode = UIViewContentModeScaleAspectFit;
+        [self.contentView addSubview:_apolloIconView];
+
+        _apolloTitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        [self.contentView addSubview:_apolloTitleLabel];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect bounds = self.contentView.bounds;
+
+    if (!CGRectIsEmpty(self.apolloIconFrame)) {
+        CGRect iconFrame = self.apolloIconFrame;
+        iconFrame.origin.y = (bounds.size.height - iconFrame.size.height) / 2.0;
+        self.apolloIconView.frame = iconFrame;
+        self.apolloIconView.hidden = NO;
+    } else {
+        self.apolloIconView.hidden = YES;
+    }
+
+    CGFloat titleLeft = CGRectIsEmpty(self.apolloTitleFrame) ? 16.0 : CGRectGetMinX(self.apolloTitleFrame);
+    CGFloat titleHeight = CGRectIsEmpty(self.apolloTitleFrame) ? 22.0 : CGRectGetHeight(self.apolloTitleFrame);
+    self.apolloTitleLabel.frame = CGRectMake(titleLeft,
+                                             (bounds.size.height - titleHeight) / 2.0,
+                                             MAX(0.0, bounds.size.width - titleLeft - 16.0),
+                                             titleHeight);
+}
+
+@end
+
+// Snapshots row 0's rendered text/style into a standalone UITableViewCell that
+// is never dequeued and never added to any table — just a carrier
+// ApolloActionMenuFirstSubviewOfClass / ApolloActionMenuDonorLabelText can walk
+// exactly like a live cell.
+//
+// This exists because an injected row's cellForRowAtIndexPath: CANNOT fetch a
+// "live" row-0 cell by calling %orig with row 0's index path: Apollo's cell
+// builder calls -[UITableView dequeueReusableCellWithIdentifier:forIndexPath:],
+// and that method asserts if the index path it's given doesn't match whatever
+// row the table's internal state currently believes it's preparing — which,
+// mid-build of the INJECTED row, is never row 0. Doing that crashed with
+// NSInternalInconsistencyException the moment a subreddit "..." sheet's Gallery
+// View row (or any injected row) was built. So the ONLY safe capture point is
+// the table's own natural, non-reentrant ask for row 0 itself — see the
+// cellForRowAtIndexPath: hook below, which calls this only from that ask.
+static UITableViewCell *ApolloActionMenuCaptureDonorSnapshot(UITableViewCell *realRow0Cell) {
+    if (![realRow0Cell isKindOfClass:[UITableViewCell class]]) return nil;
+    [realRow0Cell layoutIfNeeded];
+
+    UILabel *label = (UILabel *)ApolloActionMenuFirstSubviewOfClass(realRow0Cell, [UILabel class], YES);
+    UIImageView *icon = (UIImageView *)ApolloActionMenuFirstSubviewOfClass(realRow0Cell, [UIImageView class], NO);
+    if (!label && !icon) return nil;
+
+    UITableViewCell *snapshot = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    if (label) {
+        UILabel *snapshotLabel = [[UILabel alloc] initWithFrame:[label convertRect:label.bounds toView:realRow0Cell]];
+        snapshotLabel.text = label.text;
+        snapshotLabel.textColor = label.textColor;
+        snapshotLabel.font = label.font;
+        snapshotLabel.textAlignment = label.textAlignment;
+        [snapshot.contentView addSubview:snapshotLabel];
+    }
+    if (icon && icon.bounds.size.width > 1.0) {
+        UIImageView *snapshotIcon = [[UIImageView alloc] initWithFrame:[icon convertRect:icon.bounds toView:realRow0Cell]];
+        snapshotIcon.tintColor = icon.tintColor;
+        [snapshot.contentView addSubview:snapshotIcon];
+    }
+    return snapshot;
+}
+
+// Style captured from the donor (Apollo's own row-0 cell — custom-drawn icon +
+// accent-tinted label at its own insets, so a stock UITableViewCell.textLabel
+// would land in the wrong place with the wrong color) and applied to `cell`.
+static void ApolloActionMenuConfigureRowCell(ApolloActionMenuRowCell *cell, NSString *title,
+                                             UIImage *image, UITableViewCell *donor) {
+    UIColor *titleColor = nil;
+    UIFont *titleFont = nil;
+    NSTextAlignment alignment = NSTextAlignmentLeft;
+    CGRect titleFrame = CGRectZero;
+    CGRect iconFrame = CGRectZero;
+    UIColor *iconTint = nil;
+
+    if ([donor isKindOfClass:[UITableViewCell class]]) {
+        [donor layoutIfNeeded];
+        UILabel *label = (UILabel *)ApolloActionMenuFirstSubviewOfClass(donor, [UILabel class], YES);
+        if (label) {
+            titleColor = label.textColor;
+            titleFont = label.font;
+            alignment = label.textAlignment;
+            titleFrame = [label convertRect:label.bounds toView:donor];
+        }
+        UIImageView *icon = (UIImageView *)ApolloActionMenuFirstSubviewOfClass(donor, [UIImageView class], NO);
+        if (icon && icon.bounds.size.width > 1.0) {
+            iconFrame = [icon convertRect:icon.bounds toView:donor];
+            iconTint = icon.tintColor;
+        }
+    }
+
+    // The accent is the right last resort: Apollo tints these rows with the
+    // theme accent, so it matches even when the donor capture came up empty.
+    UIColor *tint = titleColor ?: ApolloThemeAccentColor() ?: UIColor.labelColor;
+
+    cell.apolloTitleLabel.text = title;
+    cell.apolloTitleLabel.textColor = tint;
+    cell.apolloTitleLabel.font = titleFont ?: [UIFont systemFontOfSize:17.0];
+    cell.apolloTitleLabel.textAlignment = alignment;
+    cell.apolloIconView.image = image;
+    cell.apolloIconView.tintColor = iconTint ?: tint;
+    cell.apolloTitleFrame = titleFrame;
+    cell.apolloIconFrame = iconFrame;
+    cell.accessibilityLabel = title;
+    [cell setNeedsLayout];
+}
+
+NSString *ApolloActionMenuDonorLabelText(UITableViewCell *donor) {
+    if (![donor isKindOfClass:[UITableViewCell class]]) return nil;
+    UILabel *label = (UILabel *)ApolloActionMenuFirstSubviewOfClass(donor, [UILabel class], YES);
+    return label.text;
+}
+
+#pragma mark - Legacy path: invoking a native row's own handler
+
+void ApolloActionMenuInvokeNativeRow(id actionController, NSInteger row) {
+    if (!actionController) return;
+    if (![actionController respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)]) {
+        ApolloLog(@"[ActionMenu] Cannot invoke native row %ld — no didSelectRowAtIndexPath:", (long)row);
+        return;
+    }
+    UITableView *tableView = ApolloReadObjectIvar(actionController, "tableView");
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:0];
+    // Re-enters this file's own didSelectRowAtIndexPath: hook below at `row`,
+    // which — being a native index, not an injected slot — falls straight
+    // through to %orig. Deliberately a plain dispatch, not
+    // ApolloNativeActionMenuSelectRow's "invoking" flag (ApolloNativeActionMenus.xm,
+    // glass-only): the legacy sheet is genuinely on screen and must actually
+    // dismiss when the native handler dismisses it.
+    ((void (*)(id, SEL, id, id))objc_msgSend)(actionController, @selector(tableView:didSelectRowAtIndexPath:),
+                                              tableView, indexPath);
+}
+
+#pragma mark - Glass path
+
+static NSUInteger ApolloActionMenuLeadingSubmitAffordanceIndex(NSArray<UIMenuElement *> *children) {
+    NSUInteger index = 0;
+    while (index < children.count) {
+        UIMenuElement *element = children[index];
+        if ([element isKindOfClass:[UIMenu class]]) { index++; continue; }
+        if ([element isKindOfClass:[UIAction class]] &&
+            [((UIAction *)element).title hasPrefix:@"Submit"]) { index++; continue; }
+        break;
+    }
+    return index;
+}
+
+void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *children,
+                                        NSString *menuTitle,
+                                        id actionController) {
+    if (![children isKindOfClass:[NSMutableArray class]] || !actionController) return;
+
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(actionController, menuTitle);
+    if (state.specs.count == 0) return;
+
+    for (ApolloActionMenuSpec *spec in state.specs) {
+        @try {
+            if (spec.buildElement) {
+                spec.buildElement(actionController, children);
+                continue;
+            }
+
+            NSString *title = spec.title ? spec.title(actionController, nil) : nil;
+            if (title.length == 0) continue;
+            UIImage *image = spec.image ? spec.image(actionController, nil) : nil;
+
+            void (^perform)(id) = spec.perform;
+            UIAction *action = [UIAction actionWithTitle:title
+                                                    image:image
+                                               identifier:nil
+                                                  handler:^(__unused __kindof UIAction *sender) {
+                if (perform) perform(actionController);
+            }];
+
+            UIMenuElement *element = action;
+            if (spec.inlineSection) {
+                element = [UIMenu menuWithTitle:@"" image:nil identifier:nil
+                                        options:UIMenuOptionsDisplayInline children:@[action]];
+            }
+
+            NSUInteger index = (spec.placement == ApolloActionMenuPlacementAfterLeadingSubmitAffordance)
+                ? ApolloActionMenuLeadingSubmitAffordanceIndex(children)
+                : children.count;
+            [children insertObject:element atIndex:MIN(index, children.count)];
+        } @catch (NSException *exception) {
+            ApolloLog(@"[ActionMenu] spec '%@' build threw: %@", spec.identifier, exception);
+        }
+    }
+}
+
+#pragma mark - Legacy path: the single table/geometry owner
+
+%hook _TtC6Apollo16ActionController
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSInteger nativeCount = %orig;
+    if (section != 0) return nativeCount;
+
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(self, nil);
+    state.nativeRowCount = nativeCount;
+    if (state.specs.count == 0) return nativeCount;
+    return nativeCount + (NSInteger)state.specs.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(self, nil);
+    NSInteger nativeCount = state.nativeRowCount;
+
+    if (state.specs.count == 0 || indexPath.section != 0 || nativeCount < 0 || indexPath.row < nativeCount) {
+        UITableViewCell *cell = %orig;
+        // Opportunistically snapshot row 0's real rendered style/text — the ONLY
+        // safe way to get a donor for the injected rows below. This must run on
+        // UIKit's OWN, non-reentrant ask for row 0; see
+        // ApolloActionMenuCaptureDonorSnapshot for why an injected row's own
+        // cellForRow can never re-invoke %orig for row 0 (it crashes). Captured
+        // fresh every time row 0 builds so a live theme change never leaves the
+        // snapshot stale.
+        if (state.specs.count > 0 && indexPath.row == 0) {
+            state.donorSnapshot = ApolloActionMenuCaptureDonorSnapshot(cell);
+        }
+        return cell;
+    }
+
+    NSInteger slotIndex = indexPath.row - nativeCount;
+    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) return %orig; // fail-soft, shouldn't happen
+
+    ApolloActionMenuSpec *spec = state.specs[(NSUInteger)slotIndex];
+    // nil until row 0 has naturally rendered at least once (e.g. a restored
+    // scroll position skipping straight past it) — every consumer already
+    // falls back gracefully on a nil donor.
+    UITableViewCell *donor = state.donorSnapshot;
+
+    NSString *title = spec.title ? spec.title(self, donor) : nil;
+    if (title.length == 0) {
+        // Fail-soft: UIKit's non-nil-cell contract applies to every spec, not
+        // just the ones whose state happens to still resolve.
+        UITableViewCell *inert = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                                          reuseIdentifier:@"ApolloActionMenuInert"];
+        inert.userInteractionEnabled = NO;
+        inert.selectionStyle = UITableViewCellSelectionStyleNone;
+        return inert;
+    }
+    UIImage *image = spec.image ? spec.image(self, donor) : nil;
+
+    ApolloActionMenuRowCell *cell = [[ApolloActionMenuRowCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                                                    reuseIdentifier:spec.identifier];
+    ApolloActionMenuConfigureRowCell(cell, title, image, donor);
+    return cell;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(self, nil);
+    NSInteger nativeCount = state.nativeRowCount;
+
+    if (state.specs.count == 0 || indexPath.section != 0 || nativeCount < 0 || indexPath.row < nativeCount) {
+        return %orig;
+    }
+    // Ask Apollo how tall its own rows are rather than guessing.
+    return %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:0]);
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(self, nil);
+    NSInteger nativeCount = state.nativeRowCount;
+
+    if (state.specs.count == 0 || indexPath.section != 0 || nativeCount < 0 || indexPath.row < nativeCount) {
+        %orig;
+        return;
+    }
+
+    NSInteger slotIndex = indexPath.row - nativeCount;
+    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) { %orig; return; } // fail-soft
+
+    ApolloActionMenuSpec *spec = state.specs[(NSUInteger)slotIndex];
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    __strong id strongSelf = self;
+    void (^perform)(id) = spec.perform;
+    if (spec.legacyDismissesSheet) {
+        [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
+            if (perform) perform(strongSelf);
+        }];
+    } else if (perform) {
+        perform(strongSelf);
+    }
+}
+
+%end
+
+%hook _TtC6Apollo38ActionControllerPresentationController
+
+- (CGRect)frameOfPresentedViewInContainerView {
+    CGRect frame = %orig;
+    UIViewController *presented = [(UIPresentationController *)self presentedViewController];
+    if (frame.size.height <= 0.0 || !presented) return frame;
+
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(presented, nil);
+    if (state.specs.count == 0) return frame;
+
+    CGFloat rowHeight = ApolloActionMenuNativeRowHeight(presented);
+    if (rowHeight <= 0.0) return frame;
+
+    CGFloat growth = rowHeight * (CGFloat)state.specs.count;
+    frame.origin.y -= growth;
+    frame.size.height += growth;
+    return frame;
+}
+
+%end
+
+%ctor {
+    %init;
+    ApolloLog(@"[ActionMenu] Action-menu registry hooks installed");
+}

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -178,20 +178,6 @@ uint32_t ApolloPackedColorFromHexString(NSString *hex);
 // snapshot for the renderer. Call on the main thread.
 void ApolloSetLinkPreviewCardColorHex(NSString *hex);
 
-// Issue #515 (ApolloPublicStickyAsSubreddit): when `menuTitle` is the removal
-// "Notify user via…" menu, append a "Public Sticky from Subreddit" UIAction to
-// `children` (an NSMutableArray<UIMenuElement *>). No-op for any other menu.
-// Called from ApolloNativeActionMenuBuildMenu as it converts the action sheet.
-void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSString *menuTitle);
-
-// ApolloDeletedCommentsMenu: when the comments view's "..." menu is being
-// built, append a "Show/Hide Deleted Comments" UIAction to `children`
-// (an NSMutableArray<UIMenuElement *>). No-op for any other menu. Called from
-// ApolloNativeActionMenuBuildMenu as it converts the action sheet; the
-// ActionController is tagged on first build so re-builds re-inject and other
-// menus can't claim the item.
-void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);
-
 // Whether the experimental native Polls feature (voting + creation) is enabled.
 // Off by default; toggled from Settings → Polls (UDKeyPollsEnabled). All poll
 // entry points — the poll-node tap handler, remembered-vote reconciliation, the
@@ -248,13 +234,6 @@ BOOL ApolloTabBarVisualProviderBoolIvar(UITabBar *tabBar, const char *name, BOOL
 // also write to the diag log.
 NSString *ApolloDebugAccountKeychainReport(void);
 NSString *ApolloDebugPoisonAccountAccessibility(void);
-
-// ApolloGalleryMenu: when the subreddit "..." menu is being built, insert an
-// inline "Gallery View" section into `children` (an NSMutableArray<UIMenuElement *>),
-// just below the leading "submit a post" affordance.
-// No-op for any other menu, and for feeds that aren't a single subreddit.
-// Called from ApolloNativeActionMenuBuildMenu as it converts the action sheet.
-void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);
 
 // Marks a tweak-created text node/label as our own UI chrome (AI summary pill,
 // injected affordances, ...). Content pipelines that scan the view/node tree

--- a/src/ApolloDeletedCommentsMenu.xm
+++ b/src/ApolloDeletedCommentsMenu.xm
@@ -1,9 +1,11 @@
 // Deleted-comments shortcut in the comments "..." menu + passive per-thread mode.
 //
 // Adds a "Show Deleted Comments" / "Hide Deleted Comments" item to the comments
-// view's overflow menu. Liquid Glass uses the native UIMenu assembled by
-// ApolloNativeActionMenus.xm; Standard/pre-Liquid-Glass builds append an
-// equivalent row to Apollo's legacy ActionController table.
+// view's overflow menu. Row rendering on both the Liquid Glass UIMenu and the
+// legacy ActionController sheet is owned entirely by ApolloActionMenu.{h,xm} —
+// see that header for the single-owner rationale. This file supplies the
+// feature-specific parts: WHICH sheet is "the comments' ... menu" (arming
+// below), the title/icon toggling between Show and Hide, and what a tap does.
 //
 // Two behaviors, decided by the "Passive Deleted Comments" setting:
 //   - Passive OFF: the item is a plain shortcut for the global Show Deleted
@@ -21,10 +23,10 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 
+#import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "ApolloDeletedCommentsData.h"
-#import "ApolloThemeRuntime.h"
 #import "UserDefaultConstants.h"
 
 static NSString *const kApolloDCMenuShowTitle = @"Show Deleted Comments";
@@ -32,9 +34,9 @@ static NSString *const kApolloDCMenuHideTitle = @"Hide Deleted Comments";
 
 // The comments VC currently presenting its "..." menu. Armed in the tap hook
 // below; menu construction happens synchronously inside that tap (see
-// ApolloNativeActionMenus' Begin/EndCapture bracket), but a short grace window
-// keeps this robust if UIKit ever defers a runloop turn. The FIRST menu built
-// while armed consumes the arm (the ActionController gets tagged with the
+// ApolloActionMenu's per-controller `matches` memoization), but a short grace
+// window keeps this robust if UIKit ever defers a runloop turn. The FIRST menu
+// built while armed consumes the arm (the ActionController gets tagged with the
 // owning VC below), so a different menu opened moments later can never pick
 // up the item.
 static __weak id sApolloDCMenuArmedVC = nil;
@@ -44,8 +46,6 @@ static CFAbsoluteTime sApolloDCMenuArmedAt = 0;
 // hash table holding the owning CommentsViewController (a plain weak assoc
 // isn't possible with objc_setAssociatedObject).
 static char kApolloDCMenuOwnerVCKey;
-// Row count before our appended legacy ActionController row.
-static char kApolloDCMenuOrigRowCountKey;
 
 // linkFullName key -> weak set of CommentsViewController instances currently
 // showing that post's thread. Main-thread only. When the last live VC for an
@@ -70,8 +70,9 @@ static id ApolloDCMenuIvarObject(id object, const char *name) {
 }
 
 // Resolve and permanently tag the ActionController presenting the armed
-// comments menu. Both the Liquid Glass UIMenu builder and the legacy table
-// sheet use this same one-shot claim, whichever asks first.
+// comments menu. Both the ApolloActionMenu `matches` block and any later
+// re-ask (e.g. `title`, `perform`) use this same one-shot claim, whichever
+// asks first.
 static id ApolloDCMenuOwnerForController(id actionController) {
     if (!actionController) return nil;
     NSHashTable *holder = objc_getAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey);
@@ -162,7 +163,7 @@ static void ApolloDCMenuRefreshComments(id vc) {
 }
 
 static void ApolloDCMenuPresentSlowdownWarning(id vc) {
-    // Give the context menu's dismissal animation a beat before presenting.
+    // Give the context menu's / sheet's dismissal animation a beat before presenting.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UIViewController *host = (UIViewController *)vc;
         if (![host isKindOfClass:[UIViewController class]] || !host.viewLoaded || !host.view.window) return;
@@ -213,37 +214,28 @@ static void ApolloDCMenuHandleToggle(id vc, NSString *linkKey, BOOL wasEffective
     ApolloDCMenuRefreshComments(vc);
 }
 
-#pragma mark - Menu injection (called from ApolloNativeActionMenuBuildMenu)
+#pragma mark - Resolving whether/how the row applies
 
-void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController) {
-    (void)menuTitle;
-    if (!children || children.count == 0) return;
-
-    // Re-builds of an already-claimed "..." menu (the builder runs more than
-    // once per presentation) reuse the tag; otherwise the FIRST menu built
-    // while armed claims the armed VC and consumes the arm, so a different
-    // menu opened within the grace window can never pick up the item.
+// Resolves the owning comments VC, its per-thread link key, and whether
+// deleted-comment recovery is CURRENTLY effective for it. Returns NO when this
+// isn't the comments "..." menu, or (passive mode) when there's no post to key
+// a per-thread override on. Called fresh from `matches`, `title`, and `perform`
+// — never memoized beyond ApolloActionMenu's own once-per-controller `matches`
+// call, so a change in global/per-thread state between build and tap is always
+// picked up.
+static BOOL ApolloDCMenuResolveState(id actionController, id *outVC,
+                                     NSString **outLinkKey, BOOL *outEffective) {
     id vc = ApolloDCMenuOwnerForController(actionController);
-    if (!vc) return;
-
+    if (!vc) return NO;
     NSString *linkKey = ApolloDCMenuLinkKeyForVC(vc);
     BOOL passive = sPassiveDeletedComments && !sShowDeletedComments;
-    // Per-thread toggling needs a post to key the override on.
-    if (passive && linkKey.length == 0) return;
-
-    BOOL effective = sShowDeletedComments || (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
-    NSString *title = effective ? kApolloDCMenuHideTitle : kApolloDCMenuShowTitle;
-    UIImage *image = [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
-
-    __weak id weakVC = vc;
-    UIAction *toggle = [UIAction actionWithTitle:title
-                                           image:image
-                                      identifier:nil
-                                         handler:^(__unused __kindof UIAction *action) {
-        ApolloDCMenuHandleToggle(weakVC, linkKey, effective);
-    }];
-    [children addObject:toggle];
-    ApolloLog(@"[DeletedCommentsMenu] Injected '%@' (passive=%d, link=%@)", title, passive, linkKey ?: @"-");
+    if (passive && linkKey.length == 0) return NO;
+    BOOL effective = sShowDeletedComments ||
+        (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
+    if (outVC) *outVC = vc;
+    if (outLinkKey) *outLinkKey = linkKey;
+    if (outEffective) *outEffective = effective;
+    return YES;
 }
 
 #pragma mark - CommentsViewController lifecycle
@@ -254,7 +246,7 @@ void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSStr
     sApolloDCMenuArmedVC = self;
     sApolloDCMenuArmedAt = CFAbsoluteTimeGetCurrent();
     %orig;
-    // The arm is consumed by the first menu build (see the injection function);
+    // The arm is consumed by the first menu build (see ApolloDCMenuOwnerForController);
     // the timestamp grace window expires it if no menu was built at all.
 }
 
@@ -287,238 +279,41 @@ void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSStr
 
 %end
 
-#pragma mark - Legacy ActionController row (Standard / pre-Liquid-Glass)
+#pragma mark - Registration
 
-// Apollo's non-Liquid-Glass overflow menu is an ActionController-backed table
-// sheet. Keep every native row at its original index and append ours: Apollo's
-// own cell builder dequeues with the supplied index path and will assert if
-// native rows are shifted.
-static NSInteger ApolloDCMenuOriginalRowCount(id actionController) {
-    NSNumber *stored = objc_getAssociatedObject(actionController, &kApolloDCMenuOrigRowCountKey);
-    return stored ? stored.integerValue : -1;
-}
+%ctor {
+    %init;
 
-static BOOL ApolloDCMenuResolveState(id actionController, id *outVC,
-                                     NSString **outLinkKey, BOOL *outEffective) {
-    id vc = ApolloDCMenuOwnerForController(actionController);
-    if (!vc) return NO;
-    NSString *linkKey = ApolloDCMenuLinkKeyForVC(vc);
-    BOOL passive = sPassiveDeletedComments && !sShowDeletedComments;
-    if (passive && linkKey.length == 0) return NO;
-    BOOL effective = sShowDeletedComments ||
-        (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
-    if (outVC) *outVC = vc;
-    if (outLinkKey) *outLinkKey = linkKey;
-    if (outEffective) *outEffective = effective;
-    return YES;
-}
+    ApolloActionMenuSpec *spec = [ApolloActionMenuSpec new];
+    spec.identifier = @"DeletedComments";
+    spec.placement = ApolloActionMenuPlacementAppend;
+    spec.inlineSection = NO;
+    spec.legacyDismissesSheet = YES;
 
-static BOOL ApolloDCMenuIsLegacyRow(id actionController, NSIndexPath *indexPath) {
-    NSInteger originalCount = ApolloDCMenuOriginalRowCount(actionController);
-    return originalCount >= 0 && indexPath.section == 0 && indexPath.row == originalCount;
-}
-
-static CGFloat ApolloDCMenuLegacyRowHeight(id actionController) {
-    id tableView = ApolloDCMenuIvarObject(actionController, "tableView");
-    if (![tableView isKindOfClass:[UITableView class]] ||
-        ![actionController respondsToSelector:@selector(tableView:heightForRowAtIndexPath:)]) {
-        return 0.0;
-    }
-    @try {
-        return [(id<UITableViewDelegate>)actionController
-                    tableView:(UITableView *)tableView
-                    heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
-    } @catch (__unused NSException *exception) {
-        return 0.0;
-    }
-}
-
-// Apollo's sheet rows use custom labels/icons rather than UITableViewCell's
-// stock textLabel geometry. Capture row 0 and mirror its presentation so the
-// appended row remains readable under stock and custom themes.
-static UIView *ApolloDCMenuFirstSubviewOfClass(UIView *root, Class cls, BOOL requireText) {
-    for (UIView *subview in root.subviews) {
-        if ([subview isKindOfClass:cls]) {
-            if (!requireText) return subview;
-            if ([subview isKindOfClass:[UILabel class]] &&
-                ((UILabel *)subview).text.length > 0) {
-                return subview;
-            }
-        }
-        UIView *nested = ApolloDCMenuFirstSubviewOfClass(subview, cls, requireText);
-        if (nested) return nested;
-    }
-    return nil;
-}
-
-static UIColor *sApolloDCMenuTitleColor = nil;
-static UIFont *sApolloDCMenuTitleFont = nil;
-static NSTextAlignment sApolloDCMenuTitleAlignment = NSTextAlignmentLeft;
-static CGRect sApolloDCMenuTitleFrame = CGRectZero;
-static CGRect sApolloDCMenuIconFrame = CGRectZero;
-static UIColor *sApolloDCMenuIconTint = nil;
-
-static void ApolloDCMenuCaptureLegacyRowStyle(UITableViewCell *cell) {
-    if (![cell isKindOfClass:[UITableViewCell class]]) return;
-    [cell layoutIfNeeded];
-    UILabel *label =
-        (UILabel *)ApolloDCMenuFirstSubviewOfClass(cell, [UILabel class], YES);
-    if (!label) return;
-    sApolloDCMenuTitleColor = label.textColor;
-    sApolloDCMenuTitleFont = label.font;
-    sApolloDCMenuTitleAlignment = label.textAlignment;
-    sApolloDCMenuTitleFrame = [label convertRect:label.bounds toView:cell];
-
-    UIImageView *icon =
-        (UIImageView *)ApolloDCMenuFirstSubviewOfClass(cell, [UIImageView class], NO);
-    if (icon.bounds.size.width > 1.0) {
-        sApolloDCMenuIconFrame = [icon convertRect:icon.bounds toView:cell];
-        sApolloDCMenuIconTint = icon.tintColor;
-    }
-}
-
-@interface ApolloDeletedCommentsMenuRowCell : UITableViewCell
-@property (nonatomic, strong) UILabel *apolloTitleLabel;
-@property (nonatomic, strong) UIImageView *apolloIconView;
-- (void)configureEffective:(BOOL)effective;
-@end
-
-@implementation ApolloDeletedCommentsMenuRowCell
-
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
-    if (self) {
-        self.backgroundColor = UIColor.clearColor;
-        self.contentView.backgroundColor = UIColor.clearColor;
-        UIColor *accent =
-            sApolloDCMenuTitleColor ?: ApolloThemeAccentColor() ?: UIColor.labelColor;
-
-        _apolloIconView = [[UIImageView alloc] initWithFrame:CGRectZero];
-        _apolloIconView.contentMode = UIViewContentModeScaleAspectFit;
-        _apolloIconView.tintColor = sApolloDCMenuIconTint ?: accent;
-        [self.contentView addSubview:_apolloIconView];
-
-        _apolloTitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-        _apolloTitleLabel.textColor = accent;
-        _apolloTitleLabel.font = sApolloDCMenuTitleFont ?: [UIFont systemFontOfSize:17.0];
-        _apolloTitleLabel.textAlignment = sApolloDCMenuTitleAlignment;
-        [self.contentView addSubview:_apolloTitleLabel];
-    }
-    return self;
-}
-
-- (void)configureEffective:(BOOL)effective {
-    self.apolloTitleLabel.text =
-        effective ? kApolloDCMenuHideTitle : kApolloDCMenuShowTitle;
-    self.apolloIconView.image =
-        [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
-    self.accessibilityLabel = self.apolloTitleLabel.text;
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    CGRect bounds = self.contentView.bounds;
-    if (!CGRectIsEmpty(sApolloDCMenuIconFrame)) {
-        CGRect iconFrame = sApolloDCMenuIconFrame;
-        iconFrame.origin.y = (bounds.size.height - iconFrame.size.height) / 2.0;
-        self.apolloIconView.frame = iconFrame;
-        self.apolloIconView.hidden = NO;
-    } else {
-        self.apolloIconView.hidden = YES;
-    }
-
-    CGFloat left = CGRectIsEmpty(sApolloDCMenuTitleFrame)
-        ? 16.0
-        : CGRectGetMinX(sApolloDCMenuTitleFrame);
-    CGFloat height = CGRectIsEmpty(sApolloDCMenuTitleFrame)
-        ? 22.0
-        : CGRectGetHeight(sApolloDCMenuTitleFrame);
-    self.apolloTitleLabel.frame =
-        CGRectMake(left, (bounds.size.height - height) / 2.0,
-                   MAX(0.0, bounds.size.width - left - 16.0), height);
-}
-
-@end
-
-%hook _TtC6Apollo16ActionController
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    NSInteger count = %orig;
-    if (section != 0 || !ApolloDCMenuResolveState(self, NULL, NULL, NULL)) return count;
-    objc_setAssociatedObject(self, &kApolloDCMenuOrigRowCountKey,
-                             @(count), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    return count + 1;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView
-         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) {
-        UITableViewCell *cell = %orig;
-        if (ApolloDCMenuOriginalRowCount(self) >= 0 &&
-            indexPath.section == 0 && indexPath.row == 0) {
-            ApolloDCMenuCaptureLegacyRowStyle(cell);
-        }
-        return cell;
-    }
-
-    BOOL effective = NO;
-    BOOL hasOwner = ApolloDCMenuResolveState(self, NULL, NULL, &effective);
-    ApolloDeletedCommentsMenuRowCell *cell =
-        [[ApolloDeletedCommentsMenuRowCell alloc]
-            initWithStyle:UITableViewCellStyleDefault
-          reuseIdentifier:@"ApolloDeletedCommentsMenuRow"];
-    [cell configureEffective:effective];
-    // UITableView requires a non-nil cell for every row previously reported by
-    // the data source. The presenting comments controller should stay alive for
-    // the sheet's lifetime, but if UIKit asks during teardown after that weak
-    // owner disappears, return an inert row rather than violating the contract.
-    if (!hasOwner) {
-        cell.userInteractionEnabled = NO;
-        cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    }
-    return cell;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView
- heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) return %orig;
-    return %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:indexPath.section]);
-}
-
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) {
-        %orig;
-        return;
-    }
-
-    id vc = nil;
-    NSString *linkKey = nil;
-    BOOL effective = NO;
-    if (!ApolloDCMenuResolveState(self, &vc, &linkKey, &effective)) return;
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
+    spec.matches = ^BOOL(id actionController, NSString *menuTitle) {
+        (void)menuTitle;
+        return ApolloDCMenuResolveState(actionController, NULL, NULL, NULL);
+    };
+    spec.title = ^NSString *(id actionController, UITableViewCell *donor) {
+        (void)donor;
+        BOOL effective = NO;
+        if (!ApolloDCMenuResolveState(actionController, NULL, NULL, &effective)) return nil;
+        return effective ? kApolloDCMenuHideTitle : kApolloDCMenuShowTitle;
+    };
+    spec.image = ^UIImage *(id actionController, UITableViewCell *donor) {
+        (void)donor;
+        BOOL effective = NO;
+        if (!ApolloDCMenuResolveState(actionController, NULL, NULL, &effective)) return nil;
+        return [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
+    };
+    spec.perform = ^(id actionController) {
+        id vc = nil;
+        NSString *linkKey = nil;
+        BOOL effective = NO;
+        if (!ApolloDCMenuResolveState(actionController, &vc, &linkKey, &effective)) return;
         ApolloDCMenuHandleToggle(vc, linkKey, effective);
-    }];
+    };
+
+    ApolloActionMenuRegister(spec);
+    ApolloLog(@"[DeletedCommentsMenu] Deleted-comments menu spec registered");
 }
-
-%end
-
-// Apollo sizes the sheet from its original data-source row count. Grow only
-// the presentation frame so the appended row is reachable above Cancel.
-%hook _TtC6Apollo38ActionControllerPresentationController
-
-- (CGRect)frameOfPresentedViewInContainerView {
-    CGRect frame = %orig;
-    UIViewController *presented =
-        [(UIPresentationController *)self presentedViewController];
-    if (frame.size.height <= 0.0 || ApolloDCMenuOriginalRowCount(presented) < 0) {
-        return frame;
-    }
-    CGFloat rowHeight = ApolloDCMenuLegacyRowHeight(presented);
-    if (rowHeight <= 0.0) return frame;
-    frame.origin.y -= rowHeight;
-    frame.size.height += rowHeight;
-    return frame;
-}
-
-%end

--- a/src/ApolloGalleryMenu.xm
+++ b/src/ApolloGalleryMenu.xm
@@ -3,36 +3,20 @@
 // Puts "Gallery View" in a subreddit or multireddit's nav-bar "..." menu, and
 // opens ApolloGalleryViewController when it's picked.
 //
-// Apollo draws that menu two different ways, so the row has to be added twice:
-//
-//   • Liquid Glass — the tweak's own ApolloNativeActionMenus module converts
-//     Apollo's ActionController sheet into a real UIKit UIMenu. It calls
-//     ApolloInjectGalleryViewMenuItemIfNeeded() while building the children, the
-//     same seam ApolloDeletedCommentsMenu and ApolloPublicStickyAsSubreddit use.
-//     We insert an inline single-item section just below the leading "submit a
-//     post" affordance, so the row reads as its own group without displacing
-//     the composer that leads the menu.
-//
-//   • Everything else — the ActionController presents itself as a table sheet.
-//     We append a row to the END of its data source and grow the presentation
-//     frame by one row height so the taller table still fits, mirroring what
-//     ApolloPublicStickyAsSubreddit does for the removal "Notify user via…"
-//     sheet. Appending (rather than inserting at the top, where it would match
-//     the glass menu) is forced: Apollo's own cellForRow calls
-//     -dequeueReusableCellWithIdentifier:forIndexPath: with the index path it
-//     was handed, and UIKit asserts if a shifted path is passed through, so the
-//     native rows have to keep their own indices. (On Liquid Glass these hooks
-//     still run, because the sheet is built before ApolloNativeActionMenus
-//     hides and swaps it — harmless, since that view never reaches the screen
-//     and the UIMenu is built from Apollo's Swift `actions` array, not from the
-//     table.)
+// Row rendering on both the Liquid Glass UIMenu and the legacy ActionController
+// sheet is owned entirely by ApolloActionMenu.{h,xm} — see that header for the
+// single-owner rationale. This file only supplies the feature-specific part
+// that genuinely can't be generic: WHICH sheet is "the subreddit's ... menu"
+// (identification below) and what happens when the row is picked
+// (ApolloGalleryMenuOpenForController). Everything about how the row looks or
+// where it's positioned is a declarative ApolloActionMenuSpec registered below.
 //
 // Which sheet is ours: the "..." menu has no header title to match on, so we
 // arm on -[PostsViewController moreOptionsBarButtonItemTappedWithSender:] and
 // let the first ActionController built inside a short grace window claim the
-// arm — the same one-shot claim ApolloDeletedCommentsMenu uses for the comments
-// "..." menu. The claim is recorded on the controller so repeat builds of the
-// same sheet re-inject, and no later, unrelated sheet can pick it up.
+// arm. The claim is recorded on the controller (via ApolloActionMenu's own
+// per-controller memoization of `matches`, which only ever runs this once per
+// sheet instance), so no later, unrelated sheet can pick it up.
 //
 // Popular/All, profile feeds and search results never get the row: subreddit
 // slugs and canonical multireddit paths are resolved by ApolloSubredditHeaders,
@@ -42,10 +26,10 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 #import "ApolloGalleryViewController.h"
 #import "ApolloNativeActionMenus.h"
-#import "ApolloThemeRuntime.h"
 
 // Defined in ApolloSubredditHeaders.xm — resolves the slug for a genuine
 // single-subreddit feed, and nil for anything else (multireddit, Popular/All,
@@ -67,14 +51,14 @@ static CFTimeInterval sApolloGalleryArmedAt = 0.0;
 // holding the owning PostsViewController weakly (a plain associated object
 // would keep the view controller alive).
 static char kApolloGalleryMenuOwnerKey;
-// Row count the sheet reported before we appended ours, per controller.
-static char kApolloGalleryMenuOrigRowCountKey;
 
 #pragma mark - Claiming
 
 // The PostsViewController this ActionController belongs to, claiming the
 // pending arm the first time it's asked. Returns nil for every sheet that isn't
-// the subreddit "..." menu.
+// the subreddit "..." menu. Safe to call more than once per controller — only
+// ApolloActionMenu's `matches` block below actually does, and it's memoized to
+// exactly once per sheet instance.
 static UIViewController *ApolloGalleryMenuOwnerForController(id actionController) {
     if (!actionController) return nil;
 
@@ -131,72 +115,11 @@ static void ApolloGalleryMenuOpenForController(id actionController) {
                                              fromViewController:owner];
     };
     if (ApolloNativeActionMenuPerformAfterDismissal(actionController, openGallery)) {
-        ApolloLog(@"[GalleryMenu] Waiting for the glass menu to dismiss before opening r/%@",
-                  subreddit);
+        ApolloLog(@"[GalleryMenu] Waiting for the glass menu to dismiss before opening %@",
+                  ApolloGalleryMenuSourceDescription(subreddit));
         return;
     }
     openGallery();
-}
-
-#pragma mark - Liquid Glass menu injection
-
-// Where our section goes: after whatever "submit a post" affordance leads the
-// menu, never above it. That affordance has two shapes in the wild — a plain
-// "Submit Post" row (what stock Apollo's action list produces), and a leading
-// inline UIMenu that renders as a small row of post-type icons (image / link /
-// text) at the top of the menu. Skipping both keeps the composer where muscle
-// memory expects it and puts Gallery View directly underneath.
-static NSUInteger ApolloGalleryMenuInsertionIndex(NSArray<UIMenuElement *> *children) {
-    NSUInteger index = 0;
-    while (index < children.count) {
-        UIMenuElement *element = children[index];
-        if ([element isKindOfClass:[UIMenu class]]) { index++; continue; }
-        if ([element isKindOfClass:[UIAction class]] &&
-            [((UIAction *)element).title hasPrefix:@"Submit"]) { index++; continue; }
-        break;
-    }
-    return index;
-}
-
-// Called from ApolloNativeActionMenuBuildMenu as it converts an ActionController
-// into a UIMenu. No-op for every sheet that isn't a supported feed's "..." menu.
-void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController) {
-    (void)menuTitle;
-    if (![children isKindOfClass:[NSMutableArray class]] || children.count == 0) return;
-
-    NSString *listingIdentifier = ApolloGalleryMenuListingIdentifierForController(actionController);
-    if (listingIdentifier.length == 0) return;
-
-    // The builder runs more than once per presentation; the claim persists on
-    // the controller, so guard against inserting our section twice.
-    for (UIMenuElement *element in children) {
-        if ([element isKindOfClass:[UIMenu class]] &&
-            [((UIMenu *)element).children.firstObject isKindOfClass:[UIAction class]] &&
-            [((UIAction *)((UIMenu *)element).children.firstObject).title isEqualToString:kApolloGalleryMenuTitle]) {
-            return;
-        }
-    }
-
-    __weak id weakController = actionController;
-    UIAction *action = [UIAction actionWithTitle:kApolloGalleryMenuTitle
-                                           image:[UIImage systemImageNamed:kApolloGalleryMenuSymbol]
-                                      identifier:nil
-                                         handler:^(__unused __kindof UIAction *sender) {
-        ApolloGalleryMenuOpenForController(weakController);
-    }];
-
-    // An inline single-item menu renders as its own separated group rather than
-    // sitting inside the native rows.
-    UIMenu *section = [UIMenu menuWithTitle:@""
-                                      image:nil
-                                 identifier:nil
-                                    options:UIMenuOptionsDisplayInline
-                                   children:@[action]];
-    NSUInteger index = ApolloGalleryMenuInsertionIndex(children);
-    [children insertObject:section atIndex:index];
-    ApolloLog(@"[GalleryMenu] Injected '%@' for %@ at index %lu (glass menu)",
-              kApolloGalleryMenuTitle, ApolloGalleryMenuSourceDescription(listingIdentifier),
-              (unsigned long)index);
 }
 
 #pragma mark - Arming
@@ -220,235 +143,35 @@ void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString 
 
 %end
 
-#pragma mark - Action-sheet row injection (non-Liquid-Glass)
-
-static NSInteger ApolloGalleryMenuOriginalRowCount(id actionController) {
-    NSNumber *stored = objc_getAssociatedObject(actionController, &kApolloGalleryMenuOrigRowCountKey);
-    return stored ? stored.integerValue : -1;
-}
-
-// Takes `id` so callers inside %hook blocks don't have to message a
-// forward-declared Swift class (clang rejects -class on one).
-static id ApolloGalleryMenuIvarObject(id object, const char *name) {
-    if (!object || !name) return nil;
-    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
-    return ivar ? object_getIvar(object, ivar) : nil;
-}
-
-// The sheet's own row height, asked of Apollo rather than guessed. 0 when it
-// can't be determined.
-static CGFloat ApolloGalleryMenuRowHeight(id actionController) {
-    id tableView = ApolloGalleryMenuIvarObject(actionController, "tableView");
-    if (![tableView isKindOfClass:[UITableView class]]) return 0.0;
-    if (![actionController respondsToSelector:@selector(tableView:heightForRowAtIndexPath:)]) return 0.0;
-    @try {
-        return [(id<UITableViewDelegate>)actionController
-                    tableView:(UITableView *)tableView
-                    heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
-    } @catch (__unused NSException *exception) {
-        return 0.0;
-    }
-}
-
-#pragma mark Row-0 styling capture
-
-// Apollo's action-sheet rows are custom-built (icon + accent-tinted label at
-// their own insets), so a stock UITableViewCell's textLabel lands in the wrong
-// place with the wrong colour — under a dark custom theme it renders as an
-// apparently blank row. Instead of guessing, mirror row 0: find its label and
-// icon by walking the cell (rather than by ivar name, which isn't stable) and
-// reuse their geometry and styling verbatim.
-static UIView *ApolloGalleryMenuFirstSubviewOfClass(UIView *root, Class cls, BOOL requireLabelText) {
-    for (UIView *subview in root.subviews) {
-        if ([subview isKindOfClass:cls]) {
-            if (!requireLabelText) return subview;
-            if ([subview isKindOfClass:[UILabel class]] && ((UILabel *)subview).text.length > 0) return subview;
-        }
-        UIView *nested = ApolloGalleryMenuFirstSubviewOfClass(subview, cls, requireLabelText);
-        if (nested) return nested;
-    }
-    return nil;
-}
-
-// Captured from row 0 the first time it builds. Frames are in the cell's own
-// coordinate space; only the x/height parts are reused (our row has the same
-// height, and the width comes from our own cell).
-static UIColor *sApolloGalleryRowTitleColor = nil;
-static UIFont *sApolloGalleryRowTitleFont = nil;
-static NSTextAlignment sApolloGalleryRowTitleAlignment = NSTextAlignmentLeft;
-static CGRect sApolloGalleryRowTitleFrame = CGRectZero;
-static CGRect sApolloGalleryRowIconFrame = CGRectZero;
-static UIColor *sApolloGalleryRowIconTint = nil;
-
-static void ApolloGalleryMenuCaptureRowStyle(UITableViewCell *cell) {
-    if (![cell isKindOfClass:[UITableViewCell class]]) return;
-    // Force a layout pass so the captured frames are real, not CGRectZero.
-    [cell layoutIfNeeded];
-
-    UILabel *label = (UILabel *)ApolloGalleryMenuFirstSubviewOfClass(cell, [UILabel class], YES);
-    if (!label) return;
-    sApolloGalleryRowTitleColor = label.textColor;
-    sApolloGalleryRowTitleFont = label.font;
-    sApolloGalleryRowTitleAlignment = label.textAlignment;
-    sApolloGalleryRowTitleFrame = [label convertRect:label.bounds toView:cell];
-
-    UIImageView *icon = (UIImageView *)ApolloGalleryMenuFirstSubviewOfClass(cell, [UIImageView class], NO);
-    if (icon && icon.bounds.size.width > 1.0) {
-        sApolloGalleryRowIconFrame = [icon convertRect:icon.bounds toView:cell];
-        sApolloGalleryRowIconTint = icon.tintColor;
-    }
-    ApolloLog(@"[GalleryMenu] Captured sheet row style: title=%@ icon=%@",
-              NSStringFromCGRect(sApolloGalleryRowTitleFrame), NSStringFromCGRect(sApolloGalleryRowIconFrame));
-}
-
-// Our appended row, laid out to match the captured native row.
-@interface ApolloGalleryMenuRowCell : UITableViewCell
-@property (nonatomic, strong) UILabel *rowTitleLabel;
-@property (nonatomic, strong) UIImageView *rowIconView;
-@end
-
-@implementation ApolloGalleryMenuRowCell
-
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
-    if (self) {
-        self.backgroundColor = UIColor.clearColor;
-        self.contentView.backgroundColor = UIColor.clearColor;
-        self.selectionStyle = UITableViewCellSelectionStyleDefault;
-
-        // The accent is the right last resort: Apollo tints these rows with the
-        // theme accent, so it matches even when the capture came up empty.
-        UIColor *tint = sApolloGalleryRowTitleColor ?: ApolloThemeAccentColor() ?: UIColor.labelColor;
-
-        _rowIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:kApolloGalleryMenuSymbol]];
-        _rowIconView.contentMode = UIViewContentModeScaleAspectFit;
-        _rowIconView.tintColor = sApolloGalleryRowIconTint ?: tint;
-        [self.contentView addSubview:_rowIconView];
-
-        _rowTitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-        _rowTitleLabel.text = kApolloGalleryMenuTitle;
-        _rowTitleLabel.textColor = tint;
-        _rowTitleLabel.font = sApolloGalleryRowTitleFont ?: [UIFont systemFontOfSize:17.0];
-        _rowTitleLabel.textAlignment = sApolloGalleryRowTitleAlignment;
-        [self.contentView addSubview:_rowTitleLabel];
-    }
-    return self;
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    CGRect bounds = self.contentView.bounds;
-
-    if (!CGRectIsEmpty(sApolloGalleryRowIconFrame)) {
-        CGRect iconFrame = sApolloGalleryRowIconFrame;
-        iconFrame.origin.y = (bounds.size.height - iconFrame.size.height) / 2.0;
-        self.rowIconView.frame = iconFrame;
-        self.rowIconView.hidden = NO;
-    } else {
-        self.rowIconView.hidden = YES;
-    }
-
-    CGFloat titleLeft = CGRectIsEmpty(sApolloGalleryRowTitleFrame) ? 16.0 : CGRectGetMinX(sApolloGalleryRowTitleFrame);
-    CGFloat titleHeight = CGRectIsEmpty(sApolloGalleryRowTitleFrame) ? 22.0 : CGRectGetHeight(sApolloGalleryRowTitleFrame);
-    self.rowTitleLabel.frame = CGRectMake(titleLeft,
-                                          (bounds.size.height - titleHeight) / 2.0,
-                                          MAX(0.0, bounds.size.width - titleLeft - 16.0),
-                                          titleHeight);
-}
-
-@end
-
-%hook _TtC6Apollo16ActionController
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    NSInteger count = %orig;
-    NSString *listingIdentifier = ApolloGalleryMenuListingIdentifierForController(self);
-    if (listingIdentifier.length == 0) return count;
-    // Only the first section grows; Apollo's "..." sheet is single-section, but
-    // being explicit keeps a multi-section sheet from sprouting extra rows.
-    if (section != 0) return count;
-    if (ApolloGalleryMenuOriginalRowCount(self) != count) {
-        ApolloLog(@"[GalleryMenu] Added '%@' row for %@ (sheet, after %ld native rows)",
-                  kApolloGalleryMenuTitle, ApolloGalleryMenuSourceDescription(listingIdentifier),
-                  (long)count);
-    }
-    objc_setAssociatedObject(self, &kApolloGalleryMenuOrigRowCountKey, @(count), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    return count + 1;
-}
-
-// Our row is the LAST row, never inserted in the middle: Apollo's own
-// cellForRow calls -dequeueReusableCellWithIdentifier:forIndexPath: with the
-// index path it was handed, and UIKit asserts if that doesn't match the row the
-// table is currently asking for. So the native rows must keep their own indices
-// and only an appended row is safe.
-static BOOL ApolloGalleryMenuIsOurRow(id actionController, NSIndexPath *indexPath) {
-    NSInteger originalCount = ApolloGalleryMenuOriginalRowCount(actionController);
-    return originalCount >= 0 && indexPath.section == 0 && indexPath.row == originalCount;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) {
-        UITableViewCell *cell = %orig;
-        // Apollo's first row is our style reference; re-capture on every sheet
-        // build so a theme change mid-session can't leave us on stale colours.
-        if (ApolloGalleryMenuOriginalRowCount(self) >= 0 && indexPath.section == 0 && indexPath.row == 0) {
-            ApolloGalleryMenuCaptureRowStyle(cell);
-        }
-        return cell;
-    }
-
-    // Built by hand with its own reuse identifier: dequeuing Apollo's cell class
-    // for an index its data source doesn't know about is what throws.
-    return [[ApolloGalleryMenuRowCell alloc] initWithStyle:UITableViewCellStyleDefault
-                                           reuseIdentifier:@"ApolloGalleryViewRow"];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) return %orig;
-    // Ask Apollo how tall its own rows are rather than guessing.
-    return %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:indexPath.section]);
-}
-
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) {
-        %orig;
-        return;
-    }
-
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    __strong id actionController = self;
-    // The sheet is modal over the subreddit; push only once it's gone.
-    [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
-        ApolloGalleryMenuOpenForController(actionController);
-    }];
-}
-
-%end
-
-// The sheet's height comes from Apollo's own row count, so it has to grow by a
-// row or the extra row is clipped. Only the presentation frame is touched —
-// growing the inner table view as well pushed its last row underneath the
-// Cancel button, where it couldn't be scrolled into view.
-%hook _TtC6Apollo38ActionControllerPresentationController
-
-- (CGRect)frameOfPresentedViewInContainerView {
-    CGRect frame = %orig;
-    UIViewController *presented = [(UIPresentationController *)self presentedViewController];
-    if (frame.size.height <= 0.0 || !presented) return frame;
-    NSInteger originalCount = ApolloGalleryMenuOriginalRowCount(presented);
-    if (originalCount < 0) return frame;
-
-    CGFloat rowHeight = ApolloGalleryMenuRowHeight(presented);
-    if (rowHeight <= 0.0) return frame;
-
-    frame.origin.y -= rowHeight;
-    frame.size.height += rowHeight;
-    return frame;
-}
-
-%end
+#pragma mark - Registration
 
 %ctor {
     %init;
-    ApolloLog(@"[GalleryMenu] Gallery View menu hooks installed");
+
+    ApolloActionMenuSpec *spec = [ApolloActionMenuSpec new];
+    spec.identifier = @"GalleryView";
+    spec.placement = ApolloActionMenuPlacementAfterLeadingSubmitAffordance;
+    spec.inlineSection = YES;
+    spec.legacyDismissesSheet = YES;
+
+    spec.matches = ^BOOL(id actionController, NSString *menuTitle) {
+        (void)menuTitle;
+        // Matches a single-subreddit feed OR a multireddit; nil for Popular/All,
+        // profile sections, and every unrelated sheet.
+        return ApolloGalleryMenuListingIdentifierForController(actionController).length > 0;
+    };
+    spec.title = ^NSString *(id actionController, UITableViewCell *donor) {
+        (void)actionController; (void)donor;
+        return kApolloGalleryMenuTitle;
+    };
+    spec.image = ^UIImage *(id actionController, UITableViewCell *donor) {
+        (void)actionController; (void)donor;
+        return [UIImage systemImageNamed:kApolloGalleryMenuSymbol];
+    };
+    spec.perform = ^(id actionController) {
+        ApolloGalleryMenuOpenForController(actionController);
+    };
+
+    ApolloActionMenuRegister(spec);
+    ApolloLog(@"[GalleryMenu] Gallery View menu spec registered");
 }

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1,6 +1,8 @@
+#import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 #import "ApolloNativeActionMenus.h"
 #import "ApolloNativeActionMetadata.h"
+#import "ApolloSwiftRuntime.h"
 #import "ApolloThemeRuntime.h"
 
 #import <UIKit/UIKit.h>
@@ -112,78 +114,6 @@ static BOOL ApolloNativeActionMenuMagicMorphEnabled(void) {
         sEnabledFn = (BOOL (*)(void))dlsym(RTLD_DEFAULT, "_UIContextMenuMagicMorphAnimationEnabled");
     });
     return sEnabledFn ? sEnabledFn() : YES;
-}
-
-static NSString *ApolloDecodeSwiftString(uint64_t w0, uint64_t w1) {
-    if (w1 == 0) {
-        return nil;
-    }
-
-    uint8_t disc = (uint8_t)(w1 >> 56);
-    if (disc >= 0xE0 && disc <= 0xEF) {
-        NSUInteger len = disc - 0xE0;
-        if (len == 0) return @"";
-
-        char buf[16] = {0};
-        memcpy(buf, &w0, 8);
-        uint64_t w1clean = w1 & 0x00FFFFFFFFFFFFFFULL;
-        memcpy(buf + 8, &w1clean, 7);
-        return [[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
-    }
-
-    typedef NSString *(*BridgeFn)(uint64_t, uint64_t);
-    static BridgeFn sBridge = NULL;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sBridge = (BridgeFn)dlsym(RTLD_DEFAULT,
-            "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF");
-    });
-
-    return sBridge ? sBridge(w0, w1) : nil;
-}
-
-static ptrdiff_t ApolloIvarOffset(Class cls, const char *name) {
-    Ivar ivar = class_getInstanceVariable(cls, name);
-    return ivar ? ivar_getOffset(ivar) : -1;
-}
-
-static void *ApolloReadRawIvar(id object, const char *name) {
-    if (!object) return NULL;
-    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
-    if (offset < 0) return NULL;
-    uint8_t *base = (uint8_t *)(__bridge void *)object;
-    return *(void **)(base + offset);
-}
-
-static id ApolloReadObjectIvar(id object, const char *name) {
-    if (!object) return nil;
-    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
-    if (offset < 0) return nil;
-    uint8_t *base = (uint8_t *)(__bridge void *)object;
-    void *value = *(void **)(base + offset);
-    return (__bridge id)value;
-}
-
-static BOOL ApolloReadBoolIvar(id object, const char *name, BOOL defaultValue) {
-    if (!object) return defaultValue;
-    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
-    if (offset < 0) return defaultValue;
-    uint8_t *base = (uint8_t *)(__bridge void *)object;
-    return *(uint8_t *)(base + offset) != 0;
-}
-
-static NSString *ApolloReadSwiftStringIvar(id object, const char *name) {
-    if (!object) return nil;
-    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
-    if (offset < 0) return nil;
-    uint8_t *base = (uint8_t *)(__bridge void *)object;
-    return ApolloDecodeSwiftString(*(uint64_t *)(base + offset), *(uint64_t *)(base + offset + 0x08));
-}
-
-static int64_t ApolloSwiftArrayCount(void *buffer) {
-    if (!buffer) return 0;
-    int64_t count = *(int64_t *)((uint8_t *)buffer + 0x10);
-    return count > 0 ? count : 0;
 }
 
 static NSString *ApolloNativeActionDefaultTitle(uint16_t actionKind) {
@@ -893,15 +823,10 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     }
 
     NSString *title = ApolloReadSwiftStringIvar(actionController, "actionsDescription") ?: @"";
-    // Issue #515: append "Public Sticky from Subreddit" when this is the removal
-    // "Notify user via…" menu (no-op otherwise).
-    ApolloInjectPublicStickyAsSubredditIfNeeded(children, title);
-    // Append "Show/Hide Deleted Comments" when this is a comments view's "..."
-    // menu (no-op otherwise; see ApolloDeletedCommentsMenu.xm).
-    ApolloInjectDeletedCommentsMenuItemIfNeeded(children, title, actionController);
-    // Prepend "Gallery View" when this is a subreddit's "..." menu (no-op
-    // otherwise; see ApolloGalleryMenu.xm).
-    ApolloInjectGalleryViewMenuItemIfNeeded(children, title, actionController);
+    // Every feature-registered row (Public Sticky from Subreddit, Show/Hide
+    // Deleted Comments, Gallery View, ...) is injected here through the single
+    // action-menu registry; see ApolloActionMenu.h for the registration contract.
+    ApolloActionMenuInjectMenuElements(children, title, actionController);
     return [UIMenu menuWithTitle:title children:children];
 }
 

--- a/src/ApolloPublicStickyAsSubreddit.xm
+++ b/src/ApolloPublicStickyAsSubreddit.xm
@@ -37,24 +37,26 @@
 //
 // How the option is added:
 //
-//   On iOS 26 the tweak's own ApolloNativeActionMenus module converts Apollo's
-//   ActionController action sheets into native UIKit context menus
-//   (UIMenu/UIAction) — so the "Notify user via…" sheet renders as a UIMenu.
-//   `ApolloNativeActionMenuBuildMenu` calls
-//   ApolloInjectPublicStickyAsSubredditIfNeeded() (this file) as it builds that
-//   menu; for the "Notify user via…" menu we append a 4th UIAction that clones
-//   the "Public Sticky"/"Public Reply" action (inheriting its styling) and, on
-//   tap, arms a one-shot flag and runs the ORIGINAL action's handler — so the
-//   entire native compose flow runs unchanged. Without Liquid Glass the same
-//   row is added to the original ActionController table sheet (see the
-//   action-sheet section below).
+//   Row rendering on both the Liquid Glass UIMenu and the legacy
+//   ActionController sheet is owned by ApolloActionMenu.{h,xm} — see that
+//   header for the single-owner rationale. This spec is the one case that
+//   can't be purely declarative on the glass path: rather than build a new
+//   UIMenuElement, it CLONES "Public Sticky"/"Public Reply"'s own UIMenuElement
+//   (title/image/attributes/attributedTitle color) via `buildElement`, so the
+//   clone inherits the moderator-green tint ApolloNativeActionMenus.xm applies,
+//   and wires its tap to arm a one-shot flag then run the ORIGINAL action's
+//   handler — so the entire native compose flow runs unchanged. On the legacy
+//   path the owner's shared row cell is used instead (via the declarative
+//   `title`/`perform`/`legacyDismissesSheet` below), with `perform` re-running
+//   row 0's own native tap handler through ApolloActionMenuInvokeNativeRow().
 //
 //   The RDKClient hook below rewrites type "public" → "public_as_subreddit" on
 //   the SEND call while the flag is set, then consumes it. The flag stays armed
 //   across the whole compose flow (the send happens inside call 1's async
 //   completion) and is re-cleared whenever a fresh "Notify user via…" menu or
-//   sheet is built, so a cancelled compose can never leak into a later genuine
-//   "Public Sticky". Every other option/path is untouched.
+//   sheet is matched (see `matches` below), so a cancelled compose can never
+//   leak into a later genuine "Public Sticky". Every other option/path is
+//   untouched.
 //
 // Mod-only and additive: non-mods never see this menu; untouched options behave
 // exactly like stock Apollo. No settings toggle.
@@ -62,6 +64,8 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
+
+#import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 
 // Title prefix of the menu we augment (ellipsis is U+2026; matched with
@@ -80,9 +84,9 @@ static NSString *const kTypePublicAsSubreddit = @"public_as_subreddit";
 
 // One-shot flag: the next removal submission should go out as the subreddit.
 // Armed when our injected action fires; consumed by the RDKClient hook; reset
-// each time the "Notify user via…" menu is rebuilt so a cancelled compose can't
-// leak into a later genuine "Public Sticky". UI is main-thread only, so a plain
-// BOOL is sufficient.
+// each time a fresh "Notify user via…" menu is matched so a cancelled compose
+// can't leak into a later genuine "Public Sticky". UI is main-thread only, so a
+// plain BOOL is sufficient.
 static BOOL sSendNextRemovalAsSubreddit = NO;
 
 #pragma mark - Runtime helper
@@ -99,238 +103,6 @@ static id PSObjectIvar(id obj, const char *name) {
     return nil;
 }
 
-#pragma mark - Non-Liquid-Glass action-sheet support
-
-// Without Liquid Glass, ApolloNativeActionMenus does NOT convert the sheet to a
-// UIMenu, so Apollo presents its real `ActionController` table sheet. We add the
-// 4th option there too. Two problems beyond the data source: (1) the sheet
-// self-sizes from the controller's own row count (textActions.count), not from
-// numberOfRows, so an appended row clips; (2) UITableView throws if cellForRow
-// dequeues a foreign indexPath. So we append the row at the end (no remap), build
-// its cell by hand with its OWN indexPath, and grow BOTH the presentation frame
-// (frameOfPresentedViewInContainerView) and the inner tableView frame
-// (viewDidLayoutSubviews) by one row height.
-
-// Original row count of the current Notify sheet (set in numberOfRows); our row
-// is appended at this index.
-static NSInteger sSheetOrigRowCount = -1;
-// Row-0 styling captured as the real rows build, mirrored onto our cell.
-static NSString *sSheetBaseTitle = nil;   // "Public Sticky" / "Public Reply"
-static UIColor  *sSheetTitleColor = nil;
-static UIFont   *sSheetTitleFont = nil;
-static NSTextAlignment sSheetTitleAlign = NSTextAlignmentCenter;
-
-// Is this ActionController the removal "Notify user via…" action sheet? Its own
-// `tableView:titleForHeaderInSection:` returns the header String (and ignores
-// both args), so it's a safe probe.
-static BOOL PSIsNotifyActionSheet(id actionController) {
-    if (![actionController respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) return NO;
-    UITableView *tv = (UITableView *)PSObjectIvar(actionController, "tableView");
-    NSString *header = nil;
-    @try {
-        header = [(id<UITableViewDataSource>)actionController tableView:tv titleForHeaderInSection:0];
-    } @catch (__unused NSException *e) {
-        return NO;
-    }
-    return [header isKindOfClass:[NSString class]] && [header hasPrefix:kNotifyMenuTitlePrefix];
-}
-
-// Height of one row in the Notify sheet (row 0), used to grow the sheet/table.
-static CGFloat PSNotifyRowHeight(id actionController) {
-    UITableView *tv = (UITableView *)PSObjectIvar(actionController, "tableView");
-    if (![tv isKindOfClass:[UITableView class]]) return 0;
-    @try {
-        return [(id<UITableViewDelegate>)actionController
-                    tableView:tv heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
-    } @catch (__unused NSException *e) {
-        return 0;
-    }
-}
-
-#pragma mark - Menu injection (called from ApolloNativeActionMenuBuildMenu)
-
-// If `menuTitle` is the removal "Notify user via…" menu, append a
-// "… from Subreddit" UIAction right after the existing "Public Sticky"/"Public
-// Reply" action. The injected action arms the flag, then invokes the original
-// action's handler (which runs Apollo's native compose+submit flow); the
-// RDKClient hook then rewrites the removal type. No-op for every other menu.
-void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSString *menuTitle) {
-    if (![menuTitle isKindOfClass:[NSString class]] ||
-        ![menuTitle hasPrefix:kNotifyMenuTitlePrefix]) {
-        return;
-    }
-    if (![children isKindOfClass:[NSMutableArray class]]) return;
-
-    // Fresh Notify menu -> disarm, so a previously-cancelled "as subreddit"
-    // intent never leaks into a genuine "Public Sticky" chosen later.
-    sSendNextRemovalAsSubreddit = NO;
-
-    // Locate the "Public Sticky"/"Public Reply" action to clone. Our injected
-    // action is identified by BOTH the "Public " prefix AND the " from
-    // Subreddit" suffix — checking the suffix alone would false-match the
-    // existing "Mod Mail from Subreddit" option and abort.
-    UIAction *publicAction = nil;
-    NSUInteger publicIndex = NSNotFound;
-    for (NSUInteger i = 0; i < children.count; i++) {
-        UIMenuElement *e = children[i];
-        if (![e isKindOfClass:[UIAction class]]) continue;
-        NSString *t = ((UIAction *)e).title;
-        if (![t hasPrefix:kPublicActionPrefix]) continue;
-        if ([t hasSuffix:kAsSubredditSuffix]) return; // our action already present
-        if (!publicAction) {
-            publicAction = (UIAction *)e;
-            publicIndex = i;
-        }
-    }
-    if (!publicAction) {
-        ApolloLog(@"[PublicStickyAsSub] Notify menu found but no 'Public …' action; leaving as-is");
-        return;
-    }
-
-    // Recover the original action's handler so ours can run the exact native
-    // compose flow after arming the flag.
-    void (^publicHandler)(UIAction *) = (void (^)(UIAction *))PSObjectIvar(publicAction, "_handler");
-    NSString *newTitle = [publicAction.title stringByAppendingString:kAsSubredditSuffix];
-
-    UIAction *injected =
-        [UIAction actionWithTitle:newTitle
-                            image:publicAction.image
-                       identifier:nil
-                          handler:^(__unused __kindof UIAction *action) {
-            ApolloLog(@"[PublicStickyAsSub] '%@' tapped; arming + running native public-sticky flow", newTitle);
-            sSendNextRemovalAsSubreddit = YES;
-            if (publicHandler) {
-                publicHandler(publicAction);
-            } else {
-                ApolloLog(@"[PublicStickyAsSub] WARN: original 'Public …' handler was nil");
-            }
-        }];
-    injected.attributes = publicAction.attributes;
-
-    // Match the original action's title color (Apollo tints these moderator
-    // actions green via a private attributedTitle); copy whatever color it has
-    // so our clone never looks out of place, in any menu style.
-    NSAttributedString *origAttributed = nil;
-    @try {
-        origAttributed = [publicAction valueForKey:@"attributedTitle"];
-    } @catch (__unused NSException *e) {
-        origAttributed = (NSAttributedString *)PSObjectIvar(publicAction, "_attributedTitle");
-    }
-    if ([origAttributed isKindOfClass:[NSAttributedString class]] && origAttributed.length > 0) {
-        UIColor *color = [origAttributed attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:NULL];
-        if (color && [injected respondsToSelector:@selector(setAttributedTitle:)]) {
-            NSAttributedString *attr = [[NSAttributedString alloc] initWithString:newTitle
-                                                                      attributes:@{NSForegroundColorAttributeName: color}];
-            ((void (*)(id, SEL, id))objc_msgSend)(injected, @selector(setAttributedTitle:), attr);
-        }
-    }
-
-    [children insertObject:injected atIndex:publicIndex + 1];
-    ApolloLog(@"[PublicStickyAsSub] injected '%@' into Notify menu (now %lu items)",
-              newTitle, (unsigned long)children.count);
-}
-
-#pragma mark - Action-sheet row injection (non-Liquid-Glass)
-
-%hook _TtC6Apollo16ActionController
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    NSInteger n = %orig;
-    if (PSIsNotifyActionSheet(self)) {
-        sSheetOrigRowCount = n;            // our row is appended at this index
-        sSendNextRemovalAsSubreddit = NO;  // fresh sheet display -> disarm
-        n += 1;
-    }
-    return n;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!PSIsNotifyActionSheet(self)) return %orig;
-
-    if (indexPath.row != sSheetOrigRowCount) {
-        // Real row — build normally (correct indexPath, no remap). Capture row
-        // 0's styling to mirror on our row.
-        UITableViewCell *cell = %orig;
-        if (indexPath.row == 0) {
-            UILabel *label = (UILabel *)PSObjectIvar(cell, "actionTitleLabel");
-            if ([label isKindOfClass:[UILabel class]]) {
-                sSheetBaseTitle  = [label.text copy];
-                sSheetTitleColor = label.textColor;
-                sSheetTitleFont  = label.font;
-                sSheetTitleAlign = label.textAlignment;
-            }
-        }
-        return cell;
-    }
-
-    // Our appended row — built by hand with ITS OWN indexPath (no foreign
-    // dequeue, so no exception), styled to match row 0.
-    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
-                                                   reuseIdentifier:@"ApolloPublicStickyAsSubRow"];
-    cell.backgroundColor = [UIColor clearColor];
-    NSString *base = sSheetBaseTitle.length ? sSheetBaseTitle : @"Public Sticky";
-    cell.textLabel.text = [base stringByAppendingString:kAsSubredditSuffix];
-    cell.textLabel.textAlignment = sSheetTitleAlign;
-    if (sSheetTitleFont)  cell.textLabel.font = sSheetTitleFont;
-    if (sSheetTitleColor) cell.textLabel.textColor = sSheetTitleColor;
-    return cell;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!PSIsNotifyActionSheet(self)) return %orig;
-    NSIndexPath *src = (indexPath.row == sSheetOrigRowCount)
-        ? [NSIndexPath indexPathForRow:0 inSection:indexPath.section]
-        : indexPath;
-    return %orig(tableView, src);
-}
-
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!PSIsNotifyActionSheet(self) || indexPath.row != sSheetOrigRowCount) {
-        %orig;
-        return;
-    }
-    // Our appended row: arm the flag, then run row 0's native handler.
-    sSendNextRemovalAsSubreddit = YES;
-    ApolloLog(@"[PublicStickyAsSub] (sheet) 'from Subreddit' tapped; arming + running row-0 flow");
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:indexPath.section]);
-}
-
-// The inner tableView is sized from the controller's own row count, so grow it
-// by one row so our appended row isn't clipped within the table.
-- (void)viewDidLayoutSubviews {
-    %orig;
-    if (!PSIsNotifyActionSheet(self)) return;
-    UITableView *tv = (UITableView *)PSObjectIvar(self, "tableView");
-    if (![tv isKindOfClass:[UITableView class]]) return;
-    CGFloat rh = PSNotifyRowHeight(self);
-    if (rh <= 0) return;
-    CGRect f = tv.frame;
-    f.size.height += rh;
-    tv.frame = f;
-}
-
-%end
-
-// The bottom sheet's overall frame is computed from the controller's row count
-// too; grow it upward by one row so the taller table fits.
-%hook _TtC6Apollo38ActionControllerPresentationController
-
-- (CGRect)frameOfPresentedViewInContainerView {
-    CGRect f = %orig;
-    UIViewController *avc = [(UIPresentationController *)self presentedViewController];
-    if (f.size.height > 0 && PSIsNotifyActionSheet(avc)) {
-        CGFloat rh = PSNotifyRowHeight(avc);
-        if (rh > 0) {
-            f.origin.y -= rh;     // grow upward (bottom sheet)
-            f.size.height += rh;
-        }
-    }
-    return f;
-}
-
-%end
-
 #pragma mark - Type rewrite at the API boundary
 
 // The swap happens on the SEND call (removal_link_message /
@@ -338,7 +110,7 @@ void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSStr
 // reason-logging call (removal_reasons), which fires first and ignores `type`.
 // The flag is consumed here (one-shot); it survives the async gap between the
 // two calls because nothing else can rebuild the Notify menu mid-flow, and any
-// abandoned compose is disarmed the next time a Notify menu/sheet is built.
+// abandoned compose is disarmed the next time a Notify menu/sheet is matched.
 %hook RDKClient
 
 - (id)sendRemovalReasonForRemovedThingWithFullName:(id)fullName
@@ -361,3 +133,115 @@ void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSStr
 }
 
 %end
+
+#pragma mark - Registration
+
+%ctor {
+    %init;
+
+    ApolloActionMenuSpec *spec = [ApolloActionMenuSpec new];
+    spec.identifier = @"PublicStickyAsSubreddit";
+    // Legacy row has no icon in the original design; the native "Notify user
+    // via…" rows are plain colored text, so the shared cell's icon stays empty
+    // regardless (no non-nil `image` block needed).
+    spec.legacyDismissesSheet = NO; // perform forwards into row 0's own handler, which self-dismisses.
+
+    spec.matches = ^BOOL(id actionController, NSString *menuTitle) {
+        (void)actionController;
+        if (![menuTitle hasPrefix:kNotifyMenuTitlePrefix]) return NO;
+        // Fresh Notify menu -> disarm. Memoized to run exactly once per sheet
+        // instance (ApolloActionMenu.xm), which is the correct granularity: a
+        // genuinely NEW sheet is what should disarm a stale intent, not every
+        // rebuild of the SAME sheet.
+        sSendNextRemovalAsSubreddit = NO;
+        return YES;
+    };
+
+    // Legacy path only: title mirrors row 0's own rendered text (Apollo's rows
+    // are custom-drawn, not built on UITableViewCell.textLabel) plus our suffix.
+    spec.title = ^NSString *(id actionController, UITableViewCell *donor) {
+        (void)actionController;
+        NSString *base = ApolloActionMenuDonorLabelText(donor);
+        if (base.length == 0) base = @"Public Sticky";
+        return [base stringByAppendingString:kAsSubredditSuffix];
+    };
+
+    // Legacy path only: re-run row 0's own native handler — the exact compose
+    // flow "Public Sticky"/"Public Reply" runs — after arming the flag that
+    // makes the RDKClient hook above rewrite the removal type.
+    spec.perform = ^(id actionController) {
+        sSendNextRemovalAsSubreddit = YES;
+        ApolloLog(@"[PublicStickyAsSub] (sheet) 'from Subreddit' tapped; arming + running row-0 flow");
+        ApolloActionMenuInvokeNativeRow(actionController, 0);
+    };
+
+    // Glass path only: clone the native "Public Sticky"/"Public Reply"
+    // UIMenuElement rather than building a new one, so the clone inherits
+    // whatever styling (including the moderator-green tint) the real action
+    // already carries, and its tap runs the REAL action's own handler.
+    spec.buildElement = ^(id actionController, NSMutableArray<UIMenuElement *> *children) {
+        (void)actionController;
+        UIAction *publicAction = nil;
+        NSUInteger publicIndex = NSNotFound;
+        for (NSUInteger i = 0; i < children.count; i++) {
+            UIMenuElement *e = children[i];
+            if (![e isKindOfClass:[UIAction class]]) continue;
+            NSString *t = ((UIAction *)e).title;
+            if (![t hasPrefix:kPublicActionPrefix]) continue;
+            if ([t hasSuffix:kAsSubredditSuffix]) return; // our action already present
+            if (!publicAction) {
+                publicAction = (UIAction *)e;
+                publicIndex = i;
+            }
+        }
+        if (!publicAction) {
+            ApolloLog(@"[PublicStickyAsSub] Notify menu found but no 'Public …' action; leaving as-is");
+            return;
+        }
+
+        // Recover the original action's handler so ours can run the exact
+        // native compose flow after arming the flag.
+        void (^publicHandler)(UIAction *) = (void (^)(UIAction *))PSObjectIvar(publicAction, "_handler");
+        NSString *newTitle = [publicAction.title stringByAppendingString:kAsSubredditSuffix];
+
+        UIAction *injected =
+            [UIAction actionWithTitle:newTitle
+                                image:publicAction.image
+                           identifier:nil
+                              handler:^(__unused __kindof UIAction *action) {
+            ApolloLog(@"[PublicStickyAsSub] '%@' tapped; arming + running native public-sticky flow", newTitle);
+            sSendNextRemovalAsSubreddit = YES;
+            if (publicHandler) {
+                publicHandler(publicAction);
+            } else {
+                ApolloLog(@"[PublicStickyAsSub] WARN: original 'Public …' handler was nil");
+            }
+        }];
+        injected.attributes = publicAction.attributes;
+
+        // Match the original action's title color (Apollo tints these
+        // moderator actions green via a private attributedTitle); copy
+        // whatever color it has so our clone never looks out of place.
+        NSAttributedString *origAttributed = nil;
+        @try {
+            origAttributed = [publicAction valueForKey:@"attributedTitle"];
+        } @catch (__unused NSException *e) {
+            origAttributed = (NSAttributedString *)PSObjectIvar(publicAction, "_attributedTitle");
+        }
+        if ([origAttributed isKindOfClass:[NSAttributedString class]] && origAttributed.length > 0) {
+            UIColor *color = [origAttributed attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:NULL];
+            if (color && [injected respondsToSelector:@selector(setAttributedTitle:)]) {
+                NSAttributedString *attr = [[NSAttributedString alloc] initWithString:newTitle
+                                                                          attributes:@{NSForegroundColorAttributeName: color}];
+                ((void (*)(id, SEL, id))objc_msgSend)(injected, @selector(setAttributedTitle:), attr);
+            }
+        }
+
+        [children insertObject:injected atIndex:publicIndex + 1];
+        ApolloLog(@"[PublicStickyAsSub] injected '%@' into Notify menu (now %lu items)",
+                  newTitle, (unsigned long)children.count);
+    };
+
+    ApolloActionMenuRegister(spec);
+    ApolloLog(@"[PublicStickyAsSub] Public Sticky as Subreddit spec registered");
+}

--- a/src/ApolloSwiftRuntime.h
+++ b/src/ApolloSwiftRuntime.h
@@ -1,0 +1,95 @@
+// ApolloSwiftRuntime — shared helpers for reading Apollo's private Swift stored
+// properties (title/subtitle strings, action arrays, boolean flags) directly off
+// ivar offsets, without an @objc-visible getter.
+//
+// Swift stored properties on a class are laid out inline at a fixed ivar offset
+// but have no ObjC getter unless explicitly @objc; these helpers read them by
+// name via the ObjC runtime's ivar list, exactly like MSHookIvar but usable
+// outside a %hook block (see AGENTS.md's "Swift Struct Ivars and iOS Version
+// Pitfalls" for why this is necessary and its limits).
+//
+// static inline, header-only: each including .xm gets its own copy, so there is
+// no shared translation unit to add to the Makefile.
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#include <dlfcn.h>
+
+// Decodes a Swift String stored inline across two 64-bit words (small-string
+// representation, <=15 UTF-8 bytes) or bridges a heap-allocated Swift String via
+// its private _bridgeToObjectiveC symbol. See AGENTS.md's "Decoding Swift small
+// strings from assembly" for the byte layout this mirrors.
+static inline NSString *ApolloDecodeSwiftString(uint64_t w0, uint64_t w1) {
+    if (w1 == 0) {
+        return nil;
+    }
+
+    uint8_t disc = (uint8_t)(w1 >> 56);
+    if (disc >= 0xE0 && disc <= 0xEF) {
+        NSUInteger len = disc - 0xE0;
+        if (len == 0) return @"";
+
+        char buf[16] = {0};
+        memcpy(buf, &w0, 8);
+        uint64_t w1clean = w1 & 0x00FFFFFFFFFFFFFFULL;
+        memcpy(buf + 8, &w1clean, 7);
+        return [[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
+    }
+
+    typedef NSString *(*BridgeFn)(uint64_t, uint64_t);
+    static BridgeFn sBridge = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sBridge = (BridgeFn)dlsym(RTLD_DEFAULT,
+            "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF");
+    });
+
+    return sBridge ? sBridge(w0, w1) : nil;
+}
+
+static inline ptrdiff_t ApolloIvarOffset(Class cls, const char *name) {
+    Ivar ivar = class_getInstanceVariable(cls, name);
+    return ivar ? ivar_getOffset(ivar) : -1;
+}
+
+static inline void *ApolloReadRawIvar(id object, const char *name) {
+    if (!object) return NULL;
+    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
+    if (offset < 0) return NULL;
+    uint8_t *base = (uint8_t *)(__bridge void *)object;
+    return *(void **)(base + offset);
+}
+
+static inline id ApolloReadObjectIvar(id object, const char *name) {
+    if (!object) return nil;
+    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
+    if (offset < 0) return nil;
+    uint8_t *base = (uint8_t *)(__bridge void *)object;
+    void *value = *(void **)(base + offset);
+    return (__bridge id)value;
+}
+
+static inline BOOL ApolloReadBoolIvar(id object, const char *name, BOOL defaultValue) {
+    if (!object) return defaultValue;
+    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
+    if (offset < 0) return defaultValue;
+    uint8_t *base = (uint8_t *)(__bridge void *)object;
+    return *(uint8_t *)(base + offset) != 0;
+}
+
+static inline NSString *ApolloReadSwiftStringIvar(id object, const char *name) {
+    if (!object) return nil;
+    ptrdiff_t offset = ApolloIvarOffset(object_getClass(object), name);
+    if (offset < 0) return nil;
+    uint8_t *base = (uint8_t *)(__bridge void *)object;
+    return ApolloDecodeSwiftString(*(uint64_t *)(base + offset), *(uint64_t *)(base + offset + 0x08));
+}
+
+// Element count of a Swift Array<T> stored inline as a buffer pointer (the count
+// word sits at buffer+0x10; see ApolloNativeActionMenus.xm's action-array layout
+// comments for the full element stride/offset convention built on top of this).
+static inline int64_t ApolloSwiftArrayCount(void *buffer) {
+    if (!buffer) return 0;
+    int64_t count = *(int64_t *)((uint8_t *)buffer + 0x10);
+    return count > 0 ? count : 0;
+}

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -7,7 +7,7 @@ Everything settings-related lives here. Two distinct layers — pick the right o
 | A **tweak-owned** screen (Apollo Reborn root, Deleted Comments, Translation, …) | `ApolloSettingsForm` — declare rows in `-buildForm` | Hand-roll `numberOfRows`/`cellForRow` switches or index arithmetic |
 | Apollo's **native** Settings > General screen (a Eureka form we don't own) | `ApolloSettingsGeneralTable` — register a hide matcher or row injection in your `%ctor` | `%hook` that screen's table delegate/dataSource methods (two remappers desync index spaces — the PR #570 bug class) |
 
-Other native screens have their own single owners: the Settings root and About injections live in `src/settings/ApolloSettings.xm`, the Filters screen in `src/ApolloFiltersBlocksInject.xm`. One remapper per screen, always.
+Other native screens have their own single owners: the Settings root and About injections live in `src/settings/ApolloSettings.xm`, the Filters screen in `src/ApolloFiltersBlocksInject.xm`, and Apollo's "..." action-menu sheet (`_TtC6Apollo16ActionController`, both the Liquid Glass `UIMenu` and the legacy table sheet) in `src/ApolloActionMenu.{h,xm}` — register a row spec in your `%ctor` via `ApolloActionMenuRegister()`, don't `%hook` that class's table methods yourself. One remapper per screen, always.
 
 ## Adding a new tweak setting (the 5-step recipe)
 


### PR DESCRIPTION
## Summary
Apollo's "..." action menu renders two ways (a Liquid Glass `UIMenu` and a legacy `ActionController` table sheet), and three feature modules (Gallery View, Show/Hide Deleted Comments, and Public Sticky from Subreddit), each independently implemented both rendering paths, triplicating ~150 lines of near-identical Logos hook code across six `%hook` blocks. This PR introduces `ApolloActionMenu.{h,xm}` as the single owner of that menu's geometry on both paths, with a declarative registry the three feature modules now register against instead of hooking the table themselves.

## Impact
- Fixes a visual bug on the legacy "Notify user via..." sheet where the "Public Sticky from Subreddit" row ate the spacing gap between the sheet's rows and the Cancel button.
- No other user-facing changes, as most changes are on the developer side.

## Changes
- New `src/ApolloActionMenu.{h,xm}`: the registry, per-controller memoized spec matching, a shared donor-styled row cell, and the single `%hook` on `_TtC6Apollo16ActionController` and `_TtC6Apollo38ActionControllerPresentationController`.
- New `src/ApolloSwiftRuntime.h`: Swift-ivar-reading helpers extracted out of `ApolloNativeActionMenus.xm`, where they were previously file-local and unusable elsewhere.
- `ApolloNativeActionMenus.xm`: the Liquid Glass menu builder now calls the registry instead of three hardcoded per-feature injector functions; the corresponding externs in `ApolloCommon.h` are removed.
- `ApolloGalleryMenu.xm`, `ApolloDeletedCommentsMenu.xm`, `ApolloPublicStickyAsSubreddit.xm`: migrated from independent `%hook` blocks on the shared table/presentation-controller classes to registering an `ApolloActionMenuSpec`. Each keeps only what is genuinely feature-specific — how it identifies its own menu, and what its row does when tapped.
- `src/settings/README.md`: documents the action-menu sheet as another single-owner surface alongside the existing ones.

## Reasoning
- A single `%hook` owner replaces three independent hook sets that only stayed correct because their match conditions happened to be mutually exclusive — the same "safe only by coincidence" setup that broke in PR #570, where two independently-hooked stacks on Apollo's native Settings > General screen disagreed about index-path spaces depending on constructor order. This PR applies that lesson preemptively to the action-menu sheet before a future feature's row injection collides the same way.
- Uses a plain `%hook` rather than the `NSProxy` technique `ApolloSettingsGeneralTable` uses for that Settings > General screen: `ActionController` is a short-lived, simple 4-method Swift table controller (not Eureka), so the proxy's structural guarantee wasn't worth the added complexity here.
- An injected row's donor styling is captured opportunistically the moment UIKit naturally builds row 0, never fetched on demand — Apollo's cell builder calls `dequeueReusableCellWithIdentifier:forIndexPath:`, which asserts if invoked for an index path other than the one the table is currently preparing.
- Dropped the inner-`tableView`-frame growth one of the three modules previously applied on the legacy sheet: on-device comparison showed it caused the Cancel-gap bug above, while outer-presentation-frame-only growth (what the other two modules already did) renders correctly.
- The #767 deferral is left at the Gallery call site rather than hoisted into the registry, since Gallery is its only consumer and wrapping every spec's handler centrally would double-defer it.

## Testing
Manually verified on device: all three features (gallery view in subreddits and multireddits, hide/show deleted comments in posts, and "Public Sticky from Subreddit" notify option when removing posts) are correctly injected into the menus and execute their actions on tap, across both standard and glass builds. On standard builds, verified that there is now some spacing between the Cancel button and the notify options when removing a post.