### PR TITLE
Stop the subreddit list's section headers overlapping rows on launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloPictureInPicture.xm \
     $(SRC_DIR)/ApolloMediaPreviewErrorFix.xm \
     $(SRC_DIR)/ApolloSubredditIndexPolish.xm \
+    $(SRC_DIR)/ApolloSubredditListLaunchSettle.xm \
     $(SRC_DIR)/ApolloQuickActions.xm \
     $(SRC_DIR)/ApolloHideModSubreddits.xm \
     $(SRC_DIR)/ApolloMultiredditEdit.xm \

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -358,6 +358,7 @@ static void ApolloSimDebugForceBottomInset(CGFloat bottom) {
 // ObjC++, so plain C++ linkage matches).
 const void *ApolloScrollEdgeEffectTopStampKey(void);
 const void *ApolloScrollEdgeEffectForcedHiddenStampKey(void);
+void ApolloSubredditListDiagRearm(void);
 
 static void ApolloSimDebugDumpHeaderEffectsInView(UIView *view) {
     if ([view isKindOfClass:[UIScrollView class]]) {
@@ -400,6 +401,14 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
         // state (pointer, hidden, style, tweak stamps) for header debugging.
         if ([contents hasPrefix:@"headerdump"]) {
             ApolloSimDebugDumpHeaderEffects();
+            return;
+        }
+        // "listdiag" command: re-arm the subreddit-list launch geometry
+        // recorder (ApolloSubredditListLaunchSettle) against the list
+        // controller, so the settle can be observed on a pop-back without a
+        // cold launch.
+        if ([contents hasPrefix:@"listdiag"]) {
+            ApolloSubredditListDiagRearm();
             return;
         }
         // "headerstyle N" command: switch the Header Style setting through the

--- a/src/ApolloSubredditListLaunchSettle.xm
+++ b/src/ApolloSubredditListLaunchSettle.xm
@@ -88,6 +88,7 @@ static CGFloat sLastSampledOffset = CGFLOAT_MAX;
 // to cover the list's first layout passes, never ordinary use of the screen.
 static NSTimeInterval sSuppressUntil = 0;
 static NSUInteger sSuppressedPasses = 0;
+static NSUInteger sSuppressedHeaderPasses = 0;
 // backtrace_symbols() does a dladdr per frame, so a trace costs about a
 // millisecond. Capping them keeps the recorder from adding measurable work to
 // the very launch it is timing — and keeps one launch from evicting the rest of
@@ -301,6 +302,7 @@ static void ApolloSLDOpenWindow(UITableView *table, NSString *reason) {
     sTracesWritten = 0;
     sSuppressUntil = CACurrentMediaTime() + kSuppressSeconds;
     sSuppressedPasses = 0;
+    sSuppressedHeaderPasses = 0;
     ApolloSLDLog(@"window open (%@) table=%p uptime=%.0fms",
                  reason, table, NSProcessInfo.processInfo.systemUptime * 1000.0);
     ApolloSLDSnapshot(table, @"open", YES);
@@ -342,8 +344,10 @@ static void ApolloSLDOpenWindow(UITableView *table, NSString *reason) {
         // the direction measured off the reporter's recording. Written straight
         // through so the summary survives even when the line cap was reached.
         ApolloSLDWrite([NSString stringWithFormat:
-            @"window closed: contentTop %.1f -> %.1f (settle %.1fpt) lines=%lu",
-            sFirstContentTop, sLastContentTop, -delta, (unsigned long)sLinesWritten]);
+            @"window closed: contentTop %.1f -> %.1f (settle %.1fpt) suppressed=%lu/%luhdr lines=%lu",
+            sFirstContentTop, sLastContentTop, -delta,
+            (unsigned long)sSuppressedPasses, (unsigned long)sSuppressedHeaderPasses,
+            (unsigned long)sLinesWritten]);
     });
 }
 
@@ -361,6 +365,29 @@ static UITableView *ApolloSLDTableForController(id controller) {
         cls = class_getSuperclass(cls);
     }
     return nil;
+}
+
+// Section header views are DIRECT subviews of the table, and their own
+// -layoutSubviews runs during the parent's subtree walk — i.e. AFTER the
+// table's -layoutSubviews returns, and therefore outside the suppression the
+// table hook applies to itself. A header that UIKit recreated moments earlier
+// (a reloadData is enough) still has its label at the old frame, so laying it
+// out inside the inherited animation glides the label diagonally into place:
+// exactly the "FAVORITES slides in" the reporter saw once the cells stopped
+// moving. Give the headers the same treatment their table already gets.
+static BOOL ApolloSLDShouldSuppressHeaderLayout(UIView *header) {
+    if (!sTrackedTable || header.superview != sTrackedTable) return NO;
+    if (sSuppressUntil <= 0 || CACurrentMediaTime() >= sSuppressUntil) return NO;
+    return [UIView inheritedAnimationDuration] > 0.0;
+}
+
+static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
+    sSuppressedHeaderPasses++;
+    if (sSuppressedHeaderPasses != 1) return;
+    ApolloSLDLog(@"+%.0fms SUPPRESSED animated header layout (%@ inherited=%.2fs frame=%@) via %@",
+                 ApolloSLDElapsedMs(), NSStringFromClass(header.class),
+                 [UIView inheritedAnimationDuration], ApolloSLDRect(header.frame),
+                 ApolloSLDCallers());
 }
 
 %group ApolloSubredditListLaunchSettle
@@ -446,8 +473,12 @@ static UITableView *ApolloSLDTableForController(id controller) {
             // One line per launch is enough to tell a fixed launch from an
             // untouched one; further passes in the same window are silent.
             if (sSuppressedPasses == 1) {
-                ApolloSLDLog(@"+%.0fms SUPPRESSED animated launch layout (inherited=%.2fs, offsetY %.1f -> %.1f)",
-                             ApolloSLDElapsedMs(), inherited, before, self.contentOffset.y);
+                // The trace here names whoever opened the animation this layout
+                // pass is inheriting — the one thing the recorder could not
+                // answer from the first round of logs.
+                ApolloSLDLog(@"+%.0fms SUPPRESSED animated launch layout (inherited=%.2fs, offsetY %.1f -> %.1f) via %@",
+                             ApolloSLDElapsedMs(), inherited, before, self.contentOffset.y,
+                             ApolloSLDCallers());
             }
             ApolloSLDSnapshot(self, @"layout(suppressed)", NO);
             return;
@@ -516,6 +547,35 @@ static UITableView *ApolloSLDTableForController(id controller) {
     ApolloSLDLog(@"+%.0fms reloadData contentHeight %.0f -> %.0f anim(%@) via %@",
                  ApolloSLDElapsedMs(), before, self.contentSize.height,
                  ApolloSLDAnimationContext(), ApolloSLDCallers());
+}
+
+%end
+
+// Apollo vends its own section header for this list; UIKit supplies the plain
+// one when Apollo does not. Both are direct subviews of the table, so the same
+// one-pointer guard covers them.
+%hook UITableViewHeaderFooterView
+
+- (void)layoutSubviews {
+    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) { %orig; return; }
+    ApolloSLDNoteHeaderSuppressed((UIView *)self);
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [UIView performWithoutAnimation:^{ %orig; }];
+    [CATransaction commit];
+}
+
+%end
+
+%hook _TtC6Apollo31RecreatedTableSectionHeaderView
+
+- (void)layoutSubviews {
+    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) { %orig; return; }
+    ApolloSLDNoteHeaderSuppressed((UIView *)self);
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [UIView performWithoutAnimation:^{ %orig; }];
+    [CATransaction commit];
 }
 
 %end

--- a/src/ApolloSubredditListLaunchSettle.xm
+++ b/src/ApolloSubredditListLaunchSettle.xm
@@ -73,7 +73,10 @@ static const NSTimeInterval kSuppressSeconds = 1.5;
 // Hard cap so a pathological launch cannot flood the cross-launch buffer.
 static const NSUInteger kMaxLines = 80;
 
-static __unsafe_unretained UITableView *sTrackedTable = nil;   // never messaged when stale
+// Compared by pointer only, never messaged, and cleared the moment the window
+// closes — so it cannot outlive the controller and cannot be matched by some
+// later table that happens to land on the same address.
+static __unsafe_unretained UITableView *sTrackedTable = nil;
 static BOOL sWindowOpen = NO;
 static NSTimeInterval sWindowOpenedAt = 0;
 static NSUInteger sLinesWritten = 0;
@@ -85,6 +88,11 @@ static CGFloat sLastSampledOffset = CGFLOAT_MAX;
 // to cover the list's first layout passes, never ordinary use of the screen.
 static NSTimeInterval sSuppressUntil = 0;
 static NSUInteger sSuppressedPasses = 0;
+// backtrace_symbols() does a dladdr per frame, so a trace costs about a
+// millisecond. Capping them keeps the recorder from adding measurable work to
+// the very launch it is timing — and keeps one launch from evicting the rest of
+// the shared cross-launch buffer.
+static NSUInteger sTracesWritten = 0;
 // The first list controller of the process, kept weakly so the simulator
 // bridge can re-arm against it even while it sits under a pushed feed.
 static __weak UIViewController *sListController = nil;
@@ -204,6 +212,8 @@ static void ApolloSLDSnapshot(UITableView *table, NSString *reason, BOOL force) 
     if (!sWindowOpen || !table || table != sTrackedTable) return;
     if (!force && ApolloSLDElapsedMs() > kWindowSeconds * 1000.0) {
         sWindowOpen = NO;
+        sTrackedTable = nil;
+        sSuppressUntil = 0;
         return;
     }
 
@@ -251,7 +261,11 @@ static void ApolloSLDSnapshot(UITableView *table, NSString *reason, BOOL force) 
 // Abbreviated caller trace for the geometry setters: enough to tell Apollo's
 // own code, UIKit's layout machinery and the tweak apart without pulling in a
 // full symbolicated backtrace on every call.
+static const NSUInteger kMaxTraces = 12;
+
 static NSString *ApolloSLDCallers(void) {
+    if (sTracesWritten >= kMaxTraces) return @"(trace capped)";
+    sTracesWritten++;
     NSArray<NSString *> *symbols = [NSThread callStackSymbols];
     NSMutableArray<NSString *> *kept = [NSMutableArray array];
     // callStackSymbols format: "<n><pad><image><pad><addr> <symbol> + <offset>".
@@ -284,6 +298,7 @@ static void ApolloSLDOpenWindow(UITableView *table, NSString *reason) {
     sLastSnapshot = nil;
     sFirstContentTop = CGFLOAT_MAX;
     sLastSampledOffset = CGFLOAT_MAX;
+    sTracesWritten = 0;
     sSuppressUntil = CACurrentMediaTime() + kSuppressSeconds;
     sSuppressedPasses = 0;
     ApolloSLDLog(@"window open (%@) table=%p uptime=%.0fms",
@@ -315,6 +330,13 @@ static void ApolloSLDOpenWindow(UITableView *table, NSString *reason) {
                    dispatch_get_main_queue(), ^{
         if (!sWindowOpen) return;
         sWindowOpen = NO;
+        // Drop every hot-path trigger together. After this the global hooks are
+        // a single BOOL test, the layoutSubviews guard can never match again
+        // (so a table allocated at this address later cannot be mistaken for
+        // the list's), and the list controller's layout hooks stop resolving
+        // ivars. The recorder and the fix are done for the life of the process.
+        sTrackedTable = nil;
+        sSuppressUntil = 0;
         CGFloat delta = (sFirstContentTop == CGFLOAT_MAX) ? 0.0 : (sLastContentTop - sFirstContentTop);
         // Positive settle == the content ended HIGHER than it started, which is
         // the direction measured off the reporter's recording. Written straight
@@ -357,23 +379,31 @@ static UITableView *ApolloSLDTableForController(id controller) {
     ApolloSLDOpenWindow(ApolloSLDTableForController(self), @"viewDidLoad");
 }
 
+// Every hook below tests sWindowOpen BEFORE resolving the table: the ivar walk
+// takes the runtime lock, and viewWillLayoutSubviews/viewDidLayoutSubviews run
+// on this screen for the life of the process. Once the window has closed these
+// are a static BOOL load and a return.
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
+    if (!sWindowOpen) return;
     ApolloSLDSnapshot(ApolloSLDTableForController(self), @"viewWillAppear", NO);
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
+    if (!sWindowOpen) return;
     ApolloSLDSnapshot(ApolloSLDTableForController(self), @"viewDidAppear", NO);
 }
 
 - (void)viewWillLayoutSubviews {
     %orig;
+    if (!sWindowOpen) return;
     ApolloSLDSnapshot(ApolloSLDTableForController(self), @"vcWillLayout", NO);
 }
 
 - (void)viewDidLayoutSubviews {
     %orig;
+    if (!sWindowOpen) return;
     ApolloSLDSnapshot(ApolloSLDTableForController(self), @"vcDidLayout", NO);
 }
 

--- a/src/ApolloSubredditListLaunchSettle.xm
+++ b/src/ApolloSubredditListLaunchSettle.xm
@@ -1,0 +1,513 @@
+// ApolloSubredditListLaunchSettle.xm
+//
+// Subreddit-list launch settle: suppress the animated first layout that makes
+// section header bands overlap the rows above them, and record the geometry
+// that produced it (issue #919).
+//
+// Symptom (measured frame-by-frame from a reporter's screen recording): on a
+// cold launch that lands on Apollo.RedditListViewController, every CELL of the
+// list glides upward by ~22-27pt over ~0.26s while the section header bands
+// ("FAVORITES", the A-Z letters) sit at their FINAL Y from the first visible
+// frame. During the settle a header therefore overlaps — and clips — the last
+// row of the section above it. Row heights and inter-row spacing never change,
+// so the whole content block is translating: a contentOffset / contentInset /
+// safe-area change, not a row-metrics change.
+//
+// Why cells animate but headers do not (UIKitCore 26.1, verified in the
+// decompiled UITableView):
+//   * -[UITableView _updateVisibleCellsNow:] re-frames every visible cell with
+//     a bare -setFrame:, so the move joins whatever animation context the
+//     layout pass is running in. Inside a UIView animation block the cells
+//     glide.
+//   * A header UIKit has to CREATE or dequeue during that same pass is built
+//     by -[UITableView _sectionHeaderView:withFrame:forSection:floating:...],
+//     whose whole build-and-frame is wrapped in +[UIView
+//     performWithoutAnimation:]. It lands at its final frame with animations
+//     suppressed.
+// So the artifact means: the list's first real layout pass happens INSIDE a
+// UIView animation, and the geometry it lays out to differs from what was on
+// screen a moment earlier. This module records which input moved.
+//
+// THE FIX (see the -[UITableView layoutSubviews] hook below): while the list is
+// arriving, a layout pass that runs inside an inherited UIView animation is
+// re-run with animations off, so the rows land where the headers already are.
+// The guard is the bug's own precondition — a healthy launch lays this table
+// out with inheritedAnimationDuration == 0 (verified in the simulator), so the
+// hook falls straight through to %orig and nothing changes for anyone who was
+// never seeing the artifact.
+//
+// THE RECORDER exists because only the reporter sees it: the maintainer, on the
+// same iPhone 17 Pro / iOS 26.5 / Liquid Glass build, does not, and neither does
+// the simulator. The most obvious asymmetry is list size (the reporter's table
+// reports a 9864pt content height, which would make the first layout land late
+// enough to fall inside the launch animation) — but that is a hypothesis, not a
+// finding. The recorder captures which input actually moved, whether or not the
+// suppression above turns out to be enough.
+//
+// Cost when idle: two static loads on the global UITableView hooks. The window
+// only ever opens for Apollo.RedditListViewController's own table, closes after
+// kWindowSeconds, and is hard-capped at kMaxLines lines. Snapshots are
+// emitted only when the formatted geometry actually CHANGES, so a healthy
+// launch writes a handful of lines, not one per layout pass.
+//
+// Output goes to ApolloListLayoutLog's channel: the apollofix os_log stream
+// AND the bounded cross-launch buffer that Settings > Export Debug Logs
+// prepends — so a reporter can force-quit, relaunch, and still export it.
+
+#import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+
+// How long the recorder stays open after the list controller loads its view.
+// The measured settle finishes ~0.3s after the launch crossfade; 4s covers the
+// slow-fetch reloads (subscriptions / multireddits / moderated subs) that land
+// afterwards without running into ordinary scrolling.
+static const NSTimeInterval kWindowSeconds = 4.0;
+// How long after the list controller loads its view the animated-layout
+// suppression stays armed. The measured settle is over ~0.3s in; 1.5s leaves
+// room for a slow first fetch without reaching into ordinary interaction.
+static const NSTimeInterval kSuppressSeconds = 1.5;
+// Hard cap so a pathological launch cannot flood the cross-launch buffer.
+static const NSUInteger kMaxLines = 80;
+
+static __unsafe_unretained UITableView *sTrackedTable = nil;   // never messaged when stale
+static BOOL sWindowOpen = NO;
+static NSTimeInterval sWindowOpenedAt = 0;
+static NSUInteger sLinesWritten = 0;
+static NSString *sLastSnapshot = nil;
+static CGFloat sFirstContentTop = CGFLOAT_MAX;   // -contentOffset.y at the first snapshot
+static CGFloat sLastContentTop = CGFLOAT_MAX;
+static CGFloat sLastSampledOffset = CGFLOAT_MAX;
+// The fix window is deliberately much shorter than the recorder's: it only has
+// to cover the list's first layout passes, never ordinary use of the screen.
+static NSTimeInterval sSuppressUntil = 0;
+static NSUInteger sSuppressedPasses = 0;
+// The first list controller of the process, kept weakly so the simulator
+// bridge can re-arm against it even while it sits under a pushed feed.
+static __weak UIViewController *sListController = nil;
+
+static NSString *ApolloSLDInsets(UIEdgeInsets i) {
+    return [NSString stringWithFormat:@"%.1f/%.1f/%.1f/%.1f", i.top, i.left, i.bottom, i.right];
+}
+
+static NSString *ApolloSLDRect(CGRect r) {
+    return [NSString stringWithFormat:@"%.0f,%.0f,%.0fx%.0f", r.origin.x, r.origin.y, r.size.width, r.size.height];
+}
+
+static void ApolloSLDWrite(NSString *line) {
+    line = [NSString stringWithFormat:@"[SubListDiag] %@", line ?: @""];
+    ApolloLog(@"%@", line);
+    ApolloAppendListLayoutDiag(line);
+}
+
+static void ApolloSLDLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+static void ApolloSLDLog(NSString *format, ...) {
+    if (sLinesWritten >= kMaxLines) return;
+    sLinesWritten++;
+    va_list args;
+    va_start(args, format);
+    NSString *body = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    ApolloSLDWrite(body);
+}
+
+// Milliseconds since the window opened — the only clock that matters here, and
+// it lines up directly with the frame timings measured off the recording.
+static double ApolloSLDElapsedMs(void) {
+    return (CACurrentMediaTime() - sWindowOpenedAt) * 1000.0;
+}
+
+// Is this call running inside a UIView animation block / a CATransaction that
+// will animate? This is the single most important field in the log: it is what
+// separates "geometry changed" from "geometry changed and the cells glided".
+static NSString *ApolloSLDAnimationContext(void) {
+    return [NSString stringWithFormat:@"inh=%.2f on=%d ca=%.2f dis=%d",
+            [UIView inheritedAnimationDuration],
+            [UIView areAnimationsEnabled],
+            [CATransaction animationDuration],
+            [CATransaction disableActions]];
+}
+
+static UIViewController *ApolloSLDOwningViewController(UIView *view) {
+    UIResponder *responder = view;
+    while (responder) {
+        responder = responder.nextResponder;
+        if ([responder isKindOfClass:[UIViewController class]]) return (UIViewController *)responder;
+    }
+    return nil;
+}
+
+// How many of the table's own subviews are mid-glide, split by kind, plus the
+// frame of the first section header band. "cells > 0 with headers == 0" is the
+// fingerprint of the reported artifact.
+//
+// This walks the table's subviews directly rather than asking for
+// -numberOfSections / -headerViewForSection:, because both of those can drive
+// the data source into a row-data rebuild — and a recorder that perturbs the
+// launch layout it is measuring is worse than no recorder at all.
+static void ApolloSLDCountLiveAnimations(UITableView *table, NSUInteger *cellsOut, NSUInteger *headersOut,
+                                         NSString **firstHeaderFrameOut) {
+    NSUInteger cells = 0, headers = 0;
+    NSString *firstHeaderFrame = @"none";
+    Class headerFooterClass = [UITableViewHeaderFooterView class];
+    for (UIView *subview in table.subviews) {
+        BOOL gliding = ([subview.layer animationForKey:@"position"] != nil ||
+                        [subview.layer animationForKey:@"bounds"] != nil);
+        if ([subview isKindOfClass:[UITableViewCell class]]) {
+            if (gliding) cells++;
+            continue;
+        }
+        // Apollo vends Apollo.RecreatedTableSectionHeaderView (a bare UIView)
+        // for some sections and lets UIKit supply the rest, so match both.
+        BOOL isHeader = [subview isKindOfClass:headerFooterClass] ||
+                        [NSStringFromClass(subview.class) containsString:@"SectionHeader"];
+        if (!isHeader) continue;
+        if ([firstHeaderFrame isEqualToString:@"none"]) {
+            firstHeaderFrame = ApolloSLDRect(subview.frame);
+        }
+        if (gliding) headers++;
+    }
+    if (cellsOut) *cellsOut = cells;
+    if (headersOut) *headersOut = headers;
+    if (firstHeaderFrameOut) *firstHeaderFrameOut = firstHeaderFrame;
+}
+
+// The CA animations that make cells glide are attached when the enclosing
+// UIView animation block commits, i.e. AFTER the setter returns — so sample the
+// fingerprint on the next runloop turn rather than in the setter itself.
+// "cells>0 hdrs=0" is the artifact; "cells=0" means the change committed
+// without animation and nothing would have been visible.
+static void ApolloSLDSampleAnimationFingerprint(UITableView *table, NSString *reason) {
+    if (!sWindowOpen || !table) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!sWindowOpen || table != sTrackedTable) return;
+        NSUInteger cells = 0, headers = 0;
+        NSString *firstHeaderFrame = @"none";
+        ApolloSLDCountLiveAnimations(table, &cells, &headers, &firstHeaderFrame);
+        CAAnimation *sample = nil;
+        for (UITableViewCell *cell in table.visibleCells) {
+            sample = [cell.layer animationForKey:@"position"];
+            if (sample) break;
+        }
+        ApolloSLDLog(@"+%.0fms fingerprint(%@) glidingCells=%lu glidingHeaders=%lu dur=%.2f off=%.1f hdr0=%@",
+                     ApolloSLDElapsedMs(), reason, (unsigned long)cells, (unsigned long)headers,
+                     sample ? sample.duration : 0.0, table.contentOffset.y, firstHeaderFrame);
+    });
+}
+
+// One formatted geometry snapshot. Emitted only when it differs from the last
+// one, so a settled table stops producing lines on its own.
+static void ApolloSLDSnapshot(UITableView *table, NSString *reason, BOOL force) {
+    if (!sWindowOpen || !table || table != sTrackedTable) return;
+    if (!force && ApolloSLDElapsedMs() > kWindowSeconds * 1000.0) {
+        sWindowOpen = NO;
+        return;
+    }
+
+    UIViewController *vc = ApolloSLDOwningViewController(table);
+    UINavigationController *nav = vc.navigationController;
+    UITabBarController *tabs = vc.tabBarController;
+    UIWindow *window = table.window;
+
+    CGRect statusBarFrame = CGRectZero;
+    if (@available(iOS 13.0, *)) {
+        statusBarFrame = window.windowScene.statusBarManager.statusBarFrame;
+    }
+
+    // contentTop is what the eye actually sees: the screen-space Y the first
+    // row starts at, in the table's own coordinates.
+    CGFloat contentTop = -table.contentOffset.y;
+
+    NSString *body = [NSString stringWithFormat:
+        @"off=%.1f inset=%@ adj=%@ tblSafe=%@ frame=%@ contentSize=%.0fw/%.0fh "
+        @"vcSafe=%@ addl=%@ winSafe=%@ status=%@ nav=%@ navHidden=%d tab=%@ anim(%@)",
+        table.contentOffset.y,
+        ApolloSLDInsets(table.contentInset),
+        ApolloSLDInsets(table.adjustedContentInset),
+        ApolloSLDInsets(table.safeAreaInsets),
+        ApolloSLDRect(table.frame),
+        table.contentSize.width, table.contentSize.height,
+        ApolloSLDInsets(vc.view.safeAreaInsets),
+        ApolloSLDInsets(vc.additionalSafeAreaInsets),
+        ApolloSLDInsets(window.safeAreaInsets),
+        ApolloSLDRect(statusBarFrame),
+        ApolloSLDRect(nav.navigationBar.frame),
+        nav.navigationBarHidden,
+        ApolloSLDRect(tabs.tabBar.frame),
+        ApolloSLDAnimationContext()];
+
+    if (!force && [body isEqualToString:sLastSnapshot]) return;
+    sLastSnapshot = body;
+
+    if (sFirstContentTop == CGFLOAT_MAX) sFirstContentTop = contentTop;
+    sLastContentTop = contentTop;
+
+    ApolloSLDLog(@"+%.0fms %@ %@", ApolloSLDElapsedMs(), reason, body);
+}
+
+// Abbreviated caller trace for the geometry setters: enough to tell Apollo's
+// own code, UIKit's layout machinery and the tweak apart without pulling in a
+// full symbolicated backtrace on every call.
+static NSString *ApolloSLDCallers(void) {
+    NSArray<NSString *> *symbols = [NSThread callStackSymbols];
+    NSMutableArray<NSString *> *kept = [NSMutableArray array];
+    // callStackSymbols format: "<n><pad><image><pad><addr> <symbol> + <offset>".
+    // The symbol itself contains spaces (ObjC selectors, C++ names), so take
+    // everything between the address and the trailing " + <offset>".
+    for (NSUInteger i = 2; i < symbols.count && kept.count < 7; i++) {
+        NSMutableArray<NSString *> *fields = [NSMutableArray array];
+        for (NSString *field in [symbols[i] componentsSeparatedByString:@" "]) {
+            if (field.length) [fields addObject:field];
+        }
+        if (fields.count < 5) continue;
+        NSString *image = fields[1];
+        NSRange symbolRange = NSMakeRange(3, fields.count - 5);   // drop idx/image/addr and "+ off"
+        NSString *name = [[fields subarrayWithRange:symbolRange] componentsJoinedByString:@" "];
+        NSString *offset = fields.lastObject;
+        // Logos thunk names are long and add nothing beyond "the tweak"; fold
+        // them so a trace stays readable.
+        if ([name hasPrefix:@"_ZL"] || [name containsString:@"_logos_method$"]) name = @"(tweak hook)";
+        if (image.length > 22) image = [image substringToIndex:22];
+        [kept addObject:[NSString stringWithFormat:@"%@!%@+%@", image, name, offset]];
+    }
+    return [kept componentsJoinedByString:@" < "];
+}
+
+static void ApolloSLDOpenWindow(UITableView *table, NSString *reason) {
+    if (!table) return;
+    sTrackedTable = table;
+    sWindowOpen = YES;
+    sWindowOpenedAt = CACurrentMediaTime();
+    sLastSnapshot = nil;
+    sFirstContentTop = CGFLOAT_MAX;
+    sLastSampledOffset = CGFLOAT_MAX;
+    sSuppressUntil = CACurrentMediaTime() + kSuppressSeconds;
+    sSuppressedPasses = 0;
+    ApolloSLDLog(@"window open (%@) table=%p uptime=%.0fms",
+                 reason, table, NSProcessInfo.processInfo.systemUptime * 1000.0);
+    ApolloSLDSnapshot(table, @"open", YES);
+
+    // Sampled sweep across the settle. Each tick logs only when something moved
+    // or a cell is mid-glide, so a healthy launch stays silent here.
+    static const int kSampleMs[] = { 80, 160, 250, 350, 500, 700, 1000, 1400, 2000, 2800 };
+    for (size_t i = 0; i < sizeof(kSampleMs) / sizeof(kSampleMs[0]); i++) {
+        int delay = kSampleMs[i];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)delay * NSEC_PER_MSEC),
+                       dispatch_get_main_queue(), ^{
+            if (!sWindowOpen || table != sTrackedTable) return;
+            NSUInteger cells = 0, headers = 0;
+            NSString *firstHeaderFrame = @"none";
+            ApolloSLDCountLiveAnimations(table, &cells, &headers, &firstHeaderFrame);
+            CGFloat offset = table.contentOffset.y;
+            BOOL moved = (sLastSampledOffset == CGFLOAT_MAX) || fabs(offset - sLastSampledOffset) > 0.5;
+            sLastSampledOffset = offset;
+            if (!moved && cells == 0 && headers == 0) return;
+            ApolloSLDLog(@"+%.0fms sample off=%.1f glidingCells=%lu glidingHeaders=%lu hdr0=%@",
+                         ApolloSLDElapsedMs(), offset,
+                         (unsigned long)cells, (unsigned long)headers, firstHeaderFrame);
+        });
+    }
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWindowSeconds * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (!sWindowOpen) return;
+        sWindowOpen = NO;
+        CGFloat delta = (sFirstContentTop == CGFLOAT_MAX) ? 0.0 : (sLastContentTop - sFirstContentTop);
+        // Positive settle == the content ended HIGHER than it started, which is
+        // the direction measured off the reporter's recording. Written straight
+        // through so the summary survives even when the line cap was reached.
+        ApolloSLDWrite([NSString stringWithFormat:
+            @"window closed: contentTop %.1f -> %.1f (settle %.1fpt) lines=%lu",
+            sFirstContentTop, sLastContentTop, -delta, (unsigned long)sLinesWritten]);
+    });
+}
+
+// The list controller's table lives in ApolloTableViewController's `tableView`
+// ivar (a Swift stored property with no ObjC getter).
+static UITableView *ApolloSLDTableForController(id controller) {
+    if (!controller) return nil;
+    Class cls = object_getClass(controller);
+    while (cls) {
+        Ivar ivar = class_getInstanceVariable(cls, "tableView");
+        if (ivar) {
+            id value = object_getIvar(controller, ivar);
+            return [value isKindOfClass:[UITableView class]] ? value : nil;
+        }
+        cls = class_getSuperclass(cls);
+    }
+    return nil;
+}
+
+%group ApolloSubredditListLaunchSettle
+
+%hook _TtC6Apollo24RedditListViewController
+
+- (void)viewDidLoad {
+    %orig;
+    // Arm on the FIRST list controller of the process only: the launch case is
+    // what is being investigated, and a later push (Edit, a second tab) would
+    // otherwise re-open the window over ordinary use.
+    static BOOL sArmed = NO;
+    sListController = (UIViewController *)self;
+    if (sArmed) return;
+    sArmed = YES;
+    ApolloSLDOpenWindow(ApolloSLDTableForController(self), @"viewDidLoad");
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloSLDSnapshot(ApolloSLDTableForController(self), @"viewWillAppear", NO);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloSLDSnapshot(ApolloSLDTableForController(self), @"viewDidAppear", NO);
+}
+
+- (void)viewWillLayoutSubviews {
+    %orig;
+    ApolloSLDSnapshot(ApolloSLDTableForController(self), @"vcWillLayout", NO);
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloSLDSnapshot(ApolloSLDTableForController(self), @"vcDidLayout", NO);
+}
+
+%end
+
+// Global scroll-view hooks. Every one of them bails on a pointer compare when
+// the window is shut or the table is not the tracked one.
+%hook UITableView
+
+// THE FIX for #919.
+//
+// A layout pass that runs inside a UIView animation re-frames the visible cells
+// through an animatable -setFrame: while any header UIKit builds during the
+// same pass is framed inside +[UIView performWithoutAnimation:] (see the file
+// header). That asymmetry is the whole artifact: the rows glide, the section
+// bands do not, and for a quarter of a second a band sits on top of the row
+// above it.
+//
+// There is no first-launch layout of the subreddit list that is better for
+// being animated — the user has not interacted with anything yet, and the list
+// is simply arriving at its resting geometry. So when this table lays out
+// inside an inherited animation during its first moments, run the pass with
+// animations off: the cells then land exactly where the headers already do.
+//
+// The guard is the bug's own precondition, which makes this a no-op for anyone
+// not seeing it: a healthy launch lays the list out with
+// inheritedAnimationDuration == 0 (confirmed in the simulator), so %orig runs
+// untouched and nothing about the screen changes.
+- (void)layoutSubviews {
+    BOOL tracked = (self == sTrackedTable);
+    if (tracked && sSuppressUntil > 0 && [UIView inheritedAnimationDuration] > 0.0) {
+        if (CACurrentMediaTime() < sSuppressUntil) {
+            NSTimeInterval inherited = [UIView inheritedAnimationDuration];
+            CGFloat before = self.contentOffset.y;
+            [CATransaction begin];
+            [CATransaction setDisableActions:YES];
+            [UIView performWithoutAnimation:^{ %orig; }];
+            [CATransaction commit];
+            sSuppressedPasses++;
+            // One line per launch is enough to tell a fixed launch from an
+            // untouched one; further passes in the same window are silent.
+            if (sSuppressedPasses == 1) {
+                ApolloSLDLog(@"+%.0fms SUPPRESSED animated launch layout (inherited=%.2fs, offsetY %.1f -> %.1f)",
+                             ApolloSLDElapsedMs(), inherited, before, self.contentOffset.y);
+            }
+            ApolloSLDSnapshot(self, @"layout(suppressed)", NO);
+            return;
+        }
+        sSuppressUntil = 0;
+        if (sSuppressedPasses) {
+            ApolloSLDLog(@"+%.0fms suppression window closed after %lu pass(es)",
+                         ApolloSLDElapsedMs(), (unsigned long)sSuppressedPasses);
+        }
+    }
+
+    %orig;
+    if (!sWindowOpen || !tracked) return;
+    ApolloSLDSnapshot(self, @"layout", NO);
+}
+
+- (void)setContentOffset:(CGPoint)offset {
+    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    CGPoint before = self.contentOffset;
+    %orig;
+    if (fabs(before.y - offset.y) < 0.5) return;
+    ApolloSLDLog(@"+%.0fms setContentOffset y %.1f -> %.1f anim(%@) via %@",
+                 ApolloSLDElapsedMs(), before.y, offset.y, ApolloSLDAnimationContext(), ApolloSLDCallers());
+    ApolloSLDSnapshot(self, @"afterSetOffset", NO);
+    ApolloSLDSampleAnimationFingerprint(self, @"offset");
+}
+
+- (void)setContentInset:(UIEdgeInsets)inset {
+    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    UIEdgeInsets before = self.contentInset;
+    %orig;
+    if (UIEdgeInsetsEqualToEdgeInsets(before, inset)) return;
+    ApolloSLDLog(@"+%.0fms setContentInset %@ -> %@ anim(%@) via %@",
+                 ApolloSLDElapsedMs(), ApolloSLDInsets(before), ApolloSLDInsets(inset),
+                 ApolloSLDAnimationContext(), ApolloSLDCallers());
+    ApolloSLDSnapshot(self, @"afterSetInset", NO);
+    ApolloSLDSampleAnimationFingerprint(self, @"inset");
+}
+
+// Apollo parks several of its tables through -setBounds: rather than
+// -setContentOffset:, so the offset move can bypass the setter above.
+- (void)setBounds:(CGRect)bounds {
+    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    CGRect before = self.bounds;
+    %orig;
+    if (fabs(before.origin.y - bounds.origin.y) < 0.5) return;
+    ApolloSLDLog(@"+%.0fms setBounds originY %.1f -> %.1f anim(%@) via %@",
+                 ApolloSLDElapsedMs(), before.origin.y, bounds.origin.y,
+                 ApolloSLDAnimationContext(), ApolloSLDCallers());
+    ApolloSLDSampleAnimationFingerprint(self, @"bounds");
+}
+
+- (void)safeAreaInsetsDidChange {
+    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    UIEdgeInsets before = self.safeAreaInsets;
+    %orig;
+    ApolloSLDLog(@"+%.0fms safeAreaInsetsDidChange %@ -> %@ anim(%@) via %@",
+                 ApolloSLDElapsedMs(), ApolloSLDInsets(before), ApolloSLDInsets(self.safeAreaInsets),
+                 ApolloSLDAnimationContext(), ApolloSLDCallers());
+}
+
+- (void)reloadData {
+    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    CGFloat before = self.contentSize.height;
+    %orig;
+    ApolloSLDLog(@"+%.0fms reloadData contentHeight %.0f -> %.0f anim(%@) via %@",
+                 ApolloSLDElapsedMs(), before, self.contentSize.height,
+                 ApolloSLDAnimationContext(), ApolloSLDCallers());
+}
+
+%end
+
+%end   // group
+
+// Re-arm from the simulator debug bridge ("listdiag") so the window can be
+// opened on demand while iterating, instead of only on a cold launch.
+void ApolloSubredditListDiagRearm(void) {
+    UITableView *table = ApolloSLDTableForController(sListController);
+    if (!table) {
+        ApolloLog(@"[SubListDiag] rearm: no RedditListViewController seen yet");
+        return;
+    }
+    sLinesWritten = 0;
+    ApolloSLDOpenWindow(table, @"rearm");
+}
+
+%ctor {
+    if (objc_getClass("_TtC6Apollo24RedditListViewController")) {
+        %init(ApolloSubredditListLaunchSettle);
+        ApolloLog(@"[SubListDiag] launch geometry recorder armed (window=%.0fs cap=%lu lines)",
+                  kWindowSeconds, (unsigned long)kMaxLines);
+    }
+}

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -878,11 +878,29 @@ static void ApolloTagPresentConfirmAlertForOverlay(id cell, UIVisualEffectView *
 
 // MARK: - Live updates
 
+// Everything this feature can change lives on a post cell, and post cells are
+// ASDK nodes (LargePostCellNode / CompactPostCellNode — see the %ctor's %init)
+// that only ever appear in Apollo's ASTableView feeds and comment threads. So
+// reload those and leave every other table alone.
+//
+// This used to reload EVERY UITableView in every window, which reached tables
+// with nothing to re-blur — the subreddit list above all. On a large list that
+// is a full row-data rebuild of a ~10,000pt table during launch, and it throws
+// away the section header views; if the next layout pass happens to be an
+// animated one, the recreated headers then glide their labels into place from
+// the previous frame instead of just appearing (issue #919). Reloading a table
+// that cannot contain a post cell was never doing anything for this feature.
 static void ApolloTagRefreshAllVisibleCells(void) {
     dispatch_async(dispatch_get_main_queue(), ^{
+        Class postTableClass = objc_getClass("ASTableView");
         void (^__block walk)(UIView *) = nil;
         void (^localWalk)(UIView *) = ^(UIView *root) {
-            if ([root isKindOfClass:[UITableView class]]) {
+            BOOL hostsPostCells = postTableClass ? [root isKindOfClass:postTableClass]
+                                                 // ASTableView missing means Texture changed under us;
+                                                 // fall back to the old broad behaviour rather than
+                                                 // silently refreshing nothing.
+                                                 : [root isKindOfClass:[UITableView class]];
+            if (hostsPostCells) {
                 UITableView *tv = (UITableView *)root;
                 @try { [tv reloadData]; } @catch (__unused id e) {}
             }


### PR DESCRIPTION
Closes #919. **Confirmed fixed by @Psyclaire** ("Everything works as it should now!") — logs and evidence below.

Two rounds, both driven by frame-by-frame measurement of @Psyclaire's recordings plus the launch recorder this PR adds.

---

## Round 1 — the rows

On a cold launch that lands on the subreddit list, the rows slid up ~22-27pt over about a quarter of a second while the grey section bands (FAVORITES, the A-Z letters) already sat at their final Y. For that quarter second a band was drawn on top of the row above it and clipped it.

Measured off the first recording (1206x2622 @3x, 50fps):

| frame | content offset vs. final |
|---|---|
| 11 | +82px (27pt) |
| 15 | +64px |
| 19 | +26px |
| 24 | 0 |

Row heights and spacing never changed, the first row (Home) moved exactly as much as rows 40 sections down, and the nav/tab bars didn't move at all — a pure content translation.

**Why the bands didn't move with the rows**, from the decompiled UIKitCore 26.1 `UITableView`:

* `-[UITableView _updateVisibleCellsNow:]` re-frames every visible cell with a plain `setFrame:`, so those moves join whatever animation context the layout pass is running in.
* A header UIKit has to **build** during that same pass goes through `-[UITableView _sectionHeaderView:withFrame:forSection:floating:…]`, and that whole build-and-frame is wrapped in `+[UIView performWithoutAnimation:]`, so it lands at its final frame.

"Cells glide, freshly built bands snap" means the list's first real layout pass is running **inside a UIView animation**.

Nothing in the tweak writes `contentInset.top`, `contentOffset`, `additionalSafeAreaInsets`, `sectionHeaderTopPadding` or a `tableHeaderView` on this table — checked repo-wide — so the late arrival at resting geometry is Apollo/UIKit's. But there is no first-launch layout of this list that is better for being animated, so while the list is arriving, a layout pass running inside an inherited animation is re-run with animations off.

The guard is the bug's own precondition — this table, first 1.5s after its `viewDidLoad`, and only when `[UIView inheritedAnimationDuration] > 0`. A healthy launch lays this table out with an inherited duration of **0** (confirmed in the simulator), so it is a no-op for anyone who was never seeing the artifact.

**Result:** confirmed fixed. The reporter's second recording has the rows dead still from the first visible frame, and their log shows the guard firing:

```
+203ms SUPPRESSED animated launch layout (inherited=0.30s, offsetY -116.0 -> -116.0)
```

So the animation is real and it is **0.30s**.

## Round 2 — the labels

What was left, per the reporter: *"now is just the 'favorites' and alphabet headers"*. Measured, the label slides diagonally from ≈(6pt, 0pt) to ≈(17pt, 7pt) inside its band over ~0.38s.

The recorder caught the cause. 19ms before that animated pass:

```
+184ms reloadData contentHeight 9810 -> 9900 via ApolloReborn.dylib!ApolloNSFWBlurOverrideTitle+16540 …
```

Symbolicated against this PR's own dSYM artifact:

```
0x2fc608 -> ApolloTagRefreshAllVisibleCells() (ApolloTagFilters.xm:888)
```

That is ours. `ApolloTagRefreshAllVisibleCells` walked every window and called `reloadData` on **every** `UITableView` in the app, fired from `RDKClient.setCurrentUser:` → `ApolloTagRecomputeEffectiveNoProfanity` the first time the account identity resolves at launch (the recompute is change-gated, but `identityChanged` is always true on that first resolve). On the reporter's account that is a full row-data rebuild of a 153-row / ~9,900pt list during launch — and `reloadData` discards the section header views, so the animated pass is where they get rebuilt, and a rebuilt header lays its label out from the old frame.

**Two changes:**

1. **Scope the tag-filter refresh to `ASTableView`.** Everything that feature can change lives on a post cell, and post cells are ASDK nodes (`LargePostCellNode` / `CompactPostCellNode`, per that module's own `%init`) which only exist in Apollo's feed and comment tables. A plain `UITableView` can never contain one, so reloading the subreddit list, Settings, Filters and friends was never doing anything for it. Falls back to the old broad walk if `ASTableView` ever stops resolving.

2. **Give the header views the same suppression the table gets.** A header's own `-layoutSubviews` runs during the *parent's* subtree walk — after the table's `-layoutSubviews` returns, and therefore outside the wrapper round 1 applies to itself. That is exactly why the cells got fixed and the labels did not. Same guard, plus a one-pointer check that the header's `superview` is the tracked table (`UITableViewHeaderFooterView` and `_TtC6Apollo31RecreatedTableSectionHeaderView`).

## The recorder

Nobody here can reproduce this — not on the same iPhone 17 Pro / iOS 26.5 / Liquid Glass build, not in the simulator — so the module also records the launch geometry into the existing cross-launch list-layout diagnostics buffer that **Export Debug Logs** already prepends. Per launch:

* `contentOffset` / `contentInset` / `adjustedContentInset` / table + VC + window safe areas / `additionalSafeAreaInsets`
* the table's frame and content size, and the nav bar, tab bar and status bar frames
* every `setContentOffset:` / `setContentInset:` / `setBounds:` / `safeAreaInsetsDidChange` / `reloadData` on that table, with a symbolicated caller trace and the animation context (`inheritedAnimationDuration`, `areAnimationsEnabled`, CATransaction duration / `disableActions`)
* a sampled sweep counting cells vs. header bands mid-glide — `cells > 0, headers = 0` is the round-1 fingerprint
* `SUPPRESSED …` lines when either guard engages, now **with a caller trace** so the next log names whoever opens that 0.30s animation

Bounded to 80 lines and the first 4 seconds, change-gated, capped at 12 backtraces, and deliberately side-effect free — it walks the table's own subviews rather than asking the data source for `numberOfSections` / `headerViewForSection:`, because a recorder that drives a row-data rebuild would perturb the very launch layout it is measuring. Once the window shuts it clears its tracked-table pointer and suppression deadline, so the global hooks reduce to a single static `BOOL` test for the rest of the process.

Healthy launch, for reference:

```
[SubListDiag] window open (viewDidLoad) table=0x1369c8000
[SubListDiag] +0ms open off=0.0 … frame=0,0,0x0 anim(inh=0.00 on=1 ca=0.25 dis=0)
[SubListDiag] +1024ms setContentOffset y 0.0 -> -116.0 anim(inh=0.00 …) via UIKitCore!_UIScrollViewAdjustForOverlayInsetsChangeIfNecessary+240 < …
[SubListDiag] +1113ms sample off=-116.0 glidingCells=0 glidingHeaders=0 hdr0=0,718,402x25
[SubListDiag] window closed: contentTop -0.0 -> 116.0 (settle -116.0pt) suppressed=0/0hdr lines=17
```

`inh=0.00`, `glidingCells=0`, `suppressed=0/0hdr` is what a launch without the bug looks like.

**Result:** confirmed fixed. The reporter's third log shows the spurious reload gone — every `reloadData` on that table is now Apollo's own, at +2679ms and +3022ms, well clear of the animation:

```
+2679ms reloadData contentHeight 9810 -> 9900 anim(inh=0.00 …) via Apollo!Apollo+6535456 < …
```

(Before: `+184ms reloadData … via ApolloReborn.dylib!…ApolloTagRefreshAllVisibleCells`.) Across every launch on the final build the accounting reads `suppressed=1/0hdr` — the round-1 table guard fires once, and the round-2 header guard never fires at all, which is what you would expect once the header views stop being thrown away mid-launch.

## The 0.30s animation is UIKit's own

Worth recording, since both rounds work around it rather than removing it. With the caller trace added, the reporter's log gives:

```
+164ms SUPPRESSED animated launch layout (inherited=0.30s, offsetY -116.0 -> -116.0) via
  UIKitCore!…+295328 < UIKitCore!…+297708 < UIKitCore!…+290976
  < QuartzCore!…+2873508 < QuartzCore!…+2872308
  < UIKitCore!…+22688 < UIKitCore!…+1732052
```

Pure UIKitCore and QuartzCore — no Apollo frame, no tweak frame. It is UIKit's own launch/appearance animation being flushed from a CoreAnimation transaction commit, which is also why the reporter sees the iOS 26 tab-bar glass slider glide into place in the same beat. Nothing on our side opens it, so suppressing its effect on this one table during its first moments is the available fix.

## Effect on people who never had this

* **The tag-filter scoping is the only change that alters behaviour for everyone**, and it is a strict subset: `ASTableView` is a `UITableView` subclass, so the walk now reloads strictly fewer tables. Audited what got dropped — every Apollo screen that can host a post cell subclasses `ASTableViewController` and therefore has an `ASTableView` (`PostsViewController`, `CommentsViewController`, `ProfileViewController`, `InboxViewController`, `SavedPostsCommentsViewController`, `ModQueueViewController`, `ModmailInboxViewController`, `ModeratorLogsViewController`, plus `LitePostsViewController` / `PostsSearchResultsViewController` / `UserCommentsViewController` / `AllSubredditCommentsViewController`, which own a `tableNode` directly). Every screen on a plain `UITableView` (`SearchViewController`, `RedditListViewController`, `MultiredditViewController`, the Settings family, the subreddit/user pickers) lists subreddits, users or settings rows — none of them can contain a `LargePostCellNode` or `CompactPostCellNode`, which are the only things this feature touches. Post *search results* are `PostsSearchResultsViewController`, which is ASDK. So nothing that could previously re-blur stops doing so.
* **Both suppressions are inert unless the bug's precondition holds**: the subreddit list's own table, within 1.5s of its `viewDidLoad`, and only when `[UIView inheritedAnimationDuration] > 0`. And even when the guard does fire, suppressing an animation only changes what you see if the geometry actually moved — the reporter's own line is `offsetY -116.0 -> -116.0`, i.e. on that pass it changed nothing. In the simulator the guard never fires at all (`inh=0.00`, `suppressed=0/0hdr`).
* **Everything goes cold after the window.** `sTrackedTable` and the suppression deadline are cleared when the recorder's window shuts, so the global `UITableView` hooks reduce to a single static `BOOL` test for the rest of the process, and the list controller's layout hooks stop resolving ivars. Verified: zero further `[SubListDiag]` lines while scrolling the list afterwards.
* **What everyone does pay** is the recorder: ~18 lines and at most 12 symbolicated backtraces per launch, into the same bounded 256KB cross-launch buffer `ListLayoutGuard` already writes to. `backtrace_symbols()` does a `dladdr` per frame, so that is a few milliseconds of main-thread work during launch. Cheap, but not free — happy to drop the traces now that they have done their job if that is preferred.

## Testing

* iOS 26.5 simulator, Liquid Glass, subreddit list with FAVORITES + A-Z sections: list renders identically, neither guard fires (`suppressed=0/0hdr`), recorder writes ~17 lines and goes quiet; zero further lines while scrolling afterwards.
* Same with Modern Subreddit Dividers off (the reporter's configuration) and on.
* Tag filters still capture and recompute after the scoping change (`[TagFilters] Captured … / Effective …` unchanged); `ASTableView` is confirmed to be the runtime class name of Apollo's feed tables.
* Device build clean at the iOS 14 floor with `-Werror`.
* The module is not Liquid Glass gated and touches no iOS 26-only API beyond an `@available`-guarded `statusBarManager` read.
* **Never reproduced locally** — not on the same iPhone 17 Pro / iOS 26.5 / Liquid Glass build, not in the simulator. Both rounds were verified on the reporter's device instead: round 1 by their second recording (rows measured stable from the first visible frame), round 2 by their third log and their own confirmation that everything now works.
* Also adds a `listdiag` command to the simulator debug bridge to re-arm the recorder without a cold launch.


