### PR TITLE
Translation: keep the globe on search results under Liquid Glass

### DIFF
--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -6477,14 +6477,23 @@ static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIBu
     return nil;
 }
 
-// Detach the globe from any container it was merged into, restoring that
-// container's original button layout (shift back, shrink).
+// Detach the globe from a container WE merged it into, restoring that
+// container's original button layout (shift back, shrink). A merged container
+// is recognised by the shift we recorded on it; any other superview is left
+// alone. That matters for the standalone fallback: once the globe is a bar
+// item of its own, UIKit hosts it inside its own item wrapper, and ripping it
+// out of that wrapper (the old "detach from whatever superview" behaviour) is
+// exactly how the search-results screen ended up with a globe-sized hole in
+// its trailing capsule — the item still reserved the slot, but every refresh
+// pulled the button back out of UIKit's wrapper.
 static void ApolloDetachGlobeFromContainer(UIButton *globe) {
-    if (!globe || ![globe.superview isKindOfClass:[UIView class]]) return;
     UIView *container = globe.superview;
-    // Undo exactly the right-shift we applied when merging (stored on the
-    // container), falling back to the slot width if unknown.
-    CGFloat shift = [objc_getAssociatedObject(container, kApolloGlobeMergeShiftKey) doubleValue];
+    if (!container) return;
+    NSNumber *storedShift = objc_getAssociatedObject(container, kApolloGlobeMergeShiftKey);
+    if (!storedShift) return;  // not a container we merged into — nothing to unpack
+    // Undo exactly the right-shift we applied when merging, falling back to
+    // the slot width if the stored value is unusable.
+    CGFloat shift = storedShift.doubleValue;
     if (shift <= 0.0) shift = globe.frame.size.width > 1.0 ? globe.frame.size.width : kApolloGlobeMergeSlotWidth;
     [globe removeFromSuperview];
     for (UIView *sub in container.subviews) {
@@ -6540,7 +6549,11 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
 
         CGFloat gw = kApolloGlobeMergeSlotWidth;
         CGFloat h = container.bounds.size.height > 1.0 ? container.bounds.size.height : 44.0;
-        [globe removeFromSuperview];  // out of any previous (stale) container
+        // Out of any previous host: unpack a stale merged container properly
+        // (restore its layout), then leave whatever else held it — e.g. the
+        // wrapper of the standalone item we just dropped above.
+        ApolloDetachGlobeFromContainer(globe);
+        [globe removeFromSuperview];
 
         // Measure Apollo's button cluster and the container's trailing inset so
         // we can insert the globe and keep the whole group SYMMETRIC inside the
@@ -6638,15 +6651,24 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     // setRightBarButtonItem(s) hook re-runs this as soon as Apollo sets its
     // container. Only fall back to standalone if the globe truly has nowhere to
     // go (already detached and no container appeared).
-    if (globe.superview && ![globe.superview isKindOfClass:[UIView class]]) {
-        // shouldn't happen, but normalize
+    //
+    // This path runs on EVERY refresh (viewWillAppear/viewDidAppear, the
+    // staggered state refreshes, each viewDidLayoutSubviews settle), so it has
+    // to be a strict no-op once the standalone item is in place: from then on
+    // UIKit owns the globe's superview (its bar-item wrapper). Screens whose
+    // only trailing button is a plain image item — PostsSearchResultsViewController
+    // with its sort bullseye — live on this path permanently.
+    ApolloDetachGlobeFromContainer(globe);  // only unpacks a container we merged into
+    if (standalone && standalone.customView == globe && [navItem.rightBarButtonItems containsObject:standalone]) {
+        return;  // already hosted as its own item — leave UIKit's wrapper alone
     }
-    ApolloDetachGlobeFromContainer(globe);
     globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
     globe.frame = CGRectMake(0.0, 0.0, kApolloGlobeMergeSlotWidth, 32.0);
     if (!standalone) {
         standalone = [[UIBarButtonItem alloc] initWithCustomView:globe];
         objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, standalone, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[Translation] Globe: no trailing container to merge into on '%@' - hosting as a standalone bar item",
+                  navItem.title ?: @"(untitled)");
     } else if (standalone.customView != globe) {
         standalone.customView = globe;
     }
@@ -6677,6 +6699,9 @@ static void ApolloRemoveGlobeMergeForNavItem(UINavigationItem *navItem) {
             sApplyingGlobeMerge = NO;
         }
     }
+    // The globe is gone for good on this nav item: make sure no host (a
+    // standalone item's wrapper included) keeps drawing it.
+    [globe removeFromSuperview];
     objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(navItem, kApolloGlobeMergeButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     // The stock container is asymmetric inside the glass capsule; with the


### PR DESCRIPTION
## What

On Liquid Glass the translate globe was missing from **search results** (type in the feed's search bar, open the results): the trailing capsule was wide enough for it but the slot next to the sort bullseye was empty. Backgrounding the app and coming back sometimes brought it back, the next app switch lost it again.

| before (main) | after |
|---|---|
| <img width="320" alt="before" src="https://github.com/user-attachments/assets/0c874128-9e1e-446c-a28d-de3b1cc547f5" /> | <img width="320" alt="after" src="https://github.com/user-attachments/assets/ecc4031d-9780-48de-843c-58ca7338ccde" /> |
| wide capsule, empty slot left of the sort button | globe sits next to the sort button and stays there |

## Why

Search results is the one feed screen whose only trailing button is a plain image `UIBarButtonItem` (Apollo's sort bullseye) instead of one of its hand-packed multi-button containers. With nothing to merge into, the globe takes the standalone fallback and becomes its own bar item, which UIKit hosts inside its own item wrapper.

That fallback runs on every refresh (appear, the staggered state refreshes, each layout settle) and it started by calling the "detach from container" helper, which removed the globe from *whatever* superview it had. On a merged container that's the intended unpack; on the standalone item it rips the button straight out of UIKit's wrapper. The item still exists so the bar keeps the slot, there's just nothing in it. Foregrounding makes UIKit re-host the custom view, then the next refresh pulls it out again, hence the flip-flopping.

## Fix

- the detach helper only unpacks a container we merged into (recognised by the shift we recorded on it) and leaves any other host alone
- the standalone path is a strict no-op once its item is in place
- the merge path still restores a stale merged container before moving the globe, and the translation-off removal explicitly drops the button from any host
- one log line when a screen ends up on the standalone path so it shows up in user logs next time

With translation off nothing changes: no item gets added, the capsule stays sort-only.

## Testing

Simulator only so far (iOS 26.5), r/soccer search results via the `apollo://…/search?q=` deep link:

- glass, main: wide capsule with the empty slot, reproduces the report; one background/foreground cycle brings the globe back like the report says
- glass, this branch: globe there right away, still there after two background/foreground cycles
- glass, translation off: capsule is sort-only
- glass, subreddit feed: merged globe + trophy + more pill unchanged
- non-glass: unaffected (uses the pre-26 separate-item path), search results and feed both fine

Not device tested yet.
