### PR TITLE
Fix duplicate saved items after refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloHiddenContentViewController.m \
     $(SRC_DIR)/ApolloHiddenContentMenu.xm \
     $(SRC_DIR)/ApolloHideLinksBatchFix.xm \
+    $(SRC_DIR)/ApolloSavedItemsDeduplicator.m \
     $(SRC_DIR)/ApolloSavedCategories.xm \
     $(SRC_DIR)/ApolloSwiftIvarBridge.swift \
     $(SRC_DIR)/ApolloUserFlair.xm \

--- a/src/ApolloSavedCategories.xm
+++ b/src/ApolloSavedCategories.xm
@@ -16,6 +16,43 @@
 #import <objc/runtime.h>
 #include <dlfcn.h>
 
+#import "ApolloCommon.h"
+#import "ApolloSavedItemsDeduplicator.h"
+
+@class RDKPagination;
+typedef void (^ApolloSavedItemsCompletion)(NSArray *items, RDKPagination *pagination, NSError *error);
+
+// MARK: - Saved-list refresh de-duplication
+
+// SavedPostsCommentsViewController uses this category-aware API for both the
+// unfiltered Saved screen (nil category) and category filters. Apollo replaces
+// its savedPostsComments array with the response on a pull-to-refresh. Reddit
+// can return the same thing twice in that response, so normalize at this data
+// boundary before the Swift controller or ListAdapter sees it. Pagination and
+// errors pass through untouched.
+%hook RDKClient
+
+- (id)savedLinksAndCommentsWithCategory:(id)category
+                              pagination:(RDKPagination *)pagination
+                              completion:(ApolloSavedItemsCompletion)completion {
+    if (!completion) return %orig;
+
+    ApolloSavedItemsCompletion originalCompletion = [completion copy];
+    ApolloSavedItemsCompletion deduplicatingCompletion = ^(NSArray *items,
+                                                            RDKPagination *responsePagination,
+                                                            NSError *error) {
+        NSArray *deduplicated = ApolloDeduplicateSavedItems(items);
+        if (deduplicated.count != items.count) {
+            ApolloLog(@"[SavedItems] Removed %lu duplicate item(s) from refresh response",
+                      (unsigned long)(items.count - deduplicated.count));
+        }
+        originalCompletion(deduplicated, responsePagination, error);
+    };
+    return %orig(category, pagination, deduplicatingCompletion);
+}
+
+%end
+
 // MARK: - ActionController In-Place Sort
 
 // Decode a Swift String stored as two raw 64-bit words into an NSString.

--- a/src/ApolloSavedItemsDeduplicator.h
+++ b/src/ApolloSavedItemsDeduplicator.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Removes duplicate Reddit things from one saved-items response while
+// preserving the first occurrence and the server's order. Objects without a
+// stable Reddit identity are retained because dropping them would be unsafe.
+FOUNDATION_EXPORT NSArray *_Nullable ApolloDeduplicateSavedItems(NSArray *_Nullable items);
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloSavedItemsDeduplicator.m
+++ b/src/ApolloSavedItemsDeduplicator.m
@@ -1,0 +1,54 @@
+#import "ApolloSavedItemsDeduplicator.h"
+
+#import <objc/message.h>
+
+static id ApolloSavedItemValue(id item, SEL selector) {
+    if (!item || ![item respondsToSelector:selector]) return nil;
+    @try {
+        return ((id (*)(id, SEL))objc_msgSend)(item, selector);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSString *ApolloSavedItemString(id value) {
+    if ([value isKindOfClass:[NSString class]]) {
+        NSString *string = (NSString *)value;
+        return string.length > 0 ? string : nil;
+    }
+    if ([value isKindOfClass:[NSNumber class]]) return [(NSNumber *)value stringValue];
+    return nil;
+}
+
+static NSString *ApolloSavedItemIdentity(id item) {
+    NSString *fullName = ApolloSavedItemString(ApolloSavedItemValue(item, @selector(fullName)));
+    if (fullName.length > 0) return [@"fullname:" stringByAppendingString:fullName];
+
+    NSString *kind = ApolloSavedItemString(ApolloSavedItemValue(item, @selector(kindName)));
+    NSString *identifier = ApolloSavedItemString(ApolloSavedItemValue(item, @selector(identifier)));
+    if (kind.length == 0 || identifier.length == 0) return nil;
+    return [NSString stringWithFormat:@"kind:%@:%@", kind, identifier];
+}
+
+NSArray *ApolloDeduplicateSavedItems(NSArray *items) {
+    if (items.count < 2) return items;
+
+    NSMutableSet<NSString *> *seen = [NSMutableSet setWithCapacity:items.count];
+    __block NSMutableArray *deduplicated = nil;
+
+    [items enumerateObjectsUsingBlock:^(id item, NSUInteger index, __unused BOOL *stop) {
+        NSString *identity = ApolloSavedItemIdentity(item);
+        BOOL duplicate = identity.length > 0 && [seen containsObject:identity];
+        if (!duplicate) {
+            if (identity.length > 0) [seen addObject:identity];
+            if (deduplicated) [deduplicated addObject:item];
+            return;
+        }
+
+        if (!deduplicated) {
+            deduplicated = [[items subarrayWithRange:NSMakeRange(0, index)] mutableCopy];
+        }
+    }];
+
+    return deduplicated ?: items;
+}

--- a/tests/saved_items_deduplicator_tests.m
+++ b/tests/saved_items_deduplicator_tests.m
@@ -1,0 +1,88 @@
+#import <Foundation/Foundation.h>
+
+#import "ApolloSavedItemsDeduplicator.h"
+
+@interface ApolloSavedItemFixture : NSObject
+@property(nonatomic, copy) NSString *fullName;
+@property(nonatomic, copy) NSString *kindName;
+@property(nonatomic, strong) id identifier;
+@property(nonatomic, copy) NSString *label;
+@end
+
+@implementation ApolloSavedItemFixture
+@end
+
+static ApolloSavedItemFixture *Item(NSString *label, NSString *fullName,
+                                    NSString *kindName, id identifier) {
+    ApolloSavedItemFixture *item = [ApolloSavedItemFixture new];
+    item.label = label;
+    item.fullName = fullName;
+    item.kindName = kindName;
+    item.identifier = identifier;
+    return item;
+}
+
+static void Require(BOOL condition, NSString *message) {
+    if (!condition) {
+        @throw [NSException exceptionWithName:@"SavedItemsDeduplicatorTestFailure"
+                                       reason:message userInfo:nil];
+    }
+}
+
+static NSArray<NSString *> *Labels(NSArray *items) {
+    return [items valueForKey:@"label"];
+}
+
+static void TestDuplicatePostAndComment(void) {
+    NSArray *input = @[
+        Item(@"post", @"t3_post", @"t3", @"post"),
+        Item(@"post duplicate", @"t3_post", @"t3", @"post"),
+        Item(@"comment", @"t1_comment", @"t1", @"comment"),
+        Item(@"comment duplicate", @"t1_comment", @"t1", @"comment"),
+    ];
+    Require([Labels(ApolloDeduplicateSavedItems(input)) isEqual:@[ @"post", @"comment" ]],
+            @"keeps the first post and comment in server order");
+}
+
+static void TestFallbackDistinguishesKinds(void) {
+    NSArray *input = @[
+        Item(@"post", nil, @"t3", @42),
+        Item(@"comment", nil, @"t1", @42),
+        Item(@"post duplicate", nil, @"t3", @42),
+    ];
+    Require([Labels(ApolloDeduplicateSavedItems(input)) isEqual:@[ @"post", @"comment" ]],
+            @"kind plus identifier prevents post/comment collisions");
+}
+
+static void TestIdentitylessObjectsArePreserved(void) {
+    ApolloSavedItemFixture *first = Item(@"first", nil, nil, nil);
+    ApolloSavedItemFixture *second = Item(@"second", nil, nil, nil);
+    NSArray *input = @[ first, second, first ];
+    NSArray *output = ApolloDeduplicateSavedItems(input);
+    Require(output.count == 3, @"identity-less objects are never dropped");
+    Require(output[0] == first && output[1] == second && output[2] == first,
+            @"identity-less object order and occurrences are preserved");
+}
+
+static void TestNilEmptyAndUniqueInputsRemainUnchanged(void) {
+    Require(ApolloDeduplicateSavedItems(nil) == nil, @"nil stays nil");
+    NSArray *empty = @[];
+    Require(ApolloDeduplicateSavedItems(empty) == empty, @"empty array identity is preserved");
+    NSArray *unique = @[
+        Item(@"first", @"t3_first", @"t3", @"first"),
+        Item(@"second", @"t3_second", @"t3", @"second"),
+    ];
+    Require(ApolloDeduplicateSavedItems(unique) == unique,
+            @"an already-unique response is returned without allocation");
+}
+
+int main(void) {
+    @autoreleasepool {
+        TestDuplicatePostAndComment();
+        TestFallbackDistinguishesKinds();
+        TestIdentitylessObjectsArePreserved();
+        TestNilEmptyAndUniqueInputsRemainUnchanged();
+        NSLog(@"saved_items_deduplicator_tests passed");
+    }
+    return 0;
+}


### PR DESCRIPTION
Fixes #379.

Apollo's Saved screen replaces its list with the response from `savedLinksAndCommentsWithCategory:pagination:completion:` after a pull-to-refresh. That response can contain the same Reddit object more than once, so the UI renders duplicates until the screen is reopened.

This change deduplicates that response before the Swift controller stores it:

- Uses `fullName` as the primary stable identity.
- Falls back to `kindName` plus `identifier`.
- Keeps the first occurrence and preserves server order.
- Keeps identity-less objects rather than dropping uncertain data.
- Leaves pagination and errors unchanged.
- Returns an already-unique array unchanged.

The hook is limited to the category-aware saved-items API used by the Saved screen, including its nil-category path. It does not touch the global list adapter or write Swift ivars directly.

Validation:

- `saved_items_deduplicator_tests` passed for duplicate posts, duplicate comments, cross-kind identifier collisions, ordering, identity-less objects, nil/empty input, and already-unique input.
- Full `THEOS=/Users/corn/.local/share/theos make package` build passed.
- `git diff --check` passed.
