### PR TITLE
Trim PR test-IPA build runner time

### DIFF
--- a/.github/workflows/pr-build-ipa.yml
+++ b/.github/workflows/pr-build-ipa.yml
@@ -120,7 +120,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Build rootful tweak package
-        run: make package FINALPACKAGE=1
+        # The .deb is only an intermediate here (and a short-lived PR artifact),
+        # so skip Theos's default lzma -9 packaging (~16s on the runner) in
+        # favour of the fastest level. Release builds keep the default.
+        run: make package FINALPACKAGE=1 THEOS_PLATFORM_DEB_COMPRESSION_LEVEL=1
         env:
           THEOS: ${{ github.workspace }}/theos
 
@@ -158,20 +161,37 @@ jobs:
           brew install xcodegen
           xcodegen --version
 
+      - name: Restore cached widget extension build
+        id: widget_cache
+        # The widget appex (+ its dSYM) only depends on widgets/** and the Xcode
+        # used to build it, so most PRs can reuse the last build (~45s saved).
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: widgets/build/Build/Products/Release-iphoneos
+          key: widget-appex-xcode-26.0.1-${{ hashFiles('widgets/**') }}
+
       - name: Download Apollo IPA
         run: |
           curl -L --fail --retry 3 "$APOLLO_IPA_URL" -o Apollo.ipa
           unzip -t Apollo.ipa >/dev/null
 
       - name: Build IPA variants
+        # PR builds skip the two GLASS icons-only variants; release builds still
+        # produce all six.
         run: |
+          WIDGET_ARGS=()
+          if [ "${{ steps.widget_cache.outputs.cache-hit }}" = "true" ]; then
+            WIDGET_ARGS=(--widget-appex widgets/build/Build/Products/Release-iphoneos/ApolloRebornWidgets.appex)
+          fi
           bash ./scripts/build_release_variants.sh \
             --ipa ./Apollo.ipa \
             --deb "${{ steps.rootful_deb.outputs.deb_path }}" \
-            --output-dir ./dist/out
+            --output-dir ./dist/out \
+            --no-glass-icons \
+            "${WIDGET_ARGS[@]}"
 
       - name: Validate IPA variants
-        run: bash ./scripts/validate_release_variants.sh ./dist/out
+        run: bash ./scripts/validate_release_variants.sh --no-glass-icons ./dist/out
 
       - name: Collect widget debug symbols
         run: |
@@ -189,9 +209,9 @@ jobs:
           SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
           PREFIX="Apollo-Reborn-PR${{ github.event.pull_request.number }}-${SHORT_SHA}"
           # build_release_variants.sh stamps the tweak version into filenames; the
-          # standard IPA is the only one without a -NOEXTENSIONS/-GLASS/-GLASSICONS
-          # suffix, so recover the base name from it for the exact upload paths.
-          STD=$(ls dist/out/*.ipa | grep -vE -- '-(NOEXTENSIONS|GLASS|GLASSICONS)' | head -1)
+          # standard IPA is the only one without a -NOEXTENSIONS/-GLASS suffix, so
+          # recover the base name from it for the exact upload paths.
+          STD=$(ls dist/out/*.ipa | grep -vE -- '-(NOEXTENSIONS|GLASS)' | head -1)
           if [ -z "$STD" ]; then
             echo "Error: could not locate the standard IPA in dist/out" >&2
             ls -la dist/out
@@ -211,6 +231,7 @@ jobs:
           name: ${{ steps.meta.outputs.prefix }}-Standard
           path: dist/out/${{ steps.meta.outputs.base }}.ipa
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          compression-level: 0
 
       - name: Upload No-Extensions IPA
         id: art_noext
@@ -219,6 +240,7 @@ jobs:
           name: ${{ steps.meta.outputs.prefix }}-NoExtensions
           path: dist/out/${{ steps.meta.outputs.base }}-NOEXTENSIONS.ipa
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          compression-level: 0
 
       - name: Upload GLASS IPA
         id: art_glass
@@ -227,6 +249,7 @@ jobs:
           name: ${{ steps.meta.outputs.prefix }}-GLASS
           path: dist/out/${{ steps.meta.outputs.base }}-GLASS.ipa
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          compression-level: 0
 
       - name: Upload GLASS No-Extensions IPA
         id: art_glass_noext
@@ -235,22 +258,7 @@ jobs:
           name: ${{ steps.meta.outputs.prefix }}-GLASS-NoExtensions
           path: dist/out/${{ steps.meta.outputs.base }}-GLASS-NOEXTENSIONS.ipa
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-
-      - name: Upload GLASS Icons IPA
-        id: art_glassicons
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ steps.meta.outputs.prefix }}-GLASSIcons
-          path: dist/out/${{ steps.meta.outputs.base }}-GLASSICONS.ipa
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-
-      - name: Upload GLASS Icons No-Extensions IPA
-        id: art_glassicons_noext
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ steps.meta.outputs.prefix }}-GLASSIcons-NoExtensions
-          path: dist/out/${{ steps.meta.outputs.base }}-GLASSICONS-NOEXTENSIONS.ipa
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          compression-level: 0
 
       - name: Upload debug symbols artifact
         id: art_symbols
@@ -267,6 +275,7 @@ jobs:
           name: ${{ steps.meta.outputs.prefix }}-deb
           path: ${{ steps.rootful_deb.outputs.deb_path }}
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          compression-level: 0
 
       - name: Build success comment
         env:
@@ -274,8 +283,6 @@ jobs:
           URL_NOEXT: ${{ steps.art_noext.outputs.artifact-url }}
           URL_GLASS: ${{ steps.art_glass.outputs.artifact-url }}
           URL_GLASS_NOEXT: ${{ steps.art_glass_noext.outputs.artifact-url }}
-          URL_GLASSICONS: ${{ steps.art_glassicons.outputs.artifact-url }}
-          URL_GLASSICONS_NOEXT: ${{ steps.art_glassicons_noext.outputs.artifact-url }}
           URL_SYMBOLS: ${{ steps.art_symbols.outputs.artifact-url }}
           URL_DEB: ${{ steps.art_deb.outputs.artifact-url }}
           DEB_PATH: ${{ steps.rootful_deb.outputs.deb_path }}
@@ -295,8 +302,6 @@ jobs:
             echo "| No Extensions | [⬇️ Download](${URL_NOEXT}) | $(size_of "${BASE}-NOEXTENSIONS.ipa") |"
             echo "| GLASS | [⬇️ Download](${URL_GLASS}) | $(size_of "${BASE}-GLASS.ipa") |"
             echo "| GLASS · No Extensions | [⬇️ Download](${URL_GLASS_NOEXT}) | $(size_of "${BASE}-GLASS-NOEXTENSIONS.ipa") |"
-            echo "| GLASS Icons | [⬇️ Download](${URL_GLASSICONS}) | $(size_of "${BASE}-GLASSICONS.ipa") |"
-            echo "| GLASS Icons · No Extensions | [⬇️ Download](${URL_GLASSICONS_NOEXT}) | $(size_of "${BASE}-GLASSICONS-NOEXTENSIONS.ipa") |"
             echo "| Tweak package (rootful \`.deb\`) | [⬇️ Download](${URL_DEB}) | $(du -h "${DEB_PATH}" 2>/dev/null | cut -f1 || echo "?") |"
             echo ""
             echo "Debug symbols: [⬇️ dSYMs](${URL_SYMBOLS}) · [workflow run](${RUN_URL})"

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -8,9 +8,12 @@ IPA_PATH=""
 DEB_PATH=""
 OUTPUT_DIR="${REPO_DIR}/dist/out"
 NAME_PREFIX="Apollo"
+BUILD_GLASS_ICONS=1
+WIDGET_APPEX=""
 
 usage() {
     echo "Usage: $0 --ipa <Apollo.ipa> [--deb <packages/*.deb>] [--output-dir <dir>] [--name-prefix <name>]"
+    echo "          [--no-glass-icons] [--widget-appex <ApolloRebornWidgets.appex>]"
     echo ""
     echo "Builds the six distributable IPA variants used by AltStore/SideStore/Feather:"
     echo "  1. standard"
@@ -19,6 +22,10 @@ usage() {
     echo "  4. no-extensions + Liquid Glass"
     echo "  5. standard + Liquid Glass icons-only"
     echo "  6. no-extensions + Liquid Glass icons-only"
+    echo ""
+    echo "  --no-glass-icons   skip variants 5 and 6 (PR test builds)"
+    echo "  --widget-appex     inject this prebuilt ApolloRebornWidgets.appex instead of"
+    echo "                     building it with xcodegen + xcodebuild (CI cache hit)"
 }
 
 absolute_path() {
@@ -110,6 +117,14 @@ while [[ $# -gt 0 ]]; do
             NAME_PREFIX="$2"
             shift 2
             ;;
+        --no-glass-icons)
+            BUILD_GLASS_ICONS=0
+            shift
+            ;;
+        --widget-appex)
+            WIDGET_APPEX="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -149,6 +164,14 @@ if [[ ! -f "$DEB_PATH" ]]; then
     exit 1
 fi
 
+if [[ -n "$WIDGET_APPEX" ]]; then
+    WIDGET_APPEX="$(absolute_path "$WIDGET_APPEX")"
+    if [[ ! -d "$WIDGET_APPEX" ]]; then
+        echo "Error: widget appex not found: $WIDGET_APPEX"
+        exit 1
+    fi
+fi
+
 for tool in unzip zip lipo python3 plutil; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "Error: required tool '$tool' is not installed."
@@ -157,7 +180,7 @@ for tool in unzip zip lipo python3 plutil; do
 done
 
 if ! command -v cyan >/dev/null 2>&1; then
-    echo "Error: 'cyan' is required to build the no-extensions variants."
+    echo "Error: 'cyan' is required to inject the tweak into the stock IPA."
     exit 1
 fi
 
@@ -203,38 +226,58 @@ rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA" \
       "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"
 
 # Build the widget appex once; the inject-widgets module injects this prebuilt
-# product into the standard variant (Glass variants inherit it).
-build_widget_appex
+# product into the standard variant (Glass variants inherit it). A caller that
+# already has the product (CI cache hit) passes it via --widget-appex.
+WIDGETS_MODULE="inject-widgets"
+if [[ -n "$WIDGET_APPEX" ]]; then
+    echo "==> Using prebuilt Reborn widget extension: $WIDGET_APPEX"
+    WIDGETS_MODULE="inject-widgets:${WIDGET_APPEX}"
+else
+    build_widget_appex
+fi
 
 # Module spec fragments reused across variants.
 VERSIONS_MODULE="patch-bundle-versions:${TWEAK_VERSION}:${APP_BUILD_VERSION}"
 SCHEMES_MODULE="inject-url-schemes:${DEFAULT_URL_SCHEMES}"
 
+if [[ $BUILD_GLASS_ICONS -eq 1 ]]; then
+    TOTAL_STEPS=6
+else
+    TOTAL_STEPS=4
+fi
+
 echo ""
-echo "[1/6] Building standard injected IPA..."
-# build-ipa.sh handles tweak injection (+ CydiaSubstrate arm64e strip) on the
-# already-prepared base IPA, preserving its azule/cyan fallback for stock IPAs.
-bash "${REPO_DIR}/build-ipa.sh" --ipa "$IPA_PATH" --deb "$DEB_PATH" -o "$STANDARD_IPA"
-# Everything else for the standard variant in ONE unpack/repack: install the
-# manual + legacy Safari extensions, repair the Open-in-Apollo share extension,
-# set versions, and inject the widget extension. The GLASS and GLASSICONS
-# variants are derived from this IPA below and inherit all of it; the
-# no-extensions variants have no appex and omit the extension/widget modules.
+echo "[1/${TOTAL_STEPS}] Building standard injected IPA..."
+# cyan injects the tweak dylibs + CydiaSubstrate.framework into the stock base
+# IPA. Its output is only an intermediate that apply-patches.sh unpacks again
+# right away, so write it stored (-c 0): deflating ~300 MB of app contents is
+# the bulk of cyan's runtime, and the orchestrator recompresses on repack.
+# (build-ipa.sh's repo-local injector only works on an IPA that was already
+# injected once, which the stock base never is; calling cyan directly here
+# skips that doomed attempt and matches the no-extensions path below.)
+cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$STANDARD_IPA" -c 0
+# Everything else for the standard variant in ONE unpack/repack: strip the
+# CydiaSubstrate arm64e slice, install the manual + legacy Safari extensions,
+# repair the Open-in-Apollo share extension, set versions, and inject the
+# widget extension. The GLASS and GLASSICONS variants are derived from this IPA
+# below and inherit all of it; the no-extensions variants have no appex and
+# omit the extension/widget modules.
 apply_patches_in_place "$STANDARD_IPA" \
     --module enable-promotion \
+    --module strip-substrate-arm64e \
     --module fix-safari-extension \
     --module fix-openin-extension \
     --module "$VERSIONS_MODULE" \
     --module "$SCHEMES_MODULE" \
-    --module inject-widgets \
+    --module "$WIDGETS_MODULE" \
     --module stamp-build-variant:ipa
 
 echo ""
-echo "[2/6] Building no-extensions injected IPA..."
+echo "[2/${TOTAL_STEPS}] Building no-extensions injected IPA..."
 # `cyan -e` injects the tweak AND strips all PlugIns (the no-extensions variant);
 # the orchestrator then strips the CydiaSubstrate arm64e slice, sets versions,
 # and injects the default URL schemes in one unpack/repack.
-cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
+cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e -c 0
 apply_patches_in_place "$NOEXT_IPA" \
     --module enable-promotion \
     --module strip-substrate-arm64e \
@@ -243,7 +286,7 @@ apply_patches_in_place "$NOEXT_IPA" \
     --module stamp-build-variant:ipa-noext
 
 echo ""
-echo "[3/6] Applying Liquid Glass patch to standard IPA..."
+echo "[3/${TOTAL_STEPS}] Applying Liquid Glass patch to standard IPA..."
 bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_IPA" \
     --module liquid-glass-binary \
     --module liquid-glass-assets \
@@ -251,28 +294,32 @@ bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_IPA" \
     --module stamp-build-variant:glass
 
 echo ""
-echo "[4/6] Applying Liquid Glass patch to no-extensions IPA..."
+echo "[4/${TOTAL_STEPS}] Applying Liquid Glass patch to no-extensions IPA..."
 bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_IPA" \
     --module liquid-glass-binary \
     --module liquid-glass-assets \
     --module "$VERSIONS_MODULE" \
     --module stamp-build-variant:glass-noext
 
-echo ""
-echo "[5/6] Applying Liquid Glass icons-only patch to standard IPA..."
-bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_ICONS_IPA" \
-    --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE" \
-    --module stamp-build-variant:glassicons
+if [[ $BUILD_GLASS_ICONS -eq 1 ]]; then
+    echo ""
+    echo "[5/6] Applying Liquid Glass icons-only patch to standard IPA..."
+    bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_ICONS_IPA" \
+        --module liquid-glass-assets \
+        --module "$VERSIONS_MODULE" \
+        --module stamp-build-variant:glassicons
 
-echo ""
-echo "[6/6] Applying Liquid Glass icons-only patch to no-extensions IPA..."
-bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_ICONS_IPA" \
-    --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE" \
-    --module stamp-build-variant:glassicons-noext
+    echo ""
+    echo "[6/6] Applying Liquid Glass icons-only patch to no-extensions IPA..."
+    bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_ICONS_IPA" \
+        --module liquid-glass-assets \
+        --module "$VERSIONS_MODULE" \
+        --module stamp-build-variant:glassicons-noext
+fi
 
 echo ""
 echo "Created:"
-printf '  %s\n' "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA" \
-                "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"
+printf '  %s\n' "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA"
+if [[ $BUILD_GLASS_ICONS -eq 1 ]]; then
+    printf '  %s\n' "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"
+fi

--- a/scripts/modules/liquid-glass-assets.sh
+++ b/scripts/modules/liquid-glass-assets.sh
@@ -13,9 +13,6 @@
 _LG_ASSETS_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _LG_ASSETS_REPO_DIR="$(cd "${_LG_ASSETS_MODULE_DIR}/../.." && pwd)"
 
-# shellcheck source=_plist-helpers.sh
-source "${_LG_ASSETS_MODULE_DIR}/_plist-helpers.sh"
-
 # Asset sources default to the Apollo-Reborn repo, but callers with their own
 # copy (e.g. the workspace build.sh under scripts/patch-assets/) can override
 # them via these env vars before sourcing/calling.
@@ -38,6 +35,12 @@ _lg_load_alternate_icons() {
     done
 }
 
+# Writes the primary + alternate icon metadata in ONE plistlib pass. The
+# previous PlistBuddy version spawned a process per key (several hundred for
+# the full icon registry, each re-parsing the whole Info.plist) and took ~17s
+# per IPA on CI runners; this takes well under a second. Existing entries under
+# CFBundleIcons are preserved and only the keys we own are (re)written, matching
+# the old behaviour. The plist's on-disk format (binary vs XML) is preserved.
 _lg_ensure_icon_metadata() {
     local plist="$1"
     local -a alt_icons=()
@@ -46,25 +49,47 @@ _lg_ensure_icon_metadata() {
         [[ -n "$line" ]] && alt_icons+=("$line")
     done < <(_lg_load_alternate_icons)
 
-    plist_ensure_dict "$plist" "CFBundleIcons"
-    plist_ensure_dict "$plist" "CFBundleIcons:CFBundlePrimaryIcon"
-    plist_ensure_dict "$plist" "CFBundleIcons:CFBundleAlternateIcons"
-    plist_ensure_dict "$plist" "CFBundleIcons~ipad"
-    plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon"
-    plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons"
+    LG_PLIST="$plist" \
+    LG_ICON_NAME="$_LG_ICON_NAME" \
+    LG_IPHONE_ICON_FILES="$(IFS=,; echo "${_LG_IPHONE_ICON_FILES[*]}")" \
+    LG_IPAD_ICON_FILES="$(IFS=,; echo "${_LG_IPAD_ICON_FILES[*]}")" \
+    LG_ALT_ICONS="$(IFS=,; echo "${alt_icons[*]+"${alt_icons[*]}"}")" \
+    python3 - <<'PY'
+import os
+import plistlib
 
-    plist_set_string "$plist" "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName" "$_LG_ICON_NAME"
-    plist_set_string "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "$_LG_ICON_NAME"
-    plist_replace_string_array "$plist" "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconFiles" "${_LG_IPHONE_ICON_FILES[@]}"
-    plist_replace_string_array "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles" "${_LG_IPAD_ICON_FILES[@]}"
+path = os.environ["LG_PLIST"]
+icon_name = os.environ["LG_ICON_NAME"]
+iphone_files = [f for f in os.environ["LG_IPHONE_ICON_FILES"].split(",") if f]
+ipad_files = [f for f in os.environ["LG_IPAD_ICON_FILES"].split(",") if f]
+alt_icons = [n for n in os.environ["LG_ALT_ICONS"].split(",") if n]
 
-    local icon_name
-    for icon_name in "${alt_icons[@]}"; do
-        plist_ensure_dict "$plist" "CFBundleIcons:CFBundleAlternateIcons:${icon_name}"
-        plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}"
-        plist_set_string "$plist" "CFBundleIcons:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "$icon_name"
-        plist_set_string "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "$icon_name"
-    done
+with open(path, "rb") as fh:
+    raw = fh.read()
+fmt = plistlib.FMT_BINARY if raw.startswith(b"bplist") else plistlib.FMT_XML
+root = plistlib.loads(raw)
+
+
+def ensure_dict(parent, key):
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        parent[key] = value
+    return value
+
+
+for icons_key, files in (("CFBundleIcons", iphone_files), ("CFBundleIcons~ipad", ipad_files)):
+    icons = ensure_dict(root, icons_key)
+    primary = ensure_dict(icons, "CFBundlePrimaryIcon")
+    primary["CFBundleIconName"] = icon_name
+    primary["CFBundleIconFiles"] = list(files)
+    alternates = ensure_dict(icons, "CFBundleAlternateIcons")
+    for name in alt_icons:
+        ensure_dict(alternates, name)["CFBundleIconName"] = name
+
+with open(path, "wb") as fh:
+    plistlib.dump(root, fh, fmt=fmt)
+PY
 }
 
 patch_liquid_glass_assets_in_app() {

--- a/scripts/validate_release_variants.sh
+++ b/scripts/validate_release_variants.sh
@@ -1,16 +1,42 @@
 #!/bin/bash
 set -euo pipefail
 
-OUT_DIR="${1:-dist/out}"
+OUT_DIR=""
+VALIDATE_GLASS_ICONS=1
 
 usage() {
-    echo "Usage: $0 <dist/out>"
+    echo "Usage: $0 [--no-glass-icons] <dist/out>"
+    echo ""
+    echo "  --no-glass-icons   do not expect the two GLASSICONS variants (PR test builds)"
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-    usage
-    exit 0
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --no-glass-icons)
+            VALIDATE_GLASS_ICONS=0
+            shift
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            if [[ -n "$OUT_DIR" ]]; then
+                echo "Error: unexpected argument: $1" >&2
+                usage
+                exit 1
+            fi
+            OUT_DIR="$1"
+            shift
+            ;;
+    esac
+done
+OUT_DIR="${OUT_DIR:-dist/out}"
 
 if [[ ! -d "$OUT_DIR" ]]; then
     echo "Error: output directory not found: $OUT_DIR" >&2
@@ -58,7 +84,10 @@ contains_path() {
     local ipa="$1"
     local pattern="$2"
 
-    unzip -Z1 "$ipa" | grep -Eq "$pattern"
+    # Not `grep -q`: it exits at the first match, unzip then dies of SIGPIPE on
+    # a listing larger than the pipe buffer, and `pipefail` turns a hit into a
+    # failure. Let grep drain the whole listing instead.
+    unzip -Z1 "$ipa" | grep -E "$pattern" >/dev/null
 }
 
 require_widget_variant() {
@@ -191,33 +220,35 @@ NOEXT_GLASS_ICONS_IPA="${BASE}-GLASSICONS-NOEXTENSIONS.ipa"
 require_file "$NOEXT_IPA" "No Extensions"
 require_file "$GLASS_IPA" "GLASS"
 require_file "$NOEXT_GLASS_IPA" "GLASS No Extensions"
-require_file "$GLASS_ICONS_IPA" "GLASS Icons"
-require_file "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
 
 require_widget_variant "$STANDARD_IPA" "standard"
 require_widget_variant "$GLASS_IPA" "GLASS"
-require_widget_variant "$GLASS_ICONS_IPA" "GLASS Icons"
 
 require_safari_extensions "$STANDARD_IPA" "standard"
 require_safari_extensions "$GLASS_IPA" "GLASS"
-require_safari_extensions "$GLASS_ICONS_IPA" "GLASS Icons"
 
 require_no_extensions_variant "$NOEXT_IPA" "No Extensions"
 require_no_extensions_variant "$NOEXT_GLASS_IPA" "GLASS No Extensions"
-require_no_extensions_variant "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
 
 require_promotion_enabled "$STANDARD_IPA" "standard"
 require_promotion_enabled "$NOEXT_IPA" "No Extensions"
 require_promotion_enabled "$GLASS_IPA" "GLASS"
 require_promotion_enabled "$NOEXT_GLASS_IPA" "GLASS No Extensions"
-require_promotion_enabled "$GLASS_ICONS_IPA" "GLASS Icons"
-require_promotion_enabled "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
+
+VALIDATED=("$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA")
+
+if [[ $VALIDATE_GLASS_ICONS -eq 1 ]]; then
+    require_file "$GLASS_ICONS_IPA" "GLASS Icons"
+    require_file "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
+    require_widget_variant "$GLASS_ICONS_IPA" "GLASS Icons"
+    require_safari_extensions "$GLASS_ICONS_IPA" "GLASS Icons"
+    require_no_extensions_variant "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
+    require_promotion_enabled "$GLASS_ICONS_IPA" "GLASS Icons"
+    require_promotion_enabled "$NOEXT_GLASS_ICONS_IPA" "GLASS Icons No Extensions"
+    VALIDATED+=("$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA")
+fi
 
 echo "IPA variant validation passed:"
-printf '  %s\n' \
-    "$(basename "$STANDARD_IPA")" \
-    "$(basename "$NOEXT_IPA")" \
-    "$(basename "$GLASS_IPA")" \
-    "$(basename "$NOEXT_GLASS_IPA")" \
-    "$(basename "$GLASS_ICONS_IPA")" \
-    "$(basename "$NOEXT_GLASS_ICONS_IPA")"
+for ipa in "${VALIDATED[@]}"; do
+    printf '  %s\n' "$(basename "$ipa")"
+done


### PR DESCRIPTION
This PR optimizes the PR IPA build workflows to cut down on our monthly GitHub Actions usage/costs.

The contents of the standard, no-extensions, and GLASS IPAs are unchanged.

### Where the time went

The compile is already parallel (Theos injects `-j<cores>`), so the savings come from the packaging half of the job, where a recent `main` run showed the same work being done twice or slower than necessary: 47s building the widget appex, 51s on the standard variant, 37s on the two icons-only variants, 17s per GLASS variant writing icon metadata, and 16s compressing the deb.

### Changes

- Skip the two GLASS icons-only variants for PR builds via `--no-glass-icons` on the build and validate scripts. Release builds still produce all six.
- Write the Liquid Glass icon metadata in a single `plistlib` pass instead of several hundred `PlistBuddy` spawns. Output is identical to the old implementation; locally 6.2s → 0.26s.
- Inject the standard variant with cyan directly, as the no-extensions path already does. `build-ipa.sh` always tried the repo-local injector first, which cannot succeed on the stock base IPA, then fell back to cyan, then the orchestrator unpacked and repacked the result again. The arm64e substrate strip is folded into the single `apply-patches.sh` pass, and cyan's intermediate IPA is written stored (`-c 0`) since it is unpacked immediately.
- Cache the widget appex build keyed on `widgets/**` and the Xcode version; on a hit the workflow passes `--widget-appex` and skips xcodegen + xcodebuild. The first run after merge is a cache miss, so judge timings from the second.
- Build the PR deb with `THEOS_PLATFORM_DEB_COMPRESSION_LEVEL=1` (it is an intermediate there) and upload the already-compressed IPA/deb artifacts with `compression-level: 0`.

### Validator fix

`contains_path` used `unzip -Z1 | grep -Eq` under `pipefail`: `grep -q` exits at the first match, unzip dies of SIGPIPE on a large listing, and a hit reads as a failure. It surfaced once the widget appex landed earlier in the zip listing; grep now drains the listing.

### Results

First CI run of this PR versus a past PR run of the same workflow. The widget cache was a miss on this run, so the next push should shave a further ~35s.

| Phase | Past PR | This PR |
| --- | ---: | ---: |
| Build job total | 465s | 285s |
| `make package` | 140s | 108s |
| Build IPA variants | 201s | 80s |
| Standard variant | 51s | 14s |
| GLASS variants (both) | 52s | 24s |
| Icons-only variants (both) | 37s | skipped |
| Widget appex | 47s | 35s (cache miss) |

### Testing

- Built and validated the four-variant PR configuration locally, including the `--widget-appex` cache-hit path, and the default six-variant release configuration.
- Per-member CRCs of the standard IPA are identical between the old `build-ipa.sh` path and the new cyan-direct path; CydiaSubstrate is arm64-only in the output.
- Info.plist output of the old and new icon-metadata implementations is identical.