### PR TITLE
visionOS: make the inline feed search bar usable

### DIFF
--- a/src/ApolloVisionOSHover.xm
+++ b/src/ApolloVisionOSHover.xm
@@ -428,6 +428,424 @@ static void ApolloRegisterBarControls(void) {
     }
 }
 
+#pragma mark - Inline search bar
+
+// The search field at the top of a subreddit / multireddit / post list is
+// Apollo's ApolloSearchToolbar (its field is an ApolloSearchBarTextField),
+// floated over the feed and collapsed again when the table is dragged. On
+// visionOS it was unusable, for two independent reasons.
+//
+//   1. GAZE. Like the feed rows, the toolbar is drawn inside a Texture subtree
+//      and so is not addressable for gaze: looking at it did nothing. It gets a
+//      window-level ghost, the same construction the rows and bar controls use,
+//      but one per bar rather than pooled because a search ghost carries per-bar
+//      state. The bar also joins the top-bar clip set, so a row ghost scrolled
+//      under it cannot own its gaze region.
+//
+//   2. LAYOUT. On focus Apollo moves the toolbar to the window's top edge
+//      (y=0, grown to 70pt) — exactly where the Liquid Glass floating tab bar
+//      sits, Z-above it. The toolbar still assumes it owns the top edge, from
+//      before the floating bar style; the same layout happens on Catalyst, but
+//      only on visionOS is it fatal, because there the buried field also loses
+//      its hit tests to _UIFloatingTabBarItemView. Clamping the toolbar's frame
+//      would mean fighting Apollo's layout every pass (and its
+//      keyboard-anchoring path would re-place it anyway), so the chrome above it
+//      is faded for the duration instead — what stock iOS does when a search
+//      field activates, and it removes that chrome from hit testing for free
+//      since UIKit skips views below alpha 0.01.
+//
+// Both are visionOS-only, and both restore themselves the moment the field
+// resigns first responder.
+
+static NSHashTable<UIView *> *gApolloSearchBars = nil;
+static NSHashTable<UIView *> *gApolloSearchTabBars = nil;
+static const void *kApolloSearchEnrolledKey = &kApolloSearchEnrolledKey;
+
+// Swift classes report as "Apollo.ApolloSearchToolbar" or the mangled
+// "_TtC6Apollo19ApolloSearchToolbar" depending on how they were declared, so
+// the test is a substring rather than an equality or a class lookup. Matching
+// UISearchBar alone finds nothing here: the visible field is Apollo's own
+// toolbar, not a UISearchBar.
+static BOOL ApolloIsSearchBarView(UIView *view) {
+    if ([view isKindOfClass:[UISearchBar class]]) return YES;
+    NSString *cls = NSStringFromClass([view class]);
+    return [cls containsString:@"SearchToolbar"] ||
+           [cls containsString:@"SearchBarTextField"] ||
+           [cls containsString:@"SearchBarPlaceholder"];
+}
+
+// The floating bar is _UIFloatingTabBar, which is not a UITabBar; its buttons
+// are _UIFloatingTabBarItemView and must never be faded individually.
+static BOOL ApolloIsFloatingTabBarView(UIView *view) {
+    if ([view isKindOfClass:[UITabBar class]]) return YES;
+    NSString *cls = NSStringFromClass([view class]);
+    return [cls containsString:@"TabBar"] && ![cls containsString:@"Item"];
+}
+
+// First UITextField in the bar's subtree, found by walk rather than through
+// -searchTextField so nothing depends on which UIKit the field class comes from.
+static UITextField *ApolloSearchFieldOf(UIView *bar) {
+    NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:bar];
+    while (stack.count) {
+        UIView *view = stack.lastObject;
+        [stack removeLastObject];
+        if ([view isKindOfClass:[UITextField class]]) return (UITextField *)view;
+        [stack addObjectsFromArray:view.subviews];
+    }
+    return nil;
+}
+
+static void ApolloFocusSearchBar(UIView *bar) {
+    if (!bar) return;
+    if ([bar becomeFirstResponder]) return;
+    [ApolloSearchFieldOf(bar) becomeFirstResponder];
+}
+
+static BOOL ApolloSearchIsActive(UIView *bar) {
+    NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:bar];
+    while (stack.count) {
+        UIView *view = stack.lastObject;
+        [stack removeLastObject];
+        if (view.isFirstResponder) return YES;
+        [stack addObjectsFromArray:view.subviews];
+    }
+    return NO;
+}
+
+// Focuses the field on a tap. Its delegate allows simultaneous recognition, so
+// it can never be the reason the field's own recogniser fails, and it declines
+// touches that landed on the bar's own buttons (clear / bookmark / cancel).
+@interface ApolloSearchActivator : NSObject <UIGestureRecognizerDelegate>
++ (instancetype)shared;
+@end
+
+@implementation ApolloSearchActivator
+
++ (instancetype)shared {
+    static ApolloSearchActivator *shared = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ shared = [[ApolloSearchActivator alloc] init]; });
+    return shared;
+}
+
+- (void)focus:(UITapGestureRecognizer *)tap {
+    UIView *view = tap.view;
+    while (view && !ApolloIsSearchBarView(view)) view = view.superview;
+    ApolloFocusSearchBar(view ?: tap.view);
+}
+
+- (BOOL)gestureRecognizer:(__unused UIGestureRecognizer *)recognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(__unused UIGestureRecognizer *)other {
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)recognizer
+       shouldReceiveTouch:(UITouch *)touch {
+    for (UIView *v = touch.view; v && v != recognizer.view; v = v.superview) {
+        if ([v isKindOfClass:[UIControl class]] &&
+            ![v isKindOfClass:[UITextField class]]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+@end
+
+// Hit-test transparent like every other ghost until `interactive` is set, at
+// which point it becomes the tap target of last resort for its bar.
+@interface ApolloSearchGhost : UIView
+@property (nonatomic, assign) BOOL interactive;
+@property (nonatomic, weak) UIView *bar;
+@end
+
+@implementation ApolloSearchGhost
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if (!self.interactive) return nil;
+    return [super hitTest:point withEvent:event];
+}
+
+- (void)focus:(__unused UITapGestureRecognizer *)tap {
+    ApolloFocusSearchBar(self.bar);
+}
+
+@end
+
+static NSMapTable<UIView *, ApolloSearchGhost *> *gApolloSearchGhosts = nil;
+
+// Is a real touch at the bar's centre delivered to the bar? Our own ghost is
+// hidden across the probe so it can never be the answer.
+static BOOL ApolloSearchBarReachable(UIView *bar, ApolloSearchGhost *ghost) {
+    UIWindow *window = bar.window;
+    if (!window) return YES;
+    BOOL wasHidden = ghost.hidden;
+    ghost.hidden = YES;
+    CGPoint centre = [bar convertPoint:CGPointMake(CGRectGetMidX(bar.bounds),
+                                                   CGRectGetMidY(bar.bounds))
+                                toView:window];
+    UIView *hit = [window hitTest:centre withEvent:nil];
+    ghost.hidden = wasHidden;
+    for (UIView *v = hit; v; v = v.superview) {
+        if (v == bar) return YES;
+    }
+    return NO;
+}
+
+static void ApolloEnrollSearchBar(UIView *bar) {
+    if (objc_getAssociatedObject(bar, kApolloSearchEnrolledKey)) return;
+    UITextField *field = ApolloSearchFieldOf(bar);
+    if (!field) return;   // retry next sweep; the toolbar may still be building
+    objc_setAssociatedObject(bar, kApolloSearchEnrolledKey, @YES,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
+        initWithTarget:[ApolloSearchActivator shared] action:@selector(focus:)];
+    tap.cancelsTouchesInView = NO;
+    tap.delaysTouchesBegan = NO;
+    tap.delaysTouchesEnded = NO;
+    tap.delegate = [ApolloSearchActivator shared];
+    [field addGestureRecognizer:tap];
+}
+
+static ApolloSearchGhost *ApolloSearchGhostFor(UIView *bar) {
+    if (!gApolloSearchGhosts) {
+        gApolloSearchGhosts = [NSMapTable weakToStrongObjectsMapTable];
+    }
+    ApolloSearchGhost *ghost = [gApolloSearchGhosts objectForKey:bar];
+    if (ghost) return ghost;
+    ghost = [[ApolloSearchGhost alloc] initWithFrame:CGRectZero];
+    ghost.bar = bar;
+    ghost.userInteractionEnabled = YES;
+    ghost.backgroundColor = [UIColor colorWithWhite:1.0 alpha:kApolloGhostRestAlpha];
+    ApolloApplyHoverStyle(ghost, ApolloControlHoverStyle());
+    // Doubles as the gaze-eligibility recogniser: presence is what the hit
+    // testing effect's gate reads, and it only ever receives a touch while the
+    // ghost is interactive, because -hitTest: returns nil otherwise.
+    UITapGestureRecognizer *tap =
+        [[UITapGestureRecognizer alloc] initWithTarget:ghost action:@selector(focus:)];
+    tap.cancelsTouchesInView = NO;
+    [ghost addGestureRecognizer:tap];
+    [gApolloSearchGhosts setObject:ghost forKey:bar];
+    return ghost;
+}
+
+// 1 Hz, alongside the other sweeps: find the bars and the floating tab bars,
+// enrol each bar, and decide whether its ghost has to carry the taps.
+static void ApolloRefreshSearchBars(void) {
+    if (!gApolloSearchBars) gApolloSearchBars = [NSHashTable weakObjectsHashTable];
+    if (!gApolloSearchTabBars) gApolloSearchTabBars = [NSHashTable weakObjectsHashTable];
+    [gApolloSearchBars removeAllObjects];
+    for (UIWindow *window in ApolloAllWindows()) {
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            if (ApolloIsFloatingTabBarView(view)) {
+                // Entries are weak, so this is never cleared: a bar that leaves
+                // its window is released by the per-frame pass rather than
+                // dropped mid-fade.
+                [gApolloSearchTabBars addObject:view];
+                continue;   // its items are not search bars
+            }
+            if (ApolloIsSearchBarView(view)) {
+                if (view.bounds.size.height >= 8.0 && view.bounds.size.width >= 40.0 &&
+                    ApolloViewVisibleInWindow(view)) {
+                    [gApolloSearchBars addObject:view];
+                    ApolloEnrollSearchBar(view);
+
+                    ApolloSearchGhost *ghost = ApolloSearchGhostFor(view);
+                    ghost.interactive = !ApolloSearchBarReachable(view, ghost);
+
+                    // A row ghost overlapping the field would own its gaze
+                    // region; the clip set is the mechanism that already keeps
+                    // row ghosts out from under the top bars.
+                    CGRect frame = [view convertRect:view.bounds toView:window];
+                    if (gApolloTopBars &&
+                        CGRectGetMinY(frame) < window.bounds.size.height * 0.4) {
+                        [gApolloTopBars addObject:view];
+                    }
+                    continue;   // nothing inside a matched bar needs a pass
+                }
+                // Matched but unusable this tick (zero-sized while the toolbar
+                // animates): keep descending, the real field may be nested.
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+// Per frame, from the ghost driver: the same job as ApolloGhostLayoutPass, but
+// one dedicated ghost per bar rather than a pool.
+static void ApolloLayoutSearchGhosts(BOOL hideAll) {
+    if (!gApolloSearchGhosts) return;
+    NSMutableArray<UIView *> *bars = [NSMutableArray array];
+    for (UIView *bar in gApolloSearchGhosts.keyEnumerator) [bars addObject:bar];
+    for (UIView *bar in bars) {
+        ApolloSearchGhost *ghost = [gApolloSearchGhosts objectForKey:bar];
+        UIWindow *window = bar.window;
+        UIView *presentedView = window ? ApolloWindowPresentedView(window) : nil;
+        if (hideAll || !window || !ApolloViewVisibleInWindow(bar) ||
+            ![gApolloSearchBars containsObject:bar] ||
+            (presentedView && !ApolloViewIsWithin(bar, presentedView))) {
+            ghost.hidden = YES;
+            continue;
+        }
+        CGRect frame = [bar convertRect:bar.bounds toView:window];
+        if (!CGRectIntersectsRect(frame, window.bounds)) {
+            ghost.hidden = YES;
+            continue;
+        }
+        if (ghost.superview != window) [window addSubview:ghost];
+        [window bringSubviewToFront:ghost];
+        ghost.hidden = NO;
+        ghost.frame = frame;
+        ghost.layer.cornerRadius = MIN(frame.size.height, frame.size.width) / 2.0;
+    }
+}
+
+#pragma mark - Active search bar vs. the floating tab bar
+
+// The glass over an active field is drawn by more than the tab bar itself: the
+// bar's own material travels with whatever container it is packaged in, and the
+// system additionally draws a scroll-edge effect (UIKit.ScrollEdgeEffectView
+// plus a separate backdrop view of the same family) across the top band, where
+// scrolled content passes under a floating bar. Both have to go, and neither
+// can be reached by name from the tab bar alone.
+static BOOL ApolloIsScrollEdgeEffectView(UIView *view) {
+    return [NSStringFromClass([view class]) containsString:@"ScrollEdgeEffect"];
+}
+
+// A scroll-edge effect is a band across one edge; the height cap means a
+// full-window view can never qualify however it is named.
+static const CGFloat kApolloEdgeEffectMaxHeight = 150.0;
+
+static CGFloat ApolloWindowCoverage(UIView *view, UIWindow *window) {
+    CGRect f = CGRectIntersection([view convertRect:view.bounds toView:window],
+                                  window.bounds);
+    if (CGRectIsNull(f) || CGRectIsEmpty(f)) return 0.0;
+    CGFloat windowArea = window.bounds.size.width * window.bounds.size.height;
+    if (windowArea <= 0.0) return 0.0;
+    return (f.size.width * f.size.height) / windowArea;
+}
+
+// The bar plus the container it is packaged in — which carries any backdrop
+// drawn beside it, without needing to know what that backdrop is called. The
+// climb stops below anything that contains the search toolbar (never fade the
+// field with the chrome) or covers more than half the window (which would take
+// the feed with it).
+static NSArray<UIView *> *ApolloTabBarFadeTargets(UIView *tabBar, UIView *toolbar) {
+    UIWindow *window = tabBar.window;
+    if (!window) return @[tabBar];
+    UIView *container = tabBar;
+    for (UIView *v = tabBar.superview; v && v != window; v = v.superview) {
+        if (toolbar && [toolbar isDescendantOfView:v]) break;
+        if (ApolloWindowCoverage(v, window) > 0.5) break;
+        container = v;
+    }
+    return @[container];
+}
+
+static void ApolloCollectScrollEdgeEffects(NSMutableArray<UIView *> *targets,
+                                           UIView *toolbar) {
+    UIWindow *toolbarWindow = toolbar.window;
+    if (!toolbarWindow) return;
+    CGRect toolbarFrame = [toolbar convertRect:toolbar.bounds toView:toolbarWindow];
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (window.windowScene != toolbarWindow.windowScene) continue;
+        if (window.hidden || window.alpha < 0.01) continue;
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            if (view.hidden) continue;
+            if (ApolloIsScrollEdgeEffectView(view) &&
+                ![toolbar isDescendantOfView:view] &&
+                [targets indexOfObjectIdenticalTo:view] == NSNotFound) {
+                CGRect f = [view convertRect:view.bounds toView:window];
+                if (window != toolbarWindow) {
+                    f = [window convertRect:f toWindow:toolbarWindow];
+                }
+                if (f.size.height <= kApolloEdgeEffectMaxHeight &&
+                    CGRectIntersectsRect(f, toolbarFrame)) {
+                    [targets addObject:view];
+                }
+            }
+            // The backdrop is a separate view of the same family, so the walk
+            // continues through a match rather than stopping at it.
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+// One held set, re-asserted every frame. Each view is stashed at its original
+// alpha the first time that INSTANCE is seen, held at 0 while it qualifies, and
+// restored when it stops qualifying or the field resigns.
+//
+// Per frame rather than once per transition because the system rebuilds the
+// scroll-edge effect during the keyboard and layout animations that follow
+// activation: a set chosen once at the transition is stale moments later, and
+// the fresh instance then draws at full alpha for the rest of the session.
+// Hiding is instant, since a per-frame assert would fight an animation;
+// restoring is animated, which is the transition that is actually seen.
+static NSMapTable<UIView *, NSNumber *> *gApolloHeldChrome = nil;
+
+static void ApolloHoldChrome(NSArray<UIView *> *targets) {
+    if (!gApolloHeldChrome) gApolloHeldChrome = [NSMapTable weakToStrongObjectsMapTable];
+    for (UIView *view in gApolloHeldChrome.keyEnumerator.allObjects) {
+        if ([targets indexOfObjectIdenticalTo:view] != NSNotFound) continue;
+        NSNumber *original = [gApolloHeldChrome objectForKey:view];
+        [gApolloHeldChrome removeObjectForKey:view];
+        CGFloat alpha = original ? original.doubleValue : 1.0;
+        // The tab bar must never come back invisible and untappable, so a
+        // sub-floor capture (a mid-animation read) restores to 1. A scroll-edge
+        // effect is the opposite case: the system drives its alpha from scroll
+        // position and legitimately parks it at 0 at the top of a feed, so its
+        // captured value is restored verbatim and the system takes it from there.
+        CGFloat restored = (alpha < 0.01 && !ApolloIsScrollEdgeEffectView(view))
+            ? 1.0 : alpha;
+        [UIView animateWithDuration:0.2 animations:^{ view.alpha = restored; }];
+    }
+    for (UIView *view in targets) {
+        if (![gApolloHeldChrome objectForKey:view]) {
+            [gApolloHeldChrome setObject:@(view.alpha) forKey:view];
+        }
+        if (view.alpha != 0.0) view.alpha = 0.0;
+    }
+}
+
+// Per frame from the ghost driver. Both conditions are required, so a toolbar
+// merely scrolled under the bar never hides it, and a first responder in the
+// Search TAB (whose bar does not overlap) never does either.
+static void ApolloUpdateSearchChrome(void) {
+    NSMutableArray<UIView *> *targets = [NSMutableArray array];
+    UIView *toolbar = nil;
+    for (UIView *tabBar in gApolloSearchTabBars.allObjects) {
+        UIWindow *window = tabBar.window;
+        if (!window) continue;
+        UIView *active = nil;
+        CGRect tabFrame = [tabBar convertRect:tabBar.bounds toView:window];
+        for (UIView *bar in gApolloSearchBars.allObjects) {
+            if (bar.window != window || !ApolloViewVisibleInWindow(bar)) continue;
+            if (!CGRectIntersectsRect([bar convertRect:bar.bounds toView:window],
+                                      tabFrame)) continue;
+            if (!ApolloSearchIsActive(bar)) continue;
+            active = bar;
+            break;
+        }
+        if (!active) continue;
+        toolbar = toolbar ?: active;
+        for (UIView *target in ApolloTabBarFadeTargets(tabBar, active)) {
+            if ([targets indexOfObjectIdenticalTo:target] == NSNotFound) {
+                [targets addObject:target];
+            }
+        }
+    }
+    // Only walked while a field is actually active, so the resting cost of this
+    // pass is one loop over the registered bars.
+    if (toolbar) ApolloCollectScrollEdgeEffects(targets, toolbar);
+    ApolloHoldChrome(targets);
+}
+
 #pragma mark - Ghost driver
 
 @interface ApolloGhostDriver : NSObject
@@ -557,6 +975,7 @@ static void ApolloGhostHideAll(NSMapTable<UIWindow *, NSMutableArray<ApolloGazeG
     if (ApolloContextMenuIsUp()) {
         if (gApolloRowPools) ApolloGhostHideAll(gApolloRowPools);
         if (gApolloControlPools) ApolloGhostHideAll(gApolloControlPools);
+        ApolloLayoutSearchGhosts(YES);
         return;
     }
     if (gApolloGhostCells) {
@@ -567,6 +986,8 @@ static void ApolloGhostHideAll(NSMapTable<UIWindow *, NSMutableArray<ApolloGazeG
         if (!gApolloControlPools) gApolloControlPools = [NSMapTable weakToStrongObjectsMapTable];
         ApolloGhostLayoutAllWindows(gApolloGhostControls, gApolloControlPools, link.timestamp, YES);
     }
+    ApolloLayoutSearchGhosts(NO);
+    ApolloUpdateSearchChrome();
 }
 
 @end
@@ -653,6 +1074,9 @@ static void ApolloStartHoverTimers(void) {
                 ApolloUnstickScrollGaze();
                 ApolloRefreshTopBars();
                 ApolloRegisterBarControls();
+                // After ApolloRefreshTopBars, so a top-anchored search bar can
+                // join the clip set it just rebuilt.
+                ApolloRefreshSearchBars();
             }];
 
             CADisplayLink *link =

--- a/src/ApolloVisionOSHover.xm
+++ b/src/ApolloVisionOSHover.xm
@@ -572,7 +572,13 @@ static BOOL ApolloSearchIsActive(UIView *bar) {
 
 @end
 
+// Keyed weakly by the bar, so a deallocated toolbar drops out of the map on its
+// own — which is why the strong list beside it exists. `upperToolbar` is a `let`
+// on ASTableViewController, so every feed push builds a new toolbar and popping
+// the feed deallocates it; without a handle that outlives the key, the ghost is
+// never touched again and stays in the window as a stale subview.
 static NSMapTable<UIView *, ApolloSearchGhost *> *gApolloSearchGhosts = nil;
+static NSMutableArray<ApolloSearchGhost *> *gApolloSearchGhostList = nil;
 
 // Is a real touch at the bar's centre delivered to the bar? Our own ghost is
 // hidden across the probe so it can never be the answer.
@@ -610,6 +616,7 @@ static void ApolloEnrollSearchBar(UIView *bar) {
 static ApolloSearchGhost *ApolloSearchGhostFor(UIView *bar) {
     if (!gApolloSearchGhosts) {
         gApolloSearchGhosts = [NSMapTable weakToStrongObjectsMapTable];
+        gApolloSearchGhostList = [NSMutableArray array];
     }
     ApolloSearchGhost *ghost = [gApolloSearchGhosts objectForKey:bar];
     if (ghost) return ghost;
@@ -626,6 +633,7 @@ static ApolloSearchGhost *ApolloSearchGhostFor(UIView *bar) {
     tap.cancelsTouchesInView = NO;
     [ghost addGestureRecognizer:tap];
     [gApolloSearchGhosts setObject:ghost forKey:bar];
+    [gApolloSearchGhostList addObject:ghost];
     return ghost;
 }
 
@@ -675,16 +683,31 @@ static void ApolloRefreshSearchBars(void) {
 }
 
 // Per frame, from the ghost driver: the same job as ApolloGhostLayoutPass, but
-// one dedicated ghost per bar rather than a pool.
+// one dedicated ghost per bar rather than a pool. Iterating the strong list
+// rather than the map's keys is what lets a ghost outlive its bar just long
+// enough to be taken out of the window: a bar that goes away or leaves its
+// window has its ghost removed from the view hierarchy and dropped from both
+// collections, and a bar that comes back is given a fresh one by the next sweep
+// (which it has to wait for regardless, since gApolloSearchBars is rebuilt
+// there and an unlisted bar keeps its ghost hidden anyway).
 static void ApolloLayoutSearchGhosts(BOOL hideAll) {
-    if (!gApolloSearchGhosts) return;
-    NSMutableArray<UIView *> *bars = [NSMutableArray array];
-    for (UIView *bar in gApolloSearchGhosts.keyEnumerator) [bars addObject:bar];
-    for (UIView *bar in bars) {
-        ApolloSearchGhost *ghost = [gApolloSearchGhosts objectForKey:bar];
+    if (!gApolloSearchGhostList) return;
+    for (ApolloSearchGhost *ghost in [gApolloSearchGhostList copy]) {
+        UIView *bar = ghost.bar;
         UIWindow *window = bar.window;
-        UIView *presentedView = window ? ApolloWindowPresentedView(window) : nil;
-        if (hideAll || !window || !ApolloViewVisibleInWindow(bar) ||
+        if (!bar || !window) {
+            // Clearing `interactive` before the removal is belt-and-braces: off
+            // the hierarchy its -hitTest: is unreachable anyway, but a stale
+            // interactive ghost is exactly what turned this leak into a dead
+            // pinch band, and nothing should be able to resurrect that.
+            ghost.interactive = NO;
+            [ghost removeFromSuperview];
+            [gApolloSearchGhostList removeObjectIdenticalTo:ghost];
+            if (bar) [gApolloSearchGhosts removeObjectForKey:bar];
+            continue;
+        }
+        UIView *presentedView = ApolloWindowPresentedView(window);
+        if (hideAll || !ApolloViewVisibleInWindow(bar) ||
             ![gApolloSearchBars containsObject:bar] ||
             (presentedView && !ApolloViewIsWithin(bar, presentedView))) {
             ghost.hidden = YES;


### PR DESCRIPTION
## What's broken

On visionOS, the **inline feed search bar** — `ApolloSearchToolbar` at the top of a subreddit, multireddit or post feed, wrapping an `ApolloSearchBarTextField` — is completely dead. It never takes a gaze highlight, and it responds to neither a pinch nor a direct touch. (The Search tab's own bar works fine; this is only the inline one.) There is no way to search a subreddit from the headset at all.

There is a second half to it. Once the field *does* become first responder, Apollo lays the toolbar out at the window's top edge (y=0, ~70pt tall) — which, on the GLASS build, is exactly where the floating tab bar sits Z-above it. The field ends up behind the glass: dim, hard to read while typing, and `_UIFloatingTabBarItemView` answers its hit tests. Worth flagging separately, because **this half also reproduces on Catalyst/macOS** — the active search toolbar still assumes it owns the top edge, from before the floating tab bar style. That looks like a base-app layout issue rather than a visionOS one; this PR works around it from the visionOS side only, and doesn't touch Apollo's layout.

## The fix

All of it lives in `src/ApolloVisionOSHover.xm`, inside that file's existing visionOS guard — no new file, no Makefile entry, and no duplicated infrastructure. It reuses what the file already has: the ghost class, the hover styles, `ApolloViewVisibleInWindow`, `gApolloTopBars`, the display link and the 1 Hz sweep. No other platform changes behaviour.

**Making the bar live.** A window-level gaze ghost per matched bar, plus a tap that calls `becomeFirstResponder` on the field. The sweep matches on class-name substring (`SearchToolbar` / `SearchBarTextField` / `SearchBarPlaceholder`) rather than `UISearchBar`, which covers both the `Apollo.Foo` and the mangled `_TtC6Apollo…` runtime forms — matching `UISearchBar` alone finds nothing here. Ghosts are clipped below any top-anchored bar (so a scrolled row can't steal the bar's gaze region) and suppressed while a modal sheet is presented.

**Keeping the active field visible.** While the field holds first responder *and* the toolbar overlaps a registered floating tab bar, the tab bar assembly and any overlapping system `ScrollEdgeEffectView` (plus its separate backdrop view, which draws the actual material) are held at **alpha 0 per frame**, and restored on dismiss. Fading alpha rather than moving the toolbar is deliberate: UIKit skips views below alpha 0.01 in hit testing, so the field gets its touches back for free, and nothing Apollo lays out is disturbed.

Two details that are load-bearing and not obvious:

- **The hold is re-asserted per frame, not faded once.** A one-shot fade loses to the system *recreating* the scroll-edge effect views during the keyboard/layout animation that follows activation — the fresh instance is never in the stash, so the fix appears to do nothing. Re-selecting targets each tick sidesteps that whole class of failure.
- **Restore is per-family.** The tab bar is floored to full alpha (it must never come back invisible), but a scroll-edge effect is restored to its *captured* value verbatim, because the system legitimately parks that at 0 at the top of a feed and drives it from scroll position afterwards.

## Testing

Device-verified on an **Apple Vision Pro (visionOS 27)**, through an iterative on-device diagnostic cycle — the stripped Swift binary doesn't say which layer breaks, so several rounds shipped an instrumented build whose HUD probed the z-stack over the active field across every window. That's how the scroll-edge effect was identified by name rather than guessed at; three earlier guesses at what drew the slab each changed nothing on device.

Also compiled clean (`logos.pl -c generator=internal` + `clang -fsyntax-only -Wall`) at both of the repo's floors: `-miphoneos-version-min=14.0` (device) and `15.0` (simulator). No new warnings.

**One honest difference between the verified build and this patch.** The build in Austin's headset (tweak 3.6.0.9) is logically identical to this diff with exactly one exception: **this patch additionally suppresses the search ghosts while a modal sheet is presented**, using this file's existing `ApolloWindowPresentedView` / `ApolloViewIsWithin` helpers. That was added here because the review of #759 asked for exactly that behaviour on the row ghosts, and it would be wrong to ship the search ghosts without it. It is inert for the verification that was performed (no sheet is up while typing in a feed's search bar), but it is code that was not on the device — calling it out rather than claiming coverage it doesn't have.

`CHANGELOG.md` is deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
