### PR TITLE
Fix tweet previews and show them regardless of post score

### DIFF
--- a/src/ApolloTweetBuddy.xm
+++ b/src/ApolloTweetBuddy.xm
@@ -9,9 +9,17 @@
 // extra link-preview networking in one place.
 
 #import <Foundation/Foundation.h>
+#import <mach-o/dyld.h>
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+
+// Minimal surface for Apollo's vote-count base class. RDKLink and RDKComment
+// both inherit `score` from RDKVotable without overriding it, so hooking
+// RDKVotable covers posts and comments alike.
+@interface RDKVotable : NSObject
+@property (nonatomic) long long score;
+@end
 
 static NSString *const kApolloTweetBaseURL = @"https://apollogur.download/api/tweet/";
 static NSString *const kXHomepageURL = @"https://x.com/";
@@ -23,6 +31,62 @@ static const NSTimeInterval kGuestTokenMaxAge = 9000.0;
 static NSString *sGuestToken = nil;
 static NSDate *sTokenFetchDate = nil;
 static dispatch_queue_t sTokenQueue;
+
+// Apollo only issues the apollogur tweet fetch this protocol intercepts when
+// the post/comment's score is > 40. That gate lives inline in three compiled
+// Swift render paths, each reading -[RDKVotable score] via objc_msgSend right
+// before comparing it:
+//   - CompactPostThumbnailNode (sub_1006f0f60): cmp x0, #0x29  -> b.lt skip
+//   - RichMediaNode            (sub_100587790): cmp x0, #0x28  -> cset w22, gt
+//   - CommentsHeaderCellNode   (sub_100568f58): cmp x0, #0x28  -> cset w23, gt
+// (the first two cover the post feeds; the third is the post detail page's
+// header cell, which has its own separate gate feeding the same link-button
+// builder.)
+// objc_msgSend tail-calls into -score, so __builtin_return_address(0) inside
+// the hooked getter equals the instruction right after each `bl objc_msgSend`
+// above -- i.e. the `cmp` itself. We match on those three exact addresses and
+// report a score of 41 (just enough to pass all gates) only there, leaving
+// every other caller (including the on-screen vote count) untouched.
+//
+// Addresses are Hopper file offsets (preferred base 0x100000000) for the
+// pinned Apollo 1.15.11 (285) binary this tweak ships against.
+static const uintptr_t kGateCompactThumbnailCmp = 0x1006f41acULL; // sub_1006f0f60: cmp x0, #0x29
+static const uintptr_t kGateRichMediaCmp = 0x100587accULL;        // sub_100587790: cmp x0, #0x28
+static const uintptr_t kGateCommentsHeaderCmp = 0x1005697e8ULL;   // sub_100568f58: cmp x0, #0x28
+
+// Expected instruction encodings at the gate sites above, verified once
+// at startup so a re-pinned/altered binary safely disables this fix instead
+// of comparing against the wrong address.
+static const uint32_t kGateCompactThumbnailCmpInsn = 0xF100A41FU; // cmp x0, #0x29
+static const uint32_t kGateRichMediaCmpInsn = 0xF100A01FU;        // cmp x0, #0x28
+static const uint32_t kGateCommentsHeaderCmpInsn = 0xF100A01FU;   // cmp x0, #0x28
+
+static intptr_t sApolloSlide = 0;
+static BOOL sUpvoteGateBypassArmed = NO;
+
+// Image 0 as seen by _dyld_get_image_*() is the first-loaded image, which for
+// an injected dylib is the dylib itself, not Apollo's main executable. Find
+// Apollo's image explicitly by matching the main bundle's executable path.
+static intptr_t ApolloTweetBuddyFindApolloSlide(void) {
+    const char *apolloPath = [[NSBundle mainBundle] executablePath].fileSystemRepresentation;
+    uint32_t count = _dyld_image_count();
+    for (uint32_t i = 0; i < count; i++) {
+        const char *name = _dyld_get_image_name(i);
+        if (name && strcmp(name, apolloPath) == 0) {
+            return _dyld_get_image_vmaddr_slide(i);
+        }
+    }
+    return 0;
+}
+
+static uintptr_t ApolloTweetBuddyGateAddress(uintptr_t hopperAddr) {
+    return (uintptr_t)((intptr_t)hopperAddr + sApolloSlide);
+}
+
+static BOOL ApolloTweetBuddyVerifyGateInstruction(uintptr_t hopperAddr, uint32_t expected) {
+    uint32_t actual = *(const uint32_t *)ApolloTweetBuddyGateAddress(hopperAddr);
+    return actual == expected;
+}
 
 static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
     NSDictionary *legacy = result[@"legacy"];
@@ -190,6 +254,31 @@ static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
 
 @end
 
+%hook RDKVotable
+
+// Apollo gates the apollogur tweet-preview fetch on score > 40. Inflate the
+// score to 41 only when read from one of the three known gate sites, so
+// previews render for tweet links regardless of vote count while the
+// displayed vote count (and everything else) sees the real score.
+- (long long)score {
+    long long real = %orig;
+
+    if (!sUpvoteGateBypassArmed) return real;
+    if (sLinkPreviewBodyMode == ApolloLinkPreviewModeOff && sLinkPreviewCommentsMode == ApolloLinkPreviewModeOff) return real;
+    if (real > 40) return real;
+
+    uintptr_t ret = (uintptr_t)__builtin_return_address(0);
+    if (ret == ApolloTweetBuddyGateAddress(kGateCompactThumbnailCmp) ||
+        ret == ApolloTweetBuddyGateAddress(kGateRichMediaCmp) ||
+        ret == ApolloTweetBuddyGateAddress(kGateCommentsHeaderCmp)) {
+        return 41;
+    }
+
+    return real;
+}
+
+%end
+
 %hook NSURLSessionConfiguration
 
 + (instancetype)defaultSessionConfiguration {
@@ -208,5 +297,16 @@ static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
 
 %ctor {
     sTokenQueue = dispatch_queue_create("com.apollo.tweetbuddy.tokenqueue", DISPATCH_QUEUE_SERIAL);
+
+    sApolloSlide = ApolloTweetBuddyFindApolloSlide();
+
+    sUpvoteGateBypassArmed = sApolloSlide != 0 &&
+                             ApolloTweetBuddyVerifyGateInstruction(kGateCompactThumbnailCmp, kGateCompactThumbnailCmpInsn) &&
+                             ApolloTweetBuddyVerifyGateInstruction(kGateRichMediaCmp, kGateRichMediaCmpInsn) &&
+                             ApolloTweetBuddyVerifyGateInstruction(kGateCommentsHeaderCmp, kGateCommentsHeaderCmpInsn);
+    if (!sUpvoteGateBypassArmed) {
+        ApolloLog(@"[TweetBuddy] upvote gate bypass disabled: unexpected instructions at gate sites (binary mismatch?)");
+    }
+
     ApolloLog(@"[TweetBuddy] ApolloTweetProtocol ready");
 }

--- a/src/ApolloTweetBuddy.xm
+++ b/src/ApolloTweetBuddy.xm
@@ -22,7 +22,7 @@
 @end
 
 static NSString *const kApolloTweetBaseURL = @"https://apollogur.download/api/tweet/";
-static NSString *const kXHomepageURL = @"https://x.com/";
+static NSString *const kXGuestActivateURL = @"https://api.x.com/1.1/guest/activate.json";
 static NSString *const kXGraphQLURL = @"https://api.x.com/graphql/zy39CwTyYhU-_0LP7dljjg/TweetResultByRestId";
 static NSString *const kXBearerToken = @"Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
 static NSString *const kHandledKey = @"ApolloTweetProtocolHandled";
@@ -171,7 +171,12 @@ static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
             return;
         }
 
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:kXHomepageURL]];
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:kXGuestActivateURL]];
+        request.HTTPMethod = @"POST";
+        [request setValue:kXBearerToken forHTTPHeaderField:@"authorization"];
+        // Also hands back guest_id / personalization_id tracking cookies; keep
+        // them out of Apollo's shared jar.
+        request.HTTPShouldHandleCookies = NO;
         [NSURLProtocol setProperty:@YES forKey:kHandledKey inRequest:request];
 
         [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -180,17 +185,22 @@ static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
                 return;
             }
 
-            NSString *html = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"gt=([0-9]+);" options:0 error:nil];
-            NSTextCheckingResult *match = [regex firstMatchInString:html options:0 range:NSMakeRange(0, html.length)];
-            if (!match || match.numberOfRanges < 2) {
+            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+            id rawToken = [json isKindOfClass:[NSDictionary class]] ? json[@"guest_token"] : nil;
+            // A string today; tolerate a bare number rather than failing the fetch.
+            NSString *token = nil;
+            if ([rawToken isKindOfClass:[NSString class]]) {
+                token = rawToken;
+            } else if ([rawToken isKindOfClass:[NSNumber class]]) {
+                token = [rawToken stringValue];
+            }
+            if (token.length == 0) {
                 completion(nil, [NSError errorWithDomain:@"ApolloTweetProtocol"
                                                     code:-2
-                                                userInfo:@{NSLocalizedDescriptionKey: @"Could not find gt= in x.com HTML"}]);
+                                                userInfo:@{NSLocalizedDescriptionKey: @"No guest_token in guest/activate.json response"}]);
                 return;
             }
 
-            NSString *token = [html substringWithRange:[match rangeAtIndex:1]];
             dispatch_async(sTokenQueue, ^{
                 sGuestToken = token;
                 sTokenFetchDate = [NSDate date];
@@ -218,6 +228,8 @@ static NSDictionary *ApolloTweetBuddyTransformResult(NSDictionary *result) {
     [request setValue:@"application/json" forHTTPHeaderField:@"content-type"];
     [request setValue:@"https://x.com" forHTTPHeaderField:@"Origin"];
     [request setValue:@"https://x.com/" forHTTPHeaderField:@"Referer"];
+    // Sets the same tracking cookies as the activate call, on every preview.
+    request.HTTPShouldHandleCookies = NO;
     [NSURLProtocol setProperty:@YES forKey:kHandledKey inRequest:request];
 
     [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {


### PR DESCRIPTION
## Summary

Tweet link previews, which were previously restored by PR #215/#218, are currently broken outright: x.com stopped inlining the guest token in the homepage HTML, so token retrieval failed on every fetch and no preview rendered for any tweet link, at any score. This switches token retrieval to X's `guest/activate` endpoint, and additionally lifts Apollo's native "score > 40" gate so tweet previews render on low-scoring posts too.

## Impact

- Tweet link previews render again (as of today none appear at all, on any post).
- Previews now also appear on posts and comments with 40 or fewer upvotes, which Apollo natively skipped.
- Twitter `guest_id` / `personalization_id` tracking cookies (~2 year expiries) from the API are no longer deposited in Apollo's shared cookie jar.

## Changes

- **Guest token**: replaced the x.com homepage GET and `gt=([0-9]+);` body regex with a POST to `https://api.x.com/1.1/guest/activate.json`, reading `guest_token` out of the JSON response. Token caching, the 9000s TTL, and the 401/403 invalidate-and-refresh path are unchanged.
- **Score gate**: hooks `-[RDKVotable score]` and reports 41 only when the read comes from one of three known gate sites (`CompactPostThumbnailNode`, `RichMediaNode`, `CommentsHeaderCellNode`), matched via `__builtin_return_address(0)`. Every other caller, including the on-screen vote count, still sees the real score.
- The gate bypass arms itself in `%ctor` only after verifying the expected `cmp` encodings at all three addresses, so a re-pinned or altered binary disables the bypass instead of matching the wrong instruction.
- Set `HTTPShouldHandleCookies = NO` on both X requests.

## Reasoning

- **`guest/activate.json` over reading the `gt` Set-Cookie header**: both work and yield an identical token, but the activate endpoint exists solely to mint guest tokens, while the homepage cookie is a side effect of the web app's bootstrap — and a bootstrap change is precisely what broke this. It also avoids parsing a folded multi-value `Set-Cookie` header whose `Expires` values contain commas.
- **Keeping a guest token at all**: the GraphQL endpoint does answer with bearer auth alone, but token-less requests share one rate-limit bucket keyed to the client IP, which behind carrier NAT would pool unrelated users into a single quota. Each guest token carries its own.
- **Return-address matching over patching the three `cmp` instructions**: leaves the app binary untouched and keeps the real score visible everywhere else in the UI.
- **Why hardcoded addresses are unavoidable here**: the score gate is compiled inline into three Swift render paths, so there is no function or selector to hook — the only ObjC seam on the path is `-[RDKVotable score]` itself, which is read all over the app including the visible vote count, so a blanket override would corrupt what users see. Matching `__builtin_return_address(0)` against the three call sites is the only way to tell the gate's read apart from every other one.

## Testing

- Full build compiles clean.
- Verified all three gate instruction encodings still match the pinned Apollo 1.15.11 (285) binary.
- Exercised `resolveGuestToken` -> `fetchTweet` -> transform against the live API in a standalone harness using the same `NSURLSession` code: token mints, GraphQL returns 200, and every field the tweet card consumes (`full_text`, `user.name`, `screen_name`, avatar, `verified`) is populated. Cookie jar count unchanged across both requests.
- Confirmed on a physical device: tweets now show their previews, including on posts that have less than 40 upvotes.