### PR TITLE
Gallery View: stream GIFs instead of holding every frame in RAM

### DIFF
--- a/src/ApolloGalleryImageLoader.h
+++ b/src/ApolloGalleryImageLoader.h
@@ -6,7 +6,7 @@
 //
 // Three things the grid and viewer both need and shouldn't each reimplement:
 //   • a bounded in-memory image cache, so scrolling back up doesn't re-download;
-//   • animated-GIF decoding (UIImage's plain +imageWithData: shows frame 0 only,
+//   • animated-GIF playback (UIImage's plain +imageWithData: shows frame 0 only,
 //     which is why a GIF looks like a still everywhere it isn't handled);
 //   • the original bytes, so Save/Share exports the real file — a GIF stays a
 //     GIF instead of being flattened by a re-encode.
@@ -25,13 +25,36 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) double progressFraction;
 @end
 
+// One decoded picture. A still carries only `image`; an animated GIF also
+// carries the FLAnimatedImage that streams its frames.
+//
+// GIFs are NOT decoded into a UIImage frame array. +[UIImage
+// animatedImageWithImages:duration:] holds every frame as a full-size bitmap
+// and UIImageView materialises the lot on the first loop, so cost is
+// frames x width x height x 4 with no ceiling — a 2.2 MB, 400-frame 1280x720
+// GIF measured at +1414 MB resident, which is what jetsam killed in issue
+// #1000. FLAnimatedImage (already bundled inside Apollo, so no new dependency)
+// keeps the compressed data plus a small self-sizing frame window and decodes
+// ahead on its own queue: the same GIF measured at +17 MB, full resolution,
+// no frames dropped.
+@interface ApolloGalleryDecodedImage : NSObject
+// Always present: the still frame. For an animation this is the poster frame,
+// which is what sizes the zoom geometry and backs a PNG re-encode for Save.
+@property (nonatomic, strong, readonly) UIImage *image;
+// The FLAnimatedImage to hand to an FLAnimatedImageView, or nil for a still.
+// Typed `id` because the tweak resolves the class at runtime out of Apollo's
+// own bundled framework rather than linking against it.
+@property (nonatomic, strong, readonly, nullable) id animatedImage;
+@end
+
 @interface ApolloGalleryImageLoader : NSObject
 
 + (instancetype)sharedLoader;
 
-// Cached image for `url`, or nil. Synchronous and cheap — call it before
-// starting a load so a warm tile renders in the same runloop turn (no flash).
-- (nullable UIImage *)cachedImageForURL:(NSURL *)url;
+// Cached full-tier decode for `url`, or nil. Synchronous and cheap — call it
+// before starting a load so a warm page renders in the same runloop turn (no
+// flash).
+- (nullable ApolloGalleryDecodedImage *)cachedImageForURL:(NSURL *)url;
 // Cached THUMBNAIL-tier decode for `url` (see -loadThumbnailAtURL:…), or nil.
 - (nullable UIImage *)cachedThumbnailForURL:(NSURL *)url;
 
@@ -42,10 +65,11 @@ NS_ASSUME_NONNULL_BEGIN
 // Downloads (or returns from cache) and decodes at full size. `completion`
 // always runs on the main thread, and is skipped entirely if the request was
 // cancelled. `progress` is optional and also runs on the main thread.
-// Animated GIFs come back as multi-frame UIImages ready for UIImageView.
+// Animated GIFs come back with `decoded.animatedImage` set (see
+// ApolloGalleryDecodedImage).
 - (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
                                      progress:(nullable void (^)(double fraction))progress
-                                   completion:(void (^)(UIImage *_Nullable image, NSData *_Nullable data))completion;
+                                   completion:(void (^)(ApolloGalleryDecodedImage *_Nullable decoded, NSData *_Nullable data))completion;
 
 // The grid tier: a single downsampled still frame, cached separately from the
 // full decode of the same URL. Cells use this so a reused tile never pays for
@@ -61,6 +85,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Drops decoded images but keeps nothing pinned; called on memory pressure.
 - (void)purge;
+
+#if APOLLO_SIM_BUILD
+// Sim-only probe hook for the `gifmem` debug-tap command: runs the full-tier
+// decode on raw bytes with no network or cache in the way, so the resident cost
+// of one picture can be measured directly. Never compiled into device builds.
++ (nullable ApolloGalleryDecodedImage *)apollo_debugDecodeData:(NSData *)data;
+#endif
 
 @end
 

--- a/src/ApolloGalleryImageLoader.m
+++ b/src/ApolloGalleryImageLoader.m
@@ -5,6 +5,7 @@
 #import "ApolloState.h"
 
 #import <ImageIO/ImageIO.h>
+#import <objc/message.h>
 
 // Decoded-image cache budget, in bytes of backing store. Grid thumbnails are
 // small; a handful of fullscreen originals is what actually fills this.
@@ -22,7 +23,7 @@ static NSTimeInterval const kApolloGalleryImageTimeout = 30.0;
 @interface ApolloGalleryImageRequest ()
 @property (nonatomic, weak) ApolloGalleryImageLoader *loader;
 @property (nonatomic, copy) NSString *key;
-@property (nonatomic, copy, nullable) void (^completion)(UIImage *_Nullable, NSData *_Nullable);
+@property (nonatomic, copy, nullable) void (^completion)(ApolloGalleryDecodedImage *_Nullable, NSData *_Nullable);
 @property (nonatomic, weak, nullable) ApolloGalleryPendingDownload *download;
 @property (nonatomic, getter=isCancelled) BOOL cancelled;
 @end
@@ -76,74 +77,140 @@ static UIImage *ApolloGalleryDecodeStillThumbnail(NSData *data, CGFloat maxPixel
     return image;
 }
 
-#pragma mark - Animated GIF decoding
+#pragma mark - Animated GIF playback
 
-// UIImage's +imageWithData: keeps only the first frame of a GIF. Walk the
-// source with ImageIO instead and build the multi-frame UIImage that
-// UIImageView animates on its own. Returns nil for single-frame data so the
-// caller falls through to the cheap decode.
-static UIImage *ApolloGalleryDecodeAnimatedImage(NSData *data) {
-    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
-    if (!source) return nil;
-
-    size_t frameCount = CGImageSourceGetCount(source);
-    if (frameCount <= 1) {
-        CFRelease(source);
-        return nil;
-    }
-
-    NSMutableArray<UIImage *> *frames = [NSMutableArray arrayWithCapacity:frameCount];
-    NSTimeInterval totalDuration = 0.0;
-
-    for (size_t i = 0; i < frameCount; i++) {
-        CGImageRef cgImage = CGImageSourceCreateImageAtIndex(source, i, NULL);
-        if (!cgImage) continue;
-
-        NSTimeInterval frameDuration = 0.1; // GIF default when unspecified
-        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, i, NULL);
-        if (properties) {
-            CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
-            if (gif) {
-                // Unclamped is the authored delay; DelayTime is the value
-                // browsers clamp. Prefer unclamped, fall back to clamped.
-                NSNumber *unclamped = (__bridge NSNumber *)CFDictionaryGetValue(gif, kCGImagePropertyGIFUnclampedDelayTime);
-                NSNumber *clamped = (__bridge NSNumber *)CFDictionaryGetValue(gif, kCGImagePropertyGIFDelayTime);
-                NSNumber *value = ([unclamped isKindOfClass:[NSNumber class]] && unclamped.doubleValue > 0.0)
-                    ? unclamped
-                    : ([clamped isKindOfClass:[NSNumber class]] ? clamped : nil);
-                if (value.doubleValue > 0.0) frameDuration = value.doubleValue;
-            }
-            CFRelease(properties);
-        }
-        // Matches what browsers do with pathologically short frame delays.
-        if (frameDuration < 0.011) frameDuration = 0.1;
-
-        totalDuration += frameDuration;
-        [frames addObject:[UIImage imageWithCGImage:cgImage]];
-        CGImageRelease(cgImage);
-    }
-    CFRelease(source);
-
-    if (frames.count == 0) return nil;
-    if (totalDuration <= 0.0) totalDuration = frames.count * 0.1;
-    return [UIImage animatedImageWithImages:frames duration:totalDuration];
+// Apollo already embeds FLAnimatedImage (Frameworks/FLAnimatedImage.framework),
+// so the streaming decoder is in the process at launch and the tweak just has
+// to find it. Resolved once and cached — NSClassFromString on every GIF would
+// be needless work, and a nil result is a permanent condition, not a transient
+// one.
+static Class ApolloGalleryFLAnimatedImageClass(void) {
+    static Class flClass;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        flClass = NSClassFromString(@"FLAnimatedImage");
+        if (!flClass) ApolloLog(@"[Gallery] FLAnimatedImage unavailable — GIFs will show as stills");
+    });
+    return flClass;
 }
 
-// Rough backing-store cost so NSCache's byte budget means something.
-static NSUInteger ApolloGalleryImageCost(UIImage *image) {
-    if (!image) return 0;
-    NSUInteger frames = MAX((NSUInteger)1, (NSUInteger)image.images.count);
-    CGImageRef cgImage = image.CGImage ?: image.images.firstObject.CGImage;
-    if (!cgImage) {
-        return (NSUInteger)(image.size.width * image.size.height * 4.0) * frames;
+// YES when `data` holds more than one frame, i.e. it is worth handing to
+// FLAnimatedImage at all. Reads the container index only; decodes nothing.
+// A multi-frame container FLAnimatedImage doesn't handle (APNG, animated WebP)
+// still comes back nil from the build below and lands on the still path — its
+// first frame, which is what those formats showed before this file existed.
+static BOOL ApolloGalleryDataIsMultiFrame(NSData *data) {
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (!source) return NO;
+    size_t frameCount = CGImageSourceGetCount(source);
+    CFRelease(source);
+    return frameCount > 1;
+}
+
+// Builds the streaming animation. nil for single-frame data (and if the
+// framework ever goes missing), so the caller falls through to a still decode.
+static id ApolloGalleryBuildAnimatedImage(NSData *data) {
+    Class flClass = ApolloGalleryFLAnimatedImageClass();
+    if (!flClass || !ApolloGalleryDataIsMultiFrame(data)) return nil;
+    id animated = ((id (*)(id, SEL, id))objc_msgSend)(flClass, @selector(animatedImageWithGIFData:), data);
+    return animated;
+}
+
+#pragma mark - Oversized stills
+
+// A still is downsampled past this many pixels. 24 MP is a full-frame camera
+// original — far beyond anything a phone screen resolves even zoomed to 5x —
+// and holds the backing store to ~96 MB, so one absurd direct link from a
+// multireddit can't do to a still what #1000's GIFs did to animations.
+static NSUInteger const kApolloGalleryStillMaxPixels = 24u * 1000u * 1000u;
+
+// Pixel dimensions from the container header, without decoding. Zero when the
+// format doesn't declare them.
+static CGSize ApolloGalleryImageDimensions(CGImageSourceRef source) {
+    CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, 0, NULL);
+    if (!properties) return CGSizeZero;
+    NSNumber *width = (__bridge NSNumber *)CFDictionaryGetValue(properties, kCGImagePropertyPixelWidth);
+    NSNumber *height = (__bridge NSNumber *)CFDictionaryGetValue(properties, kCGImagePropertyPixelHeight);
+    CGSize size = CGSizeMake(width.doubleValue, height.doubleValue);
+    CFRelease(properties);
+    return size;
+}
+
+// Full-tier still decode, downsampled only when the source is preposterously
+// large. Ordinary pictures take the plain path and keep every pixel.
+static UIImage *ApolloGalleryDecodeStill(NSData *data) {
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (!source) return [UIImage imageWithData:data];
+    CGSize size = ApolloGalleryImageDimensions(source);
+    CFRelease(source);
+
+    CGFloat longSide = MAX(size.width, size.height);
+    CGFloat shortSide = MIN(size.width, size.height);
+    // shortSide == 0 means the format didn't declare dimensions; there is
+    // nothing to base a budget on, so decode it as-is.
+    if (shortSide < 1.0 || (double)size.width * (double)size.height <= (double)kApolloGalleryStillMaxPixels) {
+        return [UIImage imageWithData:data];
     }
-    return CGImageGetHeight(cgImage) * CGImageGetBytesPerRow(cgImage) * frames;
+
+    // Preserve the aspect ratio while landing on the pixel budget: with
+    // r = long/short, long' = sqrt(budget * r) gives long' * short' = budget.
+    CGFloat maxPixel = sqrt((double)kApolloGalleryStillMaxPixels * (longSide / shortSide));
+    ApolloLog(@"[Gallery] downsampling %.0fx%.0f still to %.0fpx", size.width, size.height, maxPixel);
+    return ApolloGalleryDecodeStillThumbnail(data, maxPixel) ?: [UIImage imageWithData:data];
+}
+
+#pragma mark - Decoded product
+
+@interface ApolloGalleryDecodedImage ()
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong, nullable) id animatedImage;
+// What the decode occupies, for the cache's byte budget.
+@property (nonatomic) NSUInteger cost;
+@end
+
+@implementation ApolloGalleryDecodedImage
+@end
+
+// Rough backing-store cost so NSCache's byte budget means something.
+static NSUInteger ApolloGalleryStillCost(UIImage *image) {
+    if (!image) return 0;
+    CGImageRef cgImage = image.CGImage;
+    if (!cgImage) return (NSUInteger)(image.size.width * image.size.height * 4.0);
+    return CGImageGetHeight(cgImage) * CGImageGetBytesPerRow(cgImage);
+}
+
+// An FLAnimatedImage holds the compressed bytes plus a handful of decoded
+// frames it sizes itself (2 for the 1280x720 GIF from #1000). The window
+// moves as playback advances, so this is an estimate for the cache's budget
+// rather than a figure to read back out of the object.
+static NSUInteger const kApolloGalleryAnimationCachedFrameEstimate = 3;
+
+static ApolloGalleryDecodedImage *ApolloGalleryMakeDecodedImage(UIImage *image, id animatedImage, NSUInteger dataLength) {
+    if (!image) return nil;
+    ApolloGalleryDecodedImage *decoded = [[ApolloGalleryDecodedImage alloc] init];
+    decoded.image = image;
+    decoded.animatedImage = animatedImage;
+    decoded.cost = animatedImage
+        ? dataLength + ApolloGalleryStillCost(image) * kApolloGalleryAnimationCachedFrameEstimate
+        : ApolloGalleryStillCost(image);
+    return decoded;
+}
+
+// The full tier: a GIF becomes a streaming animation carrying its own poster
+// frame, anything else a still. Runs off the main thread.
+static ApolloGalleryDecodedImage *ApolloGalleryDecodeFullTier(NSData *data) {
+    id animated = ApolloGalleryBuildAnimatedImage(data);
+    UIImage *poster = animated ? [animated valueForKey:@"posterImage"] : nil;
+    // A poster-less FLAnimatedImage would leave the page blank, so treat it as
+    // a failed build and fall back to the still decode.
+    return poster ? ApolloGalleryMakeDecodedImage(poster, animated, data.length)
+                  : ApolloGalleryMakeDecodedImage(ApolloGalleryDecodeStill(data), nil, data.length);
 }
 
 #pragma mark - Loader
 
 @interface ApolloGalleryImageLoader ()
-@property (nonatomic, strong) NSCache<NSString *, UIImage *> *imageCache;
+@property (nonatomic, strong) NSCache<NSString *, ApolloGalleryDecodedImage *> *imageCache;
 @property (nonatomic, strong) NSCache<NSString *, NSData *> *dataCache;
 @property (nonatomic, strong) NSURLSession *session;
 // key -> the single in-flight download for that URL. Main-thread only, so no
@@ -220,7 +287,13 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
     [self.dataCache removeAllObjects];
 }
 
-- (UIImage *)cachedImageForURL:(NSURL *)url {
+#if APOLLO_SIM_BUILD
++ (ApolloGalleryDecodedImage *)apollo_debugDecodeData:(NSData *)data {
+    return ApolloGalleryDecodeFullTier(data);
+}
+#endif
+
+- (ApolloGalleryDecodedImage *)cachedImageForURL:(NSURL *)url {
     NSString *key = url.absoluteString;
     return key.length > 0 ? [self.imageCache objectForKey:key] : nil;
 }
@@ -232,13 +305,13 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
 
 - (UIImage *)cachedThumbnailForURL:(NSURL *)url {
     NSString *key = ApolloGalleryThumbnailKey(url);
-    return key.length > 0 ? [self.imageCache objectForKey:key] : nil;
+    return key.length > 0 ? [self.imageCache objectForKey:key].image : nil;
 }
 
 - (ApolloGalleryImageRequest *)prefetchImageAtURL:(NSURL *)url {
     if (!url || [self cachedImageForURL:url]) return nil;
-    return [self loadImageAtURL:url progress:nil completion:^(UIImage *image, NSData *data) {
-        (void)image;
+    return [self loadImageAtURL:url progress:nil completion:^(ApolloGalleryDecodedImage *decoded, NSData *data) {
+        (void)decoded;
         (void)data;
     }];
 }
@@ -255,9 +328,9 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
     return [self apollo_loadURL:url
                    thumbnailMax:kApolloGalleryThumbnailDecodeMaxPixel
                        progress:nil
-                     completion:^(UIImage *image, NSData *data) {
+                     completion:^(ApolloGalleryDecodedImage *decoded, NSData *data) {
         (void)data;
-        completion(image);
+        completion(decoded.image);
     }];
 }
 
@@ -278,7 +351,7 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
 
 - (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
                                      progress:(void (^)(double fraction))progress
-                                   completion:(void (^)(UIImage *image, NSData *data))completion {
+                                   completion:(void (^)(ApolloGalleryDecodedImage *decoded, NSData *data))completion {
     return [self apollo_loadURL:url thumbnailMax:0.0 progress:progress completion:completion];
 }
 
@@ -289,7 +362,7 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
 - (ApolloGalleryImageRequest *)apollo_loadURL:(NSURL *)url
                                  thumbnailMax:(CGFloat)thumbnailMax
                                      progress:(void (^)(double fraction))progress
-                                   completion:(void (^)(UIImage *image, NSData *data))completion {
+                                   completion:(void (^)(ApolloGalleryDecodedImage *decoded, NSData *data))completion {
     NSAssert(NSThread.isMainThread, @"ApolloGalleryImageLoader must be driven from the main thread");
 
     ApolloGalleryImageRequest *request = [[ApolloGalleryImageRequest alloc] init];
@@ -305,7 +378,7 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
     }
     request.key = key;
 
-    UIImage *cached = [self.imageCache objectForKey:key];
+    ApolloGalleryDecodedImage *cached = [self.imageCache objectForKey:key];
     if (cached) {
         NSData *cachedData = [self.dataCache objectForKey:key];
         // Async even on a cache hit: callers set up their view state after this
@@ -336,25 +409,27 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
     __weak typeof(self) weakSelf = self;
     download.task = [self.session dataTaskWithRequest:urlRequest
                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        UIImage *image = nil;
+        ApolloGalleryDecodedImage *decoded = nil;
         if (!error && data.length > 0) {
             // Decoding happens here, off the main thread, so a big decode never
-            // stalls a scroll. The thumbnail tier decodes ONE downsampled frame;
-            // the full tier keeps animations intact.
-            image = thumbnailMax > 0.0
-                ? ApolloGalleryDecodeStillThumbnail(data, thumbnailMax)
-                : (ApolloGalleryDecodeAnimatedImage(data) ?: [UIImage imageWithData:data]);
+            // stalls a scroll. The thumbnail tier decodes ONE downsampled frame.
+            // The full tier hands a GIF to FLAnimatedImage, which parses the
+            // frame table and poster now and decodes the rest on demand during
+            // playback; a still decodes normally.
+            decoded = thumbnailMax > 0.0
+                ? ApolloGalleryMakeDecodedImage(ApolloGalleryDecodeStillThumbnail(data, thumbnailMax), nil, 0)
+                : ApolloGalleryDecodeFullTier(data);
         }
         BOOL wasCancelled = [error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled;
-        if (!image && error && !wasCancelled) {
+        if (!decoded && error && !wasCancelled) {
             ApolloLog(@"[Gallery] image load failed (%@): %@", url.host ?: @"?", error.localizedDescription);
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{
             typeof(self) strongSelf = weakSelf;
             if (!strongSelf) return;
-            if (image) {
-                [strongSelf.imageCache setObject:image forKey:key cost:ApolloGalleryImageCost(image)];
+            if (decoded) {
+                [strongSelf.imageCache setObject:decoded forKey:key cost:decoded.cost];
                 // Original bytes are only kept for full-tier loads — they exist
                 // for Save/Share, which never exports a thumbnail.
                 if (thumbnailMax <= 0.0 && data.length > 0) {
@@ -371,7 +446,7 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
                 [strongSelf.pending removeObjectForKey:key];
             }
             for (ApolloGalleryImageRequest *waiter in download.requests) {
-                if (!waiter.isCancelled && waiter.completion) waiter.completion(image, data);
+                if (!waiter.isCancelled && waiter.completion) waiter.completion(decoded, data);
             }
         });
     }];

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -25,6 +25,31 @@ static NSInteger const kApolloGalleryViewerLoadAheadSlack = 4;
 
 static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
 
+// Pages display through FLAnimatedImageView — a UIImageView subclass out of
+// Apollo's own bundled framework — so an animated GIF streams its frames
+// instead of being held in RAM all at once (see ApolloGalleryImageLoader.h and
+// issue #1000). Everything else about the page is unchanged: it is still a
+// UIImageView, so contentMode, `image`, and the zoom geometry all behave.
+// Resolved once; a nil result means GIFs fall back to their poster frame.
+static Class ApolloGalleryPageImageViewClass(void) {
+    static Class viewClass;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        viewClass = NSClassFromString(@"FLAnimatedImageView") ?: UIImageView.class;
+    });
+    return viewClass;
+}
+
+// FLAnimatedImageView goes on animating whatever it was last handed until the
+// animation is cleared explicitly — its -setImage: only clears it when the new
+// image is non-nil, so `imageView.image = nil` on a recycled cell would leave
+// the previous GIF playing. Every path that changes what a page shows goes
+// through here.
+static void ApolloGalleryPageSetAnimation(UIImageView *imageView, id animatedImage) {
+    if (![imageView respondsToSelector:@selector(setAnimatedImage:)]) return;
+    ((void (*)(id, SEL, id))objc_msgSend)(imageView, @selector(setAnimatedImage:), animatedImage);
+}
+
 // Mute state is sticky across pages and launches: someone browsing a video
 // subreddit in public wants it to stay off, and re-muting every clip by hand
 // would be miserable.
@@ -123,7 +148,7 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
         _mediaContainerView.backgroundColor = UIColor.blackColor;
         [_zoomView addSubview:_mediaContainerView];
 
-        _imageView = [[UIImageView alloc] initWithFrame:_mediaContainerView.bounds];
+        _imageView = [[ApolloGalleryPageImageViewClass() alloc] initWithFrame:_mediaContainerView.bounds];
         _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
         _imageView.backgroundColor = UIColor.blackColor;
@@ -150,13 +175,23 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     return self.player != nil;
 }
 
+// The one place a page's picture changes. `animation` non-nil streams a GIF;
+// nil clears any previous one before showing the still.
+- (void)apollo_displayImage:(UIImage *)image animation:(id)animation {
+    BOOL canAnimate = [self.imageView respondsToSelector:@selector(setAnimatedImage:)];
+    ApolloGalleryPageSetAnimation(self.imageView, animation);
+    // Without FLAnimatedImageView there is nothing to hand the animation to, so
+    // show its poster frame rather than leaving the page blank.
+    if (!animation || !canAnimate) self.imageView.image = image;
+}
+
 - (void)prepareForReuse {
     [super prepareForReuse];
     [self.request cancel];
     self.request = nil;
     self.imageURL = nil;
     [self teardownPlayer];
-    self.imageView.image = nil;
+    [self apollo_displayImage:nil animation:nil];
     self.fullImageLoaded = NO;
     self.zoomGeometrySize = CGSizeZero;
     self.zoomView.zoomScale = 1.0;
@@ -298,8 +333,8 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     // immediately so the page is never a black rectangle, then swap in the
     // full-size version when it lands.
     UIImage *placeholder = item.thumbnailURL ? [[ApolloGalleryImageLoader sharedLoader] cachedThumbnailForURL:item.thumbnailURL] : nil;
-    UIImage *full = url ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url] : nil;
-    self.imageView.image = full ?: placeholder;
+    ApolloGalleryDecodedImage *full = url ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url] : nil;
+    [self apollo_displayImage:(full.image ?: placeholder) animation:full.animatedImage];
     self.fullImageLoaded = (full != nil);
     // The fit rect depends on the image's proportions, so re-derive it whenever
     // the displayed image changes — including the placeholder→full swap, which
@@ -315,15 +350,15 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     __weak typeof(self) weakSelf = self;
     self.request = [[ApolloGalleryImageLoader sharedLoader] loadImageAtURL:url
                                                                   progress:nil
-                                                                completion:^(UIImage *image, NSData *data) {
+                                                                completion:^(ApolloGalleryDecodedImage *decoded, NSData *data) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf) return;
         // The cell may have been recycled onto a different picture while this
         // download was in flight.
         if (![strongSelf.imageURL isEqual:url]) return;
         [strongSelf.spinner stopAnimating];
-        if (image) {
-            strongSelf.imageView.image = image;
+        if (decoded) {
+            [strongSelf apollo_displayImage:decoded.image animation:decoded.animatedImage];
             strongSelf.fullImageLoaded = YES;
             [strongSelf apollo_resetZoomGeometry];
         }

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -19,11 +19,13 @@
 #import "ApolloCommentVoteInsights.h"
 #import "ApolloCommon.h"
 #import "ApolloLinkPreviewFetcher.h"
+#import "ApolloGalleryImageLoader.h"
 #import "ApolloWebTextDecoding.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "UIWindow+Apollo.h"
 #import <objc/message.h>
+#import <mach/mach.h>
 
 @interface UITouch (ApolloSimDebugTap)
 - (void)setPhase:(UITouchPhase)phase;
@@ -383,6 +385,88 @@ static void ApolloSimDebugDumpHeaderEffects(void) {
     }
 }
 
+#pragma mark - gifmem probe (issue #1000)
+
+static double ApolloSimDebugFootprintMB(void) {
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    if (task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&info, &count) != KERN_SUCCESS) return -1.0;
+    return info.phys_footprint / 1048576.0;
+}
+
+// Keeps the probe's view + image alive between samples.
+static UIImageView *sApolloSimDebugGIFView = nil;
+static UIImage *sApolloSimDebugGIFImage = nil;
+
+static void ApolloSimDebugSampleGIFMemory(NSInteger remaining, double baseline) {
+    ApolloLog(@"[gifmem] t+%lds footprint %.0f MB (+%.0f)",
+              (long)(6 - remaining), ApolloSimDebugFootprintMB(), ApolloSimDebugFootprintMB() - baseline);
+    if (remaining <= 0) {
+        [sApolloSimDebugGIFView removeFromSuperview];
+        sApolloSimDebugGIFView = nil;
+        sApolloSimDebugGIFImage = nil;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloLog(@"[gifmem] released: footprint %.0f MB (+%.0f)",
+                      ApolloSimDebugFootprintMB(), ApolloSimDebugFootprintMB() - baseline);
+        });
+        return;
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ApolloSimDebugSampleGIFMemory(remaining - 1, baseline);
+    });
+}
+
+static void ApolloSimDebugMeasureGIFMemory(NSString *source) {
+    double baseline = ApolloSimDebugFootprintMB();
+    ApolloLog(@"[gifmem] baseline footprint %.0f MB, source %@", baseline, source);
+
+    void (^measure)(NSData *) = ^(NSData *data) {
+        if (data.length == 0) { ApolloLog(@"[gifmem] no bytes"); return; }
+        ApolloLog(@"[gifmem] %.1f MB of source bytes", data.length / 1048576.0);
+
+        UIWindow *window = nil;
+        for (UIWindow *candidate in ApolloAllWindows()) if (candidate.isKeyWindow) { window = candidate; break; }
+        window = window ?: ApolloAllWindows().firstObject;
+        if (!window) { ApolloLog(@"[gifmem] no window"); return; }
+
+        NSDate *start = NSDate.date;
+        ApolloGalleryDecodedImage *decoded = [ApolloGalleryImageLoader apollo_debugDecodeData:data];
+        if (!decoded) { ApolloLog(@"[gifmem] decode returned nil"); return; }
+        ApolloLog(@"[gifmem] decoded %.0fx%.0f in %.2fs, animated=%@",
+                  decoded.image.size.width, decoded.image.size.height,
+                  -[start timeIntervalSinceNow], decoded.animatedImage ? @"YES" : @"NO");
+
+        // Mounted exactly the way a viewer page mounts it, so the sample covers
+        // the frame traffic UIKit generates during playback and not just the
+        // decode.
+        Class viewClass = NSClassFromString(@"FLAnimatedImageView") ?: UIImageView.class;
+        UIImageView *view = [[viewClass alloc] initWithFrame:window.bounds];
+        if (decoded.animatedImage && [view respondsToSelector:@selector(setAnimatedImage:)]) {
+            [view setValue:decoded.animatedImage forKey:@"animatedImage"];
+        } else {
+            view.image = decoded.image;
+        }
+        sApolloSimDebugGIFImage = decoded.image;
+        double afterDecode = ApolloSimDebugFootprintMB();
+        ApolloLog(@"[gifmem] after build: footprint %.0f MB (+%.0f)", afterDecode, afterDecode - baseline);
+
+        view.contentMode = UIViewContentModeScaleAspectFit;
+        [window addSubview:view];
+        sApolloSimDebugGIFView = view;
+        ApolloLog(@"[gifmem] installed on screen, sampling for 6s…");
+        ApolloSimDebugSampleGIFMemory(6, baseline);
+    };
+
+    if ([source hasPrefix:@"http"]) {
+        NSURL *url = [NSURL URLWithString:source];
+        [[NSURLSession.sharedSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *r, NSError *e) {
+            dispatch_async(dispatch_get_main_queue(), ^{ measure(data); });
+        }] resume];
+    } else {
+        measure([NSData dataWithContentsOfFile:source]);
+    }
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -438,6 +522,17 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
         // needs no Reddit account, so metadata extraction — charset handling
         // above all (issue #945) — can be verified against live foreign-language
         // pages on a signed-out simulator.
+        // "gifmem <path-or-url>" command: measure what the gallery viewer's
+        // animated-GIF path actually costs in resident memory. Decodes with the
+        // shipping loader entry point, hangs the result on a real on-screen
+        // UIImageView, and samples phys_footprint across the first animation
+        // loops — the point where issue #1000's jetsam happened.
+        if ([contents hasPrefix:@"gifmem "]) {
+            NSString *arg = [[contents substringFromIndex:7] stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugMeasureGIFMemory(arg);
+            return;
+        }
         if ([contents hasPrefix:@"linkpreview "]) {
             NSString *urlString = [[contents substringFromIndex:12] stringByTrimmingCharactersInSet:
                 NSCharacterSet.whitespaceAndNewlineCharacterSet];


### PR DESCRIPTION
Fixes #1000.

That report isn't a normal crash, it's a memory termination. No threads, no
binary images, just a footprint of 2745 MB against the iPhone 15's 3072 MB
limit, recorded while the reporter opened a GIF from Gallery View on a
multireddit.

The gallery loader was decoding animated GIFs by walking the whole
CGImageSource and building `+[UIImage animatedImageWithImages:duration:]` out
of every frame at full size. `CGImageSourceCreateImageAtIndex` returns a lazy
image so the decode itself looks free, but UIImageView animating that array
materialises all of them on the first loop, and nothing capped
`frames x width x height x 4`. The file size doesn't bound it either. A 2.2 MB,
400 frame 1280x720 GIF is 1406 MB of RGBA, and the viewer warms +/-1 page
ahead, so three ordinary GIFs in a row will kill the app on any device.

Measured in the sim through the loader's own path with the result mounted on a
real on-screen image view:

```
before   2.2 MB / 400 frames / 1280x720   ->  +1414 MB, flat
after    same file                        ->    +17 MB, flat
```

Apollo already ships FLAnimatedImage in Frameworks/, so the streaming decoder
is already in the process at launch and the tweak just has to find it. GIFs now
become an FLAnimatedImage (compressed bytes plus a small self-sizing frame
window, decoded ahead on its own queue) and viewer pages display through
FLAnimatedImageView, which is a UIImageView subclass, so contentMode, `image`
and the zoom geometry all keep working. Full resolution, no dropped frames, no
new dependency. If the framework ever isn't there both lookups come back nil
and a GIF shows its poster frame instead of animating.

Loads return an `ApolloGalleryDecodedImage` (still frame + optional animation)
now instead of a bare UIImage, which is what lets the cache charge an animation
its real weight rather than the frame array's. The grid didn't change, it was
already on the single-frame thumbnail tier, which is why only the fullscreen
viewer could hit this.

Two smaller things in the same seam:

- FLAnimatedImageView keeps animating whatever it was last handed until you
  clear it explicitly (its `-setImage:` only clears on a non-nil image), so a
  recycled page would have carried on playing the previous GIF. Everything that
  changes a page's picture goes through one `-apollo_displayImage:animation:`.
- The full-tier still decode downsamples past 24 MP now. That's a camera
  original, no Reddit preview gets near it and the guard never fired once
  across the whole test session, but it closes the same crash class for a
  direct link to a ridiculous image, which a multireddit can carry just as
  easily as a GIF.

Also adds a sim-only `gifmem <path-or-url>` debug-tap command that runs the
full-tier decode and samples phys_footprint with the result on screen, so the
numbers above are re-measurable instead of just being a claim in a PR.

### Testing

Sim, glass and non-glass, signed in with an API key. Opened Gallery View on
r/gifs (98 GIFs, all animated), opened one, paged through 13. Footprint sat
between 195 and 279 MB the whole time with the animations running, and
screenshot sampling confirms the frames are actually moving. Stills in the
gallery still render at full resolution and the 24 MP downsample guard stayed
quiet.

Device testing still to come, leaving it as a draft until then.