### PR TITLE
Autoplay Inline GIFs: keep playing in Low Power Mode (fixes #1004, #634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- Stop **Autoplay Inline GIFs** treating Low Power Mode as Tap to Play — Always and WiFi Only now keep GIFs animating in Low Power Mode, and Tap to Play or Never remain the battery-saving choices (#634, #1004: @icpryde)
 - Give **Show/Hide Deleted Comments** in the comments ⋯ menu custom icons that match Apollo's own artwork instead of the SF Symbol eye (#962: @AcornElf, @icpryde)
 - Restore Apollo's original icon weight across the ⋯ menus — the Liquid Glass menu was downscaling every icon to 18pt, and rows added by the tweak (Gallery View, View Hidden/Deleted Content, Show/Hide Deleted Comments) rendered smaller than Apollo's own rows on the legacy sheet (#985: @AcornElf, @icpryde)
 

--- a/src/ApolloMediaAutoplay.h
+++ b/src/ApolloMediaAutoplay.h
@@ -12,7 +12,8 @@ extern "C" {
 BOOL ApolloShouldAutoplayInlineGIF(void);
 
 /// Cached autoplay decision for the current settings/reachability epoch.
-/// Invalidated when settings, reachability, or Low Power Mode changes.
+/// Invalidated when settings or reachability change. Low Power Mode is
+/// deliberately not part of the decision (the mode setting is).
 BOOL ApolloShouldAutoplayInlineGIFCached(void);
 
 /// Current inline-GIF autoplay mode as a normalized string
@@ -92,7 +93,7 @@ BOOL ApolloPauseInlineGIFNodeForAutoplay(id imageNode);
 /// Returns YES when a paused node was reloaded; NO when skipped or resume-only.
 BOOL ApolloReloadInlineGIFImageNodeForAutoplay(id imageNode);
 
-/// Install observers for the Autoplay Inline GIFs preference / reachability / Low Power Mode.
+/// Install observers for the Autoplay Inline GIFs preference / reachability.
 void ApolloMediaAutoplayInstall(void);
 
 #ifdef __cplusplus

--- a/src/ApolloMediaAutoplay.m
+++ b/src/ApolloMediaAutoplay.m
@@ -151,14 +151,13 @@ static void ApolloInstallAutoplayDefaultsKVO(NSUserDefaults *defaults, NSString 
     }
 }
 
+// Deliberately NOT gated on Low Power Mode. The Autoplay Inline GIFs setting is
+// the user's whole answer to "should these animate?": Always / WiFi Only keep
+// playing in Low Power Mode, and anyone who wants to save battery picks Tap to
+// Play or Never. The old unconditional LPM veto made Always silently behave
+// like Tap to Play for anyone whose phone lives in Low Power Mode (#634,
+// #1004), and Apollo's own feed GIFs never checked LPM either.
 static BOOL ApolloComputeShouldAutoplayInlineGIF(NSString **outMode) {
-    if (@available(iOS 9.0, *)) {
-        if ([NSProcessInfo processInfo].isLowPowerModeEnabled) {
-            if (outMode) *outMode = @"lpm";
-            return NO;
-        }
-    }
-
     ApolloStartReachabilityMonitor();
 
     NSString *mode = ApolloAutoplayGIFModeString();
@@ -629,13 +628,8 @@ void ApolloMediaAutoplayInstall(void) {
         ApolloInstallAutoplayDefaultsKVO([NSUserDefaults standardUserDefaults], UDKeyAutoplayInlineGIFs);
         ApolloInstallAutoplayDefaultsKVO([NSUserDefaults standardUserDefaults], kApolloNativeAutoplayGIFsKey);
         ApolloInstallAutoplayDefaultsKVO([[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName], kApolloNativeAutoplayGIFsKey);
-        if (@available(iOS 9.0, *)) {
-            [[NSNotificationCenter defaultCenter] addObserverForName:NSProcessInfoPowerStateDidChangeNotification
-                                                              object:nil
-                                                               queue:[NSOperationQueue mainQueue]
-                                                          usingBlock:^(__unused NSNotification *note) {
-                ApolloRefreshVisibleInlineGIFAutoplay();
-            }];
-        }
+        // No NSProcessInfoPowerStateDidChangeNotification observer: Low Power
+        // Mode no longer feeds the decision, so a power-state flip has nothing
+        // to refresh (see ApolloComputeShouldAutoplayInlineGIF).
     });
 }

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -470,6 +470,69 @@ static void ApolloSimDebugMeasureGIFMemory(NSString *source) {
     }
 }
 
+// "scrollto Y" command support: pin the tallest on-screen scroll view (the
+// comments table on a thread) to a content offset, so a test can land on the
+// same comments every run — a synthesized flick's inertia varies run to run.
+static UIScrollView *ApolloSimDebugTallestScrollViewIn(UIView *view) {
+    UIScrollView *best = nil;
+    if ([view isKindOfClass:[UIScrollView class]] && !view.hidden && view.window) {
+        best = (UIScrollView *)view;
+    }
+    for (UIView *sub in view.subviews) {
+        UIScrollView *candidate = ApolloSimDebugTallestScrollViewIn(sub);
+        if (candidate && (!best || candidate.contentSize.height > best.contentSize.height)) {
+            best = candidate;
+        }
+    }
+    return best;
+}
+
+static void ApolloSimDebugScrollTo(CGFloat y) {
+    UIScrollView *best = nil;
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (window.hidden) continue;
+        UIScrollView *candidate = ApolloSimDebugTallestScrollViewIn(window);
+        if (candidate && (!best || candidate.contentSize.height > best.contentSize.height)) {
+            best = candidate;
+        }
+    }
+    if (!best) { ApolloLog(@"[SimDebugTap] scrollto: no scroll view"); return; }
+    CGFloat top = best.adjustedContentInset.top;
+    CGFloat maxY = MAX(-top, best.contentSize.height - best.bounds.size.height + best.adjustedContentInset.bottom);
+    CGFloat target = MIN(MAX(y - top, -top), maxY);
+    [best setContentOffset:CGPointMake(best.contentOffset.x, target) animated:NO];
+    ApolloLog(@"[SimDebugTap] scrollto %.0f -> offset %.0f (%@ content %.0f)",
+              y, target, NSStringFromClass([best class]), best.contentSize.height);
+}
+
+// "lpm on|off" command support: the simulator has no Battery settings pane,
+// so Low Power Mode can't be toggled there. Force -[NSProcessInfo
+// isLowPowerModeEnabled] instead and post the real power-state notification,
+// so the inline-GIF autoplay rules (which must ignore LPM — #634/#1004) and
+// anything else listening to the power state react exactly as on a device.
+// Swizzled by hand on the CONCRETE class of +[NSProcessInfo processInfo]
+// (swift-foundation hands back an _NSSwiftProcessInfo subclass on current
+// iOS, so a plain `%hook NSProcessInfo` never sees the call).
+static BOOL sApolloSimForceLowPowerMode = NO;
+static BOOL (*sApolloSimOrigIsLowPowerModeEnabled)(id, SEL) = NULL;
+
+static BOOL ApolloSimHookedIsLowPowerModeEnabled(id self, SEL _cmd) {
+    if (sApolloSimForceLowPowerMode) return YES;
+    return sApolloSimOrigIsLowPowerModeEnabled ? sApolloSimOrigIsLowPowerModeEnabled(self, _cmd) : NO;
+}
+
+static void ApolloSimInstallLowPowerModeOverride(void) {
+    Class cls = object_getClass(NSProcessInfo.processInfo);
+    Method m = class_getInstanceMethod(cls, @selector(isLowPowerModeEnabled));
+    if (!m) {
+        ApolloLog(@"[SimDebugTap] lpm override: no isLowPowerModeEnabled on %@", NSStringFromClass(cls));
+        return;
+    }
+    sApolloSimOrigIsLowPowerModeEnabled = (BOOL (*)(id, SEL))method_getImplementation(m);
+    method_setImplementation(m, (IMP)ApolloSimHookedIsLowPowerModeEnabled);
+    ApolloLog(@"[SimDebugTap] lpm override installed on %@", NSStringFromClass(cls));
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -508,6 +571,29 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
             [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyScrollEdgeEffectStyle];
             [[NSNotificationCenter defaultCenter] postNotificationName:ApolloScrollEdgeEffectStyleChangedNotification object:nil];
             ApolloLog(@"[SimDebugTap] headerstyle -> %ld", (long)mode);
+            return;
+        }
+        // "gifmode N" command: set Autoplay Inline GIFs (1 Never, 2 WiFi Only,
+        // 3 Always, 4 Tap to Play) through the same defaults write the settings
+        // picker makes, so the KVO reload + live refresh of on-screen GIFs run.
+        if ([contents hasPrefix:@"gifmode "]) {
+            NSInteger mode = [[contents substringFromIndex:8] integerValue];
+            [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyAutoplayInlineGIFs];
+            ApolloLog(@"[SimDebugTap] gifmode -> %ld", (long)mode);
+            return;
+        }
+        if ([contents hasPrefix:@"scrollto "]) {
+            ApolloSimDebugScrollTo([[contents substringFromIndex:9] doubleValue]);
+            return;
+        }
+        if ([contents hasPrefix:@"lpm "]) {
+            NSString *payload = [[contents substringFromIndex:4] stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            sApolloSimForceLowPowerMode = [payload isEqualToString:@"on"];
+            [[NSNotificationCenter defaultCenter] postNotificationName:NSProcessInfoPowerStateDidChangeNotification
+                                                                object:NSProcessInfo.processInfo];
+            ApolloLog(@"[SimDebugTap] lpm -> %d (isLowPowerModeEnabled=%d)",
+                      sApolloSimForceLowPowerMode, NSProcessInfo.processInfo.isLowPowerModeEnabled);
             return;
         }
         if ([contents hasPrefix:@"crash "]) {
@@ -619,6 +705,7 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
 }
 
 %ctor {
+    ApolloSimInstallLowPowerModeOverride();
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL,
         ApolloSimDebugTapNotification, CFSTR("apollofix.debugtap"), NULL,
         CFNotificationSuspensionBehaviorDeliverImmediately);


### PR DESCRIPTION
Fixes #1004, fixes #634

## What

`Autoplay Inline GIFs` had a hidden rule on top of the four modes: if the phone was in Low Power Mode, inline GIFs never autoplayed no matter what you picked, so `Always` silently behaved like `Tap to Play` for anyone whose phone lives in LPM (both issues, plus the "on and off since 3.0" reports in #1004). This drops that rule. The setting is now the whole answer:

- **Always** / **WiFi Only** keep playing in Low Power Mode (WiFi Only still needs WiFi).
- **Tap to Play** / **Never** are unchanged and remain the way to save battery.

No new toggle. If you want GIFs paused in LPM, `Tap to Play` already does exactly that.

## Why no LPM gate

- Apollo itself never checked Low Power Mode for GIFs — its only `isLowPowerModeEnabled` call is in the YouTube embed player (`YouTubePlayerController`, the "YouTube videos can't autoplay when Low Power Mode is enabled" path). Feed GIFs always autoplayed in LPM, which is the inconsistency @AcornElf noticed on #1004.
- The gate lived entirely in our `ApolloComputeShouldAutoplayInlineGIF` (an early `return NO` before the mode was even read), plus a power-state observer that only existed to re-run that veto. Both are gone; the decision log line still prints `lpm=` for diagnostics.

## Sim-only test plumbing

The simulator has no Battery pane, so `ApolloSimDebugTap.xm` (never compiled into device builds) gains `lpm on|off` (overrides `isLowPowerModeEnabled` on the concrete `_NSSwiftProcessInfo` class and posts the real power-state notification), `gifmode N` (same defaults write the settings picker makes, so the KVO reload + live refresh run), and `scrollto Y` (deterministic table offset — a synthesized flick's inertia landed somewhere different every run).

## Testing

Two screenshots 0.7s apart, counting changed pixels over a thread with two inline comment GIFs (r/Destiny `1uq0hu6`), with LPM forced on unless noted:

| shell | account | Always (LPM off) | Always | WiFi Only | Tap to Play | Never | back to Always |
|---|---|---|---|---|---|---|---|
| Liquid Glass | API key | animating | animating | animating | static + play badge | static | animating |
| Liquid Glass | API-key-free | animating | animating | animating | static + play badge | static | animating |
| non-glass | API-key-free | animating | animating | animating | static + play badge | static | animating |

The debug log confirms the decision each time (`mode=always shouldPlay=1 lpm=1`, `mode=tap-to-play shouldPlay=0 lpm=1`, `refresh … nodes=2 pause=2` / `reload=2`).

Not testable in the sim: WiFi Only on cellular (the sim is always WiFi) — that path is untouched by this change.
