### PR TITLE
Add per-account subreddit list favorites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSimDebugTap.xm \
     $(SRC_DIR)/ApolloManualSignInViewController.m \
     $(SRC_DIR)/ApolloAccountCredentials.m \
+    $(SRC_DIR)/ApolloPerAccountFavorites.m \
     $(SRC_DIR)/ApolloAccountSwitcherViewController.xm \
     $(SRC_DIR)/ApolloSignInSplash.xm \
     $(SRC_DIR)/ApolloHideSubscribePrompt.xm \

--- a/src/ApolloAccountCredentials.h
+++ b/src/ApolloAccountCredentials.h
@@ -74,6 +74,34 @@ NSString *ApolloEffectiveRedirectURI(void);
 // ([[RDKClient sharedClient] currentUser].username), or nil if none/unavailable.
 NSString * _Nullable ApolloActiveAccountUsername(void);
 
+// A persisted active-account lookup that distinguishes a real signed-out state
+// from an unreadable/transient account archive. Per-account stores must not treat
+// an unknown decode as anonymous or they can install the wrong user's data.
+typedef NS_ENUM(NSInteger, ApolloPersistedAccountIdentityStatus) {
+    ApolloPersistedAccountIdentityUnknown = 0,
+    ApolloPersistedAccountIdentitySignedOut,
+    ApolloPersistedAccountIdentitySignedIn,
+};
+ApolloPersistedAccountIdentityStatus ApolloResolvePersistedActiveAccountIdentity(
+    NSString * _Nullable * _Nullable outNormalizedUsername);
+
+// Live equivalent used from AccountManager's synchronous account-change
+// notification. Its in-memory selection changes before the defaults mirror is
+// persisted, so quick-switch consumers must prefer this signal at that point.
+ApolloPersistedAccountIdentityStatus ApolloResolveLiveActiveAccountIdentity(
+    NSString * _Nullable * _Nullable outNormalizedUsername);
+
+// Every readable, normalized username in the persisted RedditAccounts2 array.
+// Used for non-destructive first-enable migrations of per-account data.
+NSSet<NSString *> *ApolloPersistedAccountUsernames(void);
+
+// Status-bearing variant. YES means the full persisted account array was
+// decoded and every entry had a usable username (an empty array is valid).
+// NO means callers must defer a migration instead of treating the account set
+// as empty and committing an incomplete store.
+BOOL ApolloResolvePersistedAccountUsernames(
+    NSSet<NSString *> * _Nullable * _Nullable outUsernames);
+
 // Invalidate the cached active username after either side of Apollo's persisted
 // account selection changes. Tweak.xm calls this from narrowly-scoped
 // NSUserDefaults write hooks for RedditAccounts2 / CurrentRedditAccountIndex.

--- a/src/ApolloAccountCredentials.m
+++ b/src/ApolloAccountCredentials.m
@@ -8,6 +8,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <os/lock.h>
+#import <malloc/malloc.h>
 #include <string.h>
 
 @implementation ApolloAccountCredentialEntry
@@ -183,23 +184,48 @@ static BOOL ApolloPublishActiveUsernameCache(NSString *username, uint64_t genera
 // Keep every assumption guarded. If a future Apollo/Swift runtime changes the
 // layout, this returns nil and callers fail closed instead of messaging an
 // invalid pointer.
-id ApolloActiveAccountClient(void) {
+static BOOL ApolloAccountIvarRangeFitsClass(Class cls, Ivar ivar, size_t length) {
+    if (!cls || !ivar) return NO;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    size_t instanceSize = class_getInstanceSize(cls);
+    return offset >= 0 && (size_t)offset <= instanceSize &&
+        length <= instanceSize - (size_t)offset;
+}
+
+static BOOL ApolloAccountLooksLikeHeapPointer(uintptr_t address) {
+    // Apollo is 64-bit-only. Reject nil/small/tagged/non-canonical values before
+    // passing a private Swift word to malloc or Objective-C runtime helpers.
+    return address >= 0x100000000ULL &&
+        (address & (sizeof(uintptr_t) - 1)) == 0 &&
+        (address & 0xF000000000000000ULL) == 0;
+}
+
+static ApolloPersistedAccountIdentityStatus ApolloResolveLiveAccountClient(id *outClient) {
+    if (outClient) *outClient = nil;
     // Main-thread only. The walk below reads AccountManager's live Swift array
     // buffer without a retain; a concurrent reassignment of `accounts` on
     // another thread would free the storage between our reads (use-after-free).
     // Every caller today is a main-thread UI action (the follow-button tap); this
     // fails closed rather than trusting a future off-main caller not to exist.
-    if (![NSThread isMainThread]) return nil;
+    if (![NSThread isMainThread]) return ApolloPersistedAccountIdentityUnknown;
 
     Class managerClass = objc_getClass("_TtC6Apollo14AccountManager");
     SEL sharedSelector = NSSelectorFromString(@"shared");
-    if (!managerClass || ![managerClass respondsToSelector:sharedSelector]) return nil;
+    if (!managerClass || ![managerClass respondsToSelector:sharedSelector]) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
 
     id manager = ((id (*)(id, SEL))objc_msgSend)(managerClass, sharedSelector);
-    if (!manager) return nil;
+    if (!manager || object_getClass(manager) != managerClass) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
     Ivar accountsIvar = class_getInstanceVariable(managerClass, "accounts");
     Ivar currentIndexIvar = class_getInstanceVariable(managerClass, "currentAccountIndex");
-    if (!accountsIvar || !currentIndexIvar) return nil;
+    if (!ApolloAccountIvarRangeFitsClass(managerClass, accountsIvar, sizeof(uintptr_t)) ||
+        !ApolloAccountIvarRangeFitsClass(managerClass, currentIndexIvar,
+                                         sizeof(NSInteger) + sizeof(uint8_t))) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
 
     // Hopper: Optional<Int> is stored as the Int word followed by an
     // extra-inhabitant byte; bit 0 set at +8 means nil. This is the same check
@@ -210,7 +236,8 @@ id ApolloActiveAccountClient(void) {
     ptrdiff_t currentIndexOffset = ivar_getOffset(currentIndexIvar);
     memcpy(&index, managerBytes + currentIndexOffset, sizeof(index));
     memcpy(&indexIsNil, managerBytes + currentIndexOffset + sizeof(NSInteger), sizeof(indexIsNil));
-    if ((indexIsNil & 0x1) != 0 || index < 0) return nil;
+    if ((indexIsNil & 0x1) != 0) return ApolloPersistedAccountIdentitySignedOut;
+    if (index < 0) return ApolloPersistedAccountIdentityUnknown;
 
     uintptr_t storageWord = 0;
     memcpy(&storageWord, managerBytes + ivar_getOffset(accountsIvar), sizeof(storageWord));
@@ -220,27 +247,71 @@ id ApolloActiveAccountClient(void) {
     // tagged-pointer top bit). object_getClass on such a word dereferences a
     // non-canonical pointer → crash. If `accounts` is ever backed by a bridged
     // NSArray, bail instead of masking-and-dereferencing.
-    if (storageWord & 0xF000000000000000ULL) return nil;
-    void *storage = (void *)(storageWord & ~(uintptr_t)0x7);
-    if (!storage) return nil;
+    uintptr_t storageAddress = storageWord & ~(uintptr_t)0x7;
+    if (!ApolloAccountLooksLikeHeapPointer(storageAddress)) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
+    void *storage = (void *)storageAddress;
+    size_t storageSize = malloc_size(storage);
+    const size_t storageHeaderSize = 4 * sizeof(uintptr_t);
+    if (storageSize < storageHeaderSize) return ApolloPersistedAccountIdentityUnknown;
     Class storageClass = object_getClass((__bridge id)storage);
     const char *storageClassName = storageClass ? class_getName(storageClass) : NULL;
-    if (!storageClassName || strstr(storageClassName, "ContiguousArrayStorage") == NULL) return nil;
+    if (!storageClassName || strstr(storageClassName, "ContiguousArrayStorage") == NULL) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
 
     uintptr_t count = 0;
     memcpy(&count, (uint8_t *)storage + (2 * sizeof(uintptr_t)), sizeof(count));
-    if (count == 0 || count > 64) return nil;
+    if (count == 0 || count > 64) return ApolloPersistedAccountIdentityUnknown;
+    if (count > (storageSize - storageHeaderSize) / sizeof(uintptr_t)) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
 
-    if ((uintptr_t)index >= count) return nil;
+    if ((uintptr_t)index >= count) return ApolloPersistedAccountIdentityUnknown;
 
-    void *rawClient = NULL;
+    uintptr_t rawClientAddress = 0;
     size_t elementOffset = (4 + (NSUInteger)index) * sizeof(uintptr_t);
-    memcpy(&rawClient, (uint8_t *)storage + elementOffset, sizeof(rawClient));
-    if (!rawClient) return nil;
-    id client = (__bridge id)rawClient;
+    memcpy(&rawClientAddress, (uint8_t *)storage + elementOffset, sizeof(rawClientAddress));
+    if (!ApolloAccountLooksLikeHeapPointer(rawClientAddress)) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
     Class clientClass = objc_getClass("RDKClient");
-    if (!clientClass || ![client isMemberOfClass:clientClass]) return nil;
-    return client;
+    if (!clientClass) return ApolloPersistedAccountIdentityUnknown;
+    void *rawClient = (void *)rawClientAddress;
+    if (malloc_size(rawClient) < class_getInstanceSize(clientClass) ||
+        object_getClass((__bridge id)rawClient) != clientClass) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
+    id client = (__bridge id)rawClient;
+    if (outClient) *outClient = client;
+    return ApolloPersistedAccountIdentitySignedIn;
+}
+
+id ApolloActiveAccountClient(void) {
+    id client = nil;
+    return ApolloResolveLiveAccountClient(&client) == ApolloPersistedAccountIdentitySignedIn
+        ? client : nil;
+}
+
+ApolloPersistedAccountIdentityStatus ApolloResolveLiveActiveAccountIdentity(
+    NSString **outNormalizedUsername) {
+    if (outNormalizedUsername) *outNormalizedUsername = nil;
+    id client = nil;
+    ApolloPersistedAccountIdentityStatus status = ApolloResolveLiveAccountClient(&client);
+    if (status != ApolloPersistedAccountIdentitySignedIn) return status;
+
+    NSString *username = nil;
+    @try {
+        id user = [client valueForKey:@"currentUser"];
+        id value = user ? [user valueForKey:@"username"] : nil;
+        if ([value isKindOfClass:[NSString class]]) username = ApolloNormalizeUsername(value);
+    } @catch (__unused NSException *e) {
+        username = nil;
+    }
+    if (username.length == 0) return ApolloPersistedAccountIdentityUnknown;
+    if (outNormalizedUsername) *outNormalizedUsername = username;
+    return ApolloPersistedAccountIdentitySignedIn;
 }
 
 static id ApolloAccountCredsUnarchive(NSData *data) {
@@ -254,6 +325,49 @@ static id ApolloAccountCredsUnarchive(NSData *data) {
     @catch (__unused NSException *ex) { obj = nil; }
     [u finishDecoding];
     return obj;
+}
+
+ApolloPersistedAccountIdentityStatus ApolloResolvePersistedActiveAccountIdentity(
+    NSString **outNormalizedUsername) {
+    if (outNormalizedUsername) *outNormalizedUsername = nil;
+
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
+    id archive = [group objectForKey:@"RedditAccounts2"];
+    // The keychain is AccountManager's authoritative launch source. A missing
+    // defaults mirror can therefore mean "not loaded yet", not signed out.
+    // Only a successfully decoded empty array confirms the anonymous state.
+    if (!archive) return ApolloPersistedAccountIdentityUnknown;
+
+    id decoded = ApolloAccountCredsUnarchive(archive);
+    if (![decoded isKindOfClass:[NSArray class]]) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
+
+    NSArray *accounts = (NSArray *)decoded;
+    if (accounts.count == 0) return ApolloPersistedAccountIdentitySignedOut;
+
+    // AccountManager treats an absent persisted selection as the first account
+    // while loading. Once present, the value must still address this exact array.
+    id indexValue = [group objectForKey:@"CurrentRedditAccountIndex"];
+    if (indexValue && ![indexValue respondsToSelector:@selector(integerValue)]) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
+    NSInteger index = indexValue ? [indexValue integerValue] : 0;
+    if (index < 0 || (NSUInteger)index >= accounts.count) {
+        return ApolloPersistedAccountIdentityUnknown;
+    }
+
+    NSString *username = nil;
+    @try {
+        id user = [accounts[(NSUInteger)index] valueForKey:@"currentUser"];
+        id value = user ? [user valueForKey:@"username"] : nil;
+        if ([value isKindOfClass:[NSString class]]) username = ApolloNormalizeUsername(value);
+    } @catch (__unused NSException *e) {
+        username = nil;
+    }
+    if (username.length == 0) return ApolloPersistedAccountIdentityUnknown;
+    if (outNormalizedUsername) *outNormalizedUsername = username;
+    return ApolloPersistedAccountIdentitySignedIn;
 }
 
 static BOOL ApolloLogIfUsernameResultChanged(NSString *newResult) {
@@ -397,7 +511,32 @@ void ApolloPersistedAccountStats(NSInteger *outCount, NSInteger *outWithUser) {
 }
 
 // All lowercased usernames currently in the persisted RedditAccounts2 blob.
-static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
+BOOL ApolloResolvePersistedAccountUsernames(NSSet<NSString *> **outUsernames) {
+    if (outUsernames) *outUsernames = nil;
+    NSMutableSet<NSString *> *names = [NSMutableSet set];
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
+    id archive = [group objectForKey:@"RedditAccounts2"];
+    if (!archive) return NO;
+    id accounts = ApolloAccountCredsUnarchive(archive);
+    if (![accounts isKindOfClass:[NSArray class]]) return NO;
+    for (id client in (NSArray *)accounts) {
+        NSString *username = nil;
+        @try { username = [[client valueForKey:@"currentUser"] valueForKey:@"username"]; }
+        @catch (__unused NSException *e) { return NO; }
+        if (![username isKindOfClass:[NSString class]]) return NO;
+        NSString *normalized = ApolloNormalizeUsername(username);
+        if (normalized.length == 0) return NO;
+        [names addObject:normalized];
+    }
+    if (outUsernames) *outUsernames = [names copy];
+    return YES;
+}
+
+NSSet<NSString *> *ApolloPersistedAccountUsernames(void) {
+    // OAuth sign-in tracking is intentionally best-effort: poison repair can
+    // leave one client without currentUser while every healthy identity still
+    // needs to count as pre-existing. Favorites migration uses the strict,
+    // status-bearing helper above instead.
     NSMutableSet<NSString *> *names = [NSMutableSet set];
     NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
     id accounts = ApolloAccountCredsUnarchive([group objectForKey:@"RedditAccounts2"]);
@@ -406,9 +545,9 @@ static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
         NSString *username = nil;
         @try { username = [[client valueForKey:@"currentUser"] valueForKey:@"username"]; }
         @catch (__unused NSException *e) { continue; }
-        if ([username isKindOfClass:[NSString class]] && username.length > 0) {
-            [names addObject:ApolloNormalizeUsername(username)];
-        }
+        if (![username isKindOfClass:[NSString class]]) continue;
+        NSString *normalized = ApolloNormalizeUsername(username);
+        if (normalized.length > 0) [names addObject:normalized];
     }
     return names;
 }
@@ -416,7 +555,7 @@ static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
 void ApolloNoteInteractiveOAuthSignIn(void) {
     // Snapshot BEFORE arming: the decode below fires the hooked setters
     // itself, and they must observe the flag as still disarmed.
-    NSMutableSet<NSString *> *preexisting = [ApolloAllPersistedAccountUsernames() mutableCopy];
+    NSMutableSet<NSString *> *preexisting = [ApolloPersistedAccountUsernames() mutableCopy];
     [preexisting unionSet:ApolloWebSessionUsernames()];
     NSSet<NSString *> *preexistingSnapshot = [preexisting copy];
     NS_VALID_UNTIL_END_OF_SCOPE NSSet<NSString *> *retiredPreexisting = nil;

--- a/src/ApolloPerAccountFavorites.h
+++ b/src/ApolloPerAccountFavorites.h
@@ -1,0 +1,42 @@
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Starts the account/favorites notification observers and installs the active
+// projection when the opt-in setting was enabled on a previous launch.
+void ApolloPerAccountFavoritesStart(void);
+
+typedef NS_ENUM(NSInteger, ApolloPerAccountFavoritesSetResult) {
+    ApolloPerAccountFavoritesSetResultApplied = 0,
+    ApolloPerAccountFavoritesSetResultIdentityUnavailable,
+    ApolloPerAccountFavoritesSetResultInvalidStore,
+    ApolloPerAccountFavoritesSetResultUnsupportedStore,
+};
+
+// Live settings transition. First enable clones Apollo's legacy shared list to
+// every existing account; later re-enables resume the saved account scopes. A
+// failed enable leaves the setting off and Apollo's native favorites untouched.
+ApolloPerAccountFavoritesSetResult ApolloPerAccountFavoritesSetEnabled(BOOL enabled);
+
+// Narrow integration points called after Apollo writes account selection state
+// or its native FavoriteSubreddits key. Both are idempotent and main-queue safe.
+void ApolloPerAccountFavoritesAccountStateDidChange(void);
+void ApolloPerAccountFavoritesAccountsCollectionDidChange(void);
+void ApolloPerAccountFavoritesLiveAccountStateDidChange(void);
+void ApolloPerAccountFavoritesNativeFavoritesDidChange(void);
+
+// Returns one coherent snapshot of the feature flag, Apollo's native favorites
+// key, and the account-bucket envelope for backup. A nil result means account
+// identity is mid-transition and the backup should fail safely and be retried.
+NSDictionary<NSString *, id> *ApolloPerAccountFavoritesCopyBackupPreferenceValues(void);
+
+// Backup restore replays defaults keys one at a time and force-exits afterward.
+// Suspend all projection/snapshot reactions first so unordered replay cannot
+// write a restored list into the pre-restore account's bucket.
+void ApolloPerAccountFavoritesSuspendForPreferencesRestore(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloPerAccountFavorites.m
+++ b/src/ApolloPerAccountFavorites.m
@@ -1,7 +1,12 @@
 #import "ApolloPerAccountFavorites.h"
 
 #import "ApolloAccountCredentials.h"
+#ifdef APOLLO_PER_ACCOUNT_FAVORITES_TESTING
+// Keep the state-machine regression harness Foundation-only on the build host.
+#define ApolloLog(fmt, ...) NSLog((fmt), ##__VA_ARGS__)
+#else
 #import "ApolloCommon.h"
+#endif
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 
@@ -11,6 +16,7 @@ static NSString *const kApolloPerAccountFavoritesVersionKey = @"version";
 static NSString *const kApolloPerAccountFavoritesBucketsKey = @"buckets";
 static NSString *const kApolloPerAccountFavoritesAnonymousIdentity = @"anonymous";
 static NSString *const kApolloPerAccountFavoritesSharedIdentity = @"shared";
+static NSString *const kApolloPerAccountFavoritesProjectionRefreshKey = @"ApolloPerAccountFavoritesProjectionRefresh";
 static const NSInteger kApolloPerAccountFavoritesStoreVersion = 1;
 
 typedef NS_ENUM(NSInteger, ApolloPerAccountFavoritesStoreStatus) {
@@ -300,7 +306,9 @@ static void ApolloPerAccountFavoritesScheduleNativeRefresh(void) {
         sApolloPerAccountFavoritesRefreshScheduled = NO;
         if (sApolloPerAccountFavoritesSuspendedForRestore) return;
         [[NSNotificationCenter defaultCenter]
-            postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+            postNotificationName:ApolloFavoriteSubredditsUpdatedNotification
+                          object:nil
+                        userInfo:@{ kApolloPerAccountFavoritesProjectionRefreshKey: @YES }];
     });
 }
 
@@ -876,7 +884,12 @@ void ApolloPerAccountFavoritesStart(void) {
         addObserverForName:ApolloFavoriteSubredditsUpdatedNotification
                     object:nil
                      queue:[NSOperationQueue mainQueue]
-                usingBlock:^(__unused NSNotification *note) {
+                usingBlock:^(NSNotification *note) {
+        // A queued projection refresh is not a native edit. In particular, it
+        // must not mark the outgoing list as mutated if identity became unknown
+        // before delivery. Filter only this observer callback: a genuine native
+        // defaults write from another observer must still be captured.
+        if ([note.userInfo[kApolloPerAccountFavoritesProjectionRefreshKey] isEqual:@YES]) return;
         ApolloPerAccountFavoritesNativeFavoritesDidChange();
     }];
 

--- a/src/ApolloPerAccountFavorites.m
+++ b/src/ApolloPerAccountFavorites.m
@@ -1,0 +1,930 @@
+#import "ApolloPerAccountFavorites.h"
+
+#import "ApolloAccountCredentials.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+#include <math.h>
+
+static NSString *const kApolloPerAccountFavoritesVersionKey = @"version";
+static NSString *const kApolloPerAccountFavoritesBucketsKey = @"buckets";
+static NSString *const kApolloPerAccountFavoritesAnonymousIdentity = @"anonymous";
+static NSString *const kApolloPerAccountFavoritesSharedIdentity = @"shared";
+static const NSInteger kApolloPerAccountFavoritesStoreVersion = 1;
+
+typedef NS_ENUM(NSInteger, ApolloPerAccountFavoritesStoreStatus) {
+    ApolloPerAccountFavoritesStoreMissing = 0,
+    ApolloPerAccountFavoritesStoreReady,
+    ApolloPerAccountFavoritesStoreInvalid,
+    ApolloPerAccountFavoritesStoreUnsupported,
+};
+
+// All mutable state below is main-thread confined. NSUserDefaults writes made
+// off-main are marshalled back before touching it; account switching itself is
+// a UI action and therefore takes the synchronous main-thread path.
+static BOOL sApolloPerAccountFavoritesStarted = NO;
+static BOOL sApolloPerAccountFavoritesInstallingProjection = NO;
+static BOOL sApolloPerAccountFavoritesRefreshScheduled = NO;
+static BOOL sApolloPerAccountFavoritesRetryScheduled = NO;
+static BOOL sApolloPerAccountFavoritesIdentityUnknown = NO;
+static BOOL sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+static BOOL sApolloPerAccountFavoritesSuspendedForRestore = NO;
+static BOOL sApolloPerAccountFavoritesStoreErrorLogged = NO;
+static BOOL sApolloPerAccountFavoritesRetryExhaustionLogged = NO;
+static NSUInteger sApolloPerAccountFavoritesRetryAttempt = 0;
+// Logical cancellation token for dispatch_after retries. An authoritative
+// account resolution advances it so an already-queued retry cannot later
+// project a stale defaults identity over the newly selected live account.
+static NSUInteger sApolloPerAccountFavoritesRetryGeneration = 1;
+static NSString *sApolloPerAccountFavoritesMaterializedIdentity = nil;
+
+static NSArray<NSString *> *ApolloPerAccountFavoritesSanitizeNativeArray(id raw) {
+    if (![raw isKindOfClass:[NSArray class]]) return nil;
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:[(NSArray *)raw count]];
+    for (id value in (NSArray *)raw) {
+        if ([value isKindOfClass:[NSString class]]) [result addObject:value];
+    }
+    return [result copy];
+}
+
+// Stored buckets are stricter than Apollo's live list. Silently dropping a
+// malformed value would make an existing account look new and replace its only
+// recoverable projection with an empty list. Reject the whole envelope instead.
+static NSArray<NSString *> *ApolloPerAccountFavoritesValidateStoredArray(id raw) {
+    if (![raw isKindOfClass:[NSArray class]]) return nil;
+    for (id value in (NSArray *)raw) {
+        if (![value isKindOfClass:[NSString class]]) return nil;
+    }
+    return [(NSArray *)raw copy];
+}
+
+static NSArray<NSString *> *ApolloPerAccountFavoritesNativeList(void) {
+    id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyApolloFavoriteSubreddits];
+    return ApolloPerAccountFavoritesSanitizeNativeArray(raw) ?: @[];
+}
+
+static BOOL ApolloPerAccountFavoritesReadStoreVersion(id raw, NSInteger *outVersion) {
+    if (![raw isKindOfClass:[NSNumber class]] ||
+        CFGetTypeID((__bridge CFTypeRef)raw) == CFBooleanGetTypeID()) {
+        return NO;
+    }
+
+    NSNumber *number = (NSNumber *)raw;
+    if (!isfinite(number.doubleValue)) return NO;
+    NSInteger version = number.integerValue;
+    // NSNumber's integerValue truncates fractions. Compare the original value
+    // back to the converted integer so 1.5 cannot be mistaken for schema v1.
+    if ([number compare:@(version)] != NSOrderedSame) return NO;
+    if (outVersion) *outVersion = version;
+    return YES;
+}
+
+static ApolloPerAccountFavoritesStoreStatus ApolloPerAccountFavoritesLoadBuckets(
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> **outBuckets) {
+    if (outBuckets) *outBuckets = nil;
+    id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyPerAccountFavoriteSubreddits];
+    if (!raw) return ApolloPerAccountFavoritesStoreMissing;
+    if (![raw isKindOfClass:[NSDictionary class]]) return ApolloPerAccountFavoritesStoreInvalid;
+
+    id rawVersion = raw[kApolloPerAccountFavoritesVersionKey];
+    NSInteger version = 0;
+    if (!ApolloPerAccountFavoritesReadStoreVersion(rawVersion, &version)) {
+        return ApolloPerAccountFavoritesStoreInvalid;
+    }
+    if (version > kApolloPerAccountFavoritesStoreVersion) {
+        return ApolloPerAccountFavoritesStoreUnsupported;
+    }
+    id rawBuckets = raw[kApolloPerAccountFavoritesBucketsKey];
+    if (version != kApolloPerAccountFavoritesStoreVersion ||
+        ![rawBuckets isKindOfClass:[NSDictionary class]]) {
+        return ApolloPerAccountFavoritesStoreInvalid;
+    }
+
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = [NSMutableDictionary dictionary];
+    __block BOOL valid = YES;
+    [(NSDictionary *)rawBuckets enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        NSArray<NSString *> *favorites = ApolloPerAccountFavoritesValidateStoredArray(value);
+        if (![key isKindOfClass:[NSString class]] || [(NSString *)key length] == 0 || !favorites) {
+            valid = NO;
+            *stop = YES;
+            return;
+        }
+        buckets[key] = favorites;
+    }];
+    // Every v1 initializer writes the anonymous sentinel, even when no user is
+    // signed in. Its absence means this is not a complete v1 store; accepting
+    // an empty/partial dictionary as Ready could replace a nonempty native list
+    // with a newly synthesized empty account bucket.
+    if (!valid || !buckets[kApolloPerAccountFavoritesAnonymousIdentity]) {
+        return ApolloPerAccountFavoritesStoreInvalid;
+    }
+    if (outBuckets) *outBuckets = buckets;
+    return ApolloPerAccountFavoritesStoreReady;
+}
+
+static NSDictionary *ApolloPerAccountFavoritesEnvelopeForBuckets(
+    NSDictionary<NSString *, NSArray<NSString *> *> *buckets) {
+    return @{
+        kApolloPerAccountFavoritesVersionKey: @(kApolloPerAccountFavoritesStoreVersion),
+        kApolloPerAccountFavoritesBucketsKey: buckets ?: @{},
+    };
+}
+
+static void ApolloPerAccountFavoritesSaveBuckets(
+    NSDictionary<NSString *, NSArray<NSString *> *> *buckets) {
+    NSDictionary *envelope = ApolloPerAccountFavoritesEnvelopeForBuckets(buckets);
+    [[NSUserDefaults standardUserDefaults] setObject:envelope
+                                             forKey:UDKeyPerAccountFavoriteSubreddits];
+}
+
+static NSString *ApolloPerAccountFavoritesUserIdentity(NSString *normalizedUsername) {
+    return normalizedUsername.length > 0 ? [@"u:" stringByAppendingString:normalizedUsername] : nil;
+}
+
+static NSString *ApolloPerAccountFavoritesIdentityForStatus(
+    ApolloPersistedAccountIdentityStatus status, NSString *username) {
+    if (status == ApolloPersistedAccountIdentitySignedIn) {
+        return ApolloPerAccountFavoritesUserIdentity(username);
+    }
+    if (status == ApolloPersistedAccountIdentitySignedOut) {
+        return kApolloPerAccountFavoritesAnonymousIdentity;
+    }
+    return nil;
+}
+
+// nil means identity could not be decoded safely. "anonymous" is returned only
+// for a confirmed empty persisted account array, never for a missing/corrupt
+// mirror that AccountManager may still populate from its authoritative keychain.
+static NSString *ApolloPerAccountFavoritesPersistedIdentity(void) {
+    NSString *username = nil;
+    ApolloPersistedAccountIdentityStatus status =
+        ApolloResolvePersistedActiveAccountIdentity(&username);
+    return ApolloPerAccountFavoritesIdentityForStatus(status, username);
+}
+
+// Called only at AccountManager's account-change notification boundary, after
+// its in-memory index changes but before its defaults mirror is written.
+static NSString *ApolloPerAccountFavoritesLiveIdentity(void) {
+    NSString *username = nil;
+    ApolloPersistedAccountIdentityStatus status =
+        ApolloResolveLiveActiveAccountIdentity(&username);
+    if (status == ApolloPersistedAccountIdentitySignedOut) {
+        // AccountManager's Optional<Int> is also nil briefly while its
+        // keychain-backed accounts are loading. Only the decoded empty mirror
+        // distinguishes a real signed-out state from that transient nil.
+        return [ApolloPerAccountFavoritesPersistedIdentity()
+            isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity]
+            ? kApolloPerAccountFavoritesAnonymousIdentity : nil;
+    }
+    return ApolloPerAccountFavoritesIdentityForStatus(status, username);
+}
+
+static void ApolloPerAccountFavoritesLogStoreFailure(
+    ApolloPerAccountFavoritesStoreStatus status) {
+    if (sApolloPerAccountFavoritesStoreErrorLogged) return;
+    sApolloPerAccountFavoritesStoreErrorLogged = YES;
+    if (status == ApolloPerAccountFavoritesStoreUnsupported) {
+        ApolloLog(@"[PerAccountFavorites] newer favorites store version found; leaving it untouched");
+    } else {
+        ApolloLog(@"[PerAccountFavorites] invalid favorites store found; leaving it and the native list untouched");
+    }
+}
+
+static void ApolloPerAccountFavoritesCancelIdentityRetries(void);
+
+static void ApolloPerAccountFavoritesFailClosedForStoreStatus(
+    ApolloPerAccountFavoritesStoreStatus status) {
+    if (status != ApolloPerAccountFavoritesStoreInvalid &&
+        status != ApolloPerAccountFavoritesStoreUnsupported) return;
+
+    // Never repair or replace an envelope whose schema we cannot trust. The
+    // opt-in setting returns to OFF, while both that envelope and Apollo's
+    // currently visible native list stay byte-for-byte under their own keys.
+    ApolloPerAccountFavoritesLogStoreFailure(status);
+    sPerAccountFavoritesEnabled = NO;
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyPerAccountFavoritesEnabled];
+    sApolloPerAccountFavoritesMaterializedIdentity = nil;
+    sApolloPerAccountFavoritesIdentityUnknown = NO;
+    sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+    ApolloPerAccountFavoritesCancelIdentityRetries();
+    ApolloLog(@"[PerAccountFavorites] disabled because the favorites store cannot be read safely");
+}
+
+static ApolloPerAccountFavoritesSetResult ApolloPerAccountFavoritesSetResultForStoreStatus(
+    ApolloPerAccountFavoritesStoreStatus status) {
+    return status == ApolloPerAccountFavoritesStoreUnsupported
+        ? ApolloPerAccountFavoritesSetResultUnsupportedStore
+        : ApolloPerAccountFavoritesSetResultInvalidStore;
+}
+
+static NSMutableDictionary<NSString *, NSArray<NSString *> *> *
+ApolloPerAccountFavoritesCreateInitialBuckets(NSString *activeIdentity) {
+    NSSet<NSString *> *usernames = nil;
+    if (activeIdentity.length == 0) return nil;
+    if (!ApolloResolvePersistedAccountUsernames(&usernames)) {
+        // Do not initialize an anonymous-only store from AccountManager's nil
+        // index alone: that same state appears before its saved accounts load.
+        // A decoded persisted array (including a confirmed empty one) is the
+        // migration boundary that proves the full account set is known.
+        return nil;
+    }
+
+    NSArray<NSString *> *legacy = ApolloPerAccountFavoritesNativeList();
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = [NSMutableDictionary dictionary];
+
+    // Clone rather than move: every existing account starts exactly as the old
+    // shared list looked, so the first quick switch cannot resemble data loss.
+    for (NSString *username in usernames) {
+        NSString *identity = ApolloPerAccountFavoritesUserIdentity(username);
+        if (identity) buckets[identity] = legacy;
+    }
+    buckets[kApolloPerAccountFavoritesAnonymousIdentity] = legacy;
+    // Keep Apollo's ordinary feature-off list as its own scope. It is not
+    // assigned to an account on re-enable, but it returns the next time this
+    // mode is disabled, so favorites changed while off are never erased.
+    buckets[kApolloPerAccountFavoritesSharedIdentity] = legacy;
+    buckets[activeIdentity] = legacy;
+    ApolloPerAccountFavoritesSaveBuckets(buckets);
+    ApolloLog(@"[PerAccountFavorites] initialized %lu favorite scope(s) from the shared list (%lu items)",
+              (unsigned long)buckets.count, (unsigned long)legacy.count);
+    return buckets;
+}
+
+static NSMutableDictionary<NSString *, NSArray<NSString *> *> *
+ApolloPerAccountFavoritesBucketsForIdentity(NSString *activeIdentity,
+                                             BOOL *outCreated,
+                                             BOOL *outRetryable,
+                                             ApolloPerAccountFavoritesStoreStatus *outStatus) {
+    if (outCreated) *outCreated = NO;
+    if (outRetryable) *outRetryable = NO;
+
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = nil;
+    ApolloPerAccountFavoritesStoreStatus status = ApolloPerAccountFavoritesLoadBuckets(&buckets);
+    if (outStatus) *outStatus = status;
+    if (status == ApolloPerAccountFavoritesStoreReady) return buckets;
+    if (status == ApolloPerAccountFavoritesStoreInvalid ||
+        status == ApolloPerAccountFavoritesStoreUnsupported) {
+        ApolloPerAccountFavoritesLogStoreFailure(status);
+        return nil;
+    }
+
+    buckets = ApolloPerAccountFavoritesCreateInitialBuckets(activeIdentity);
+    if (!buckets) {
+        if (outRetryable) *outRetryable = YES;
+        return nil;
+    }
+    if (outCreated) *outCreated = YES;
+    return buckets;
+}
+
+static BOOL ApolloPerAccountFavoritesInstallNativeList(NSArray<NSString *> *favorites) {
+    NSArray<NSString *> *safeFavorites = ApolloPerAccountFavoritesSanitizeNativeArray(favorites) ?: @[];
+    if ([ApolloPerAccountFavoritesNativeList() isEqualToArray:safeFavorites]) return NO;
+
+    sApolloPerAccountFavoritesInstallingProjection = YES;
+    @try {
+        [[NSUserDefaults standardUserDefaults] setObject:safeFavorites
+                                                 forKey:UDKeyApolloFavoriteSubreddits];
+    } @finally {
+        sApolloPerAccountFavoritesInstallingProjection = NO;
+    }
+    return YES;
+}
+
+static void ApolloPerAccountFavoritesScheduleNativeRefresh(void) {
+    if (sApolloPerAccountFavoritesRefreshScheduled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    sApolloPerAccountFavoritesRefreshScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        sApolloPerAccountFavoritesRefreshScheduled = NO;
+        if (sApolloPerAccountFavoritesSuspendedForRestore) return;
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    });
+}
+
+static void ApolloPerAccountFavoritesSnapshotMaterializedList(void) {
+    if (!sPerAccountFavoritesEnabled || sApolloPerAccountFavoritesInstallingProjection ||
+        sApolloPerAccountFavoritesSuspendedForRestore ||
+        sApolloPerAccountFavoritesIdentityUnknown ||
+        sApolloPerAccountFavoritesMaterializedIdentity.length == 0) return;
+
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = nil;
+    ApolloPerAccountFavoritesStoreStatus status = ApolloPerAccountFavoritesLoadBuckets(&buckets);
+    if (status != ApolloPerAccountFavoritesStoreReady) {
+        if (status == ApolloPerAccountFavoritesStoreInvalid ||
+            status == ApolloPerAccountFavoritesStoreUnsupported) {
+            ApolloPerAccountFavoritesFailClosedForStoreStatus(status);
+        }
+        return;
+    }
+
+    NSArray<NSString *> *favorites = ApolloPerAccountFavoritesNativeList();
+    if ([buckets[sApolloPerAccountFavoritesMaterializedIdentity] isEqualToArray:favorites]) return;
+    buckets[sApolloPerAccountFavoritesMaterializedIdentity] = favorites;
+    ApolloPerAccountFavoritesSaveBuckets(buckets);
+}
+
+static void ApolloPerAccountFavoritesReconcilePersisted(NSString *reason,
+                                                         BOOL mayRetry,
+                                                         BOOL authoritative);
+static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentity,
+                                                        NSString *reason,
+                                                        BOOL mayRetry,
+                                                        BOOL authoritative);
+
+static void ApolloPerAccountFavoritesCancelIdentityRetries(void) {
+    sApolloPerAccountFavoritesRetryGeneration++;
+    sApolloPerAccountFavoritesRetryScheduled = NO;
+    sApolloPerAccountFavoritesRetryAttempt = 0;
+    sApolloPerAccountFavoritesRetryExhaustionLogged = NO;
+}
+
+static void ApolloPerAccountFavoritesBeginIdentityRetryBurst(void) {
+    // A real account signal is new evidence. Re-open the bounded retry window
+    // and invalidate any delayed callback from an older transition.
+    sApolloPerAccountFavoritesRetryGeneration++;
+    sApolloPerAccountFavoritesRetryScheduled = NO;
+    sApolloPerAccountFavoritesRetryAttempt = 0;
+    sApolloPerAccountFavoritesRetryExhaustionLogged = NO;
+}
+
+static void ApolloPerAccountFavoritesRetryIdentity(NSString *reason) {
+    // AccountManager is authoritative during quick switching. Its in-memory
+    // selection changes before CurrentRedditAccountIndex is persisted, so a
+    // timer must never prefer an older defaults mirror when live state can be
+    // read. Persisted state is a safe startup fallback only before any account
+    // projection has been materialized.
+    NSString *liveIdentity = ApolloPerAccountFavoritesLiveIdentity();
+    if ([liveIdentity hasPrefix:@"u:"] ||
+        (liveIdentity.length > 0 &&
+         sApolloPerAccountFavoritesMaterializedIdentity.length > 0)) {
+        ApolloPerAccountFavoritesReconcileIdentity(liveIdentity, reason, YES, YES);
+        return;
+    }
+    if (sApolloPerAccountFavoritesMaterializedIdentity.length == 0) {
+        // A nil live currentAccountIndex is also what AccountManager exposes
+        // before it has loaded its keychain-backed accounts. On launch, do not
+        // mistake that transient state for a genuinely signed-out user and
+        // perform an incomplete first migration. Persisted confirmed-empty is
+        // the only authoritative anonymous signal before the first projection.
+        if ([liveIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity]) {
+            NSString *persistedIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+            if ([persistedIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity]) {
+                ApolloPerAccountFavoritesReconcileIdentity(liveIdentity, reason, YES, YES);
+            } else {
+                ApolloPerAccountFavoritesReconcileIdentity(nil, reason, YES, NO);
+            }
+            return;
+        }
+        ApolloPerAccountFavoritesReconcilePersisted(reason, YES, NO);
+        return;
+    }
+    ApolloPerAccountFavoritesReconcileIdentity(nil, reason, YES, NO);
+}
+
+static void ApolloPerAccountFavoritesScheduleIdentityRetry(NSString *reason) {
+    static const NSTimeInterval delays[] = { 0.15, 0.5, 1.5, 5.0 };
+    NSUInteger delayCount = sizeof(delays) / sizeof(delays[0]);
+    if (sApolloPerAccountFavoritesRetryScheduled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    if (sApolloPerAccountFavoritesRetryAttempt >= delayCount) {
+        if (!sApolloPerAccountFavoritesRetryExhaustionLogged) {
+            sApolloPerAccountFavoritesRetryExhaustionLogged = YES;
+            ApolloLog(@"[PerAccountFavorites] live account identity stayed unavailable; preserving the last projection until the next account signal");
+        }
+        return;
+    }
+
+    NSTimeInterval delay = delays[sApolloPerAccountFavoritesRetryAttempt++];
+    NSUInteger generation = sApolloPerAccountFavoritesRetryGeneration;
+    sApolloPerAccountFavoritesRetryScheduled = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (generation != sApolloPerAccountFavoritesRetryGeneration) return;
+        sApolloPerAccountFavoritesRetryScheduled = NO;
+        ApolloPerAccountFavoritesRetryIdentity(reason);
+    });
+}
+
+static void ApolloPerAccountFavoritesEnterUnknownIdentity(NSString *reason, BOOL mayRetry) {
+    BOOL firstUnknownEntry = !sApolloPerAccountFavoritesIdentityUnknown;
+    if (firstUnknownEntry) {
+        // Preserve the last definitely-attributed list. If Apollo mutates its
+        // shared key while identity is unknown, the later reconcile must not
+        // cross-write that ambiguous list into the outgoing user's bucket.
+        ApolloPerAccountFavoritesSnapshotMaterializedList();
+        if (!sPerAccountFavoritesEnabled) return;
+        sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+    }
+    sApolloPerAccountFavoritesIdentityUnknown = YES;
+    if (mayRetry) ApolloPerAccountFavoritesScheduleIdentityRetry(reason);
+    if (firstUnknownEntry) {
+        ApolloLog(@"[PerAccountFavorites] account identity temporarily unavailable; projection unchanged");
+    }
+}
+
+static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentity,
+                                                        NSString *reason,
+                                                        BOOL mayRetry,
+                                                        BOOL authoritative) {
+    if (!sApolloPerAccountFavoritesStarted || !sPerAccountFavoritesEnabled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    if (incomingIdentity.length == 0) {
+        ApolloPerAccountFavoritesEnterUnknownIdentity(reason, mayRetry);
+        return;
+    }
+
+    BOOL wasUnknown = sApolloPerAccountFavoritesIdentityUnknown;
+    BOOL nativeMutatedWhileUnknown = sApolloPerAccountFavoritesNativeMutationWhileUnknown;
+    // A delayed defaults read may merely rediscover the outgoing identity while
+    // AccountManager is already switching elsewhere. Once a projection exists,
+    // only a live AccountManager resolution may replace or confirm it. This is
+    // intentionally broader than the unknown-state check: a queued retry can
+    // fire after a later live notification already resolved the transition.
+    if (sApolloPerAccountFavoritesMaterializedIdentity.length > 0 && !authoritative) {
+        if (mayRetry) ApolloPerAccountFavoritesScheduleIdentityRetry(reason);
+        return;
+    }
+    if ([sApolloPerAccountFavoritesMaterializedIdentity isEqualToString:incomingIdentity]) {
+        sApolloPerAccountFavoritesIdentityUnknown = NO;
+        sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+        if (wasUnknown && nativeMutatedWhileUnknown) {
+            // The authoritative resolution returned to the same account, so
+            // the native write made during quarantine can now be safely saved.
+            ApolloPerAccountFavoritesSnapshotMaterializedList();
+        }
+        ApolloPerAccountFavoritesCancelIdentityRetries();
+        return;
+    }
+
+    BOOL created = NO;
+    BOOL retryable = NO;
+    ApolloPerAccountFavoritesStoreStatus storeStatus = ApolloPerAccountFavoritesStoreMissing;
+    NSMutableDictionary *buckets =
+        ApolloPerAccountFavoritesBucketsForIdentity(incomingIdentity, &created, &retryable,
+                                                     &storeStatus);
+    if (!buckets) {
+        if (storeStatus == ApolloPerAccountFavoritesStoreInvalid ||
+            storeStatus == ApolloPerAccountFavoritesStoreUnsupported) {
+            ApolloPerAccountFavoritesFailClosedForStoreStatus(storeStatus);
+            return;
+        }
+        sApolloPerAccountFavoritesIdentityUnknown = YES;
+        // Keep NativeMutationWhileUnknown intact: losing it here would let a
+        // later retry cross-write an ambiguous list into the outgoing bucket.
+        if (retryable && mayRetry) ApolloPerAccountFavoritesScheduleIdentityRetry(reason);
+        return;
+    }
+    NSArray<NSString *> *outgoingFavorites = ApolloPerAccountFavoritesNativeList();
+    if (wasUnknown && nativeMutatedWhileUnknown) {
+        // The edit happened while no account could be identified safely, so it
+        // cannot be attributed to either side of this switch. Preserve exactly
+        // what the user saw in Apollo's shared (feature-off) scope; disabling
+        // the feature is then a deterministic recovery path.
+        buckets[kApolloPerAccountFavoritesSharedIdentity] = outgoingFavorites;
+        ApolloLog(@"[PerAccountFavorites] preserved an unattributed favorites edit in the shared scope");
+    } else if (sApolloPerAccountFavoritesMaterializedIdentity.length > 0) {
+        buckets[sApolloPerAccountFavoritesMaterializedIdentity] = outgoingFavorites;
+    }
+
+    NSArray<NSString *> *incomingFavorites = buckets[incomingIdentity];
+    if (!incomingFavorites) {
+        // The store is initialized, so a missing bucket means an account added
+        // later. Future accounts deliberately start empty.
+        incomingFavorites = @[];
+        buckets[incomingIdentity] = incomingFavorites;
+    }
+    ApolloPerAccountFavoritesSaveBuckets(buckets);
+
+    sApolloPerAccountFavoritesMaterializedIdentity = [incomingIdentity copy];
+    sApolloPerAccountFavoritesIdentityUnknown = NO;
+    sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+    ApolloPerAccountFavoritesCancelIdentityRetries();
+    BOOL changed = ApolloPerAccountFavoritesInstallNativeList(incomingFavorites);
+    ApolloPerAccountFavoritesScheduleNativeRefresh();
+    ApolloLog(@"[PerAccountFavorites] switched scope (%lu -> %lu favorites, projectionChanged=%d, reason=%@%@)",
+              (unsigned long)outgoingFavorites.count, (unsigned long)incomingFavorites.count,
+              changed, reason ?: @"unknown", created ? @", migrated store" : @"");
+}
+
+static void ApolloPerAccountFavoritesReconcilePersisted(NSString *reason,
+                                                         BOOL mayRetry,
+                                                         BOOL authoritative) {
+    ApolloPerAccountFavoritesReconcileIdentity(ApolloPerAccountFavoritesPersistedIdentity(),
+                                                reason, mayRetry, authoritative);
+}
+
+void ApolloPerAccountFavoritesAccountStateDidChange(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloPerAccountFavoritesAccountStateDidChange(); });
+        return;
+    }
+    // The feature is opt-in. Keep the default-off path completely dormant:
+    // resolving identity would otherwise inspect AccountManager's private Swift
+    // array and unarchive every persisted RDKClient on ordinary account writes.
+    if (!sApolloPerAccountFavoritesStarted || !sPerAccountFavoritesEnabled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    ApolloPerAccountFavoritesBeginIdentityRetryBurst();
+    // A rapid A→B→C switch can deliver B's delayed defaults write after the
+    // synchronous notification already projected C. Prefer a live signed-in
+    // identity so stale persistence cannot roll the projection backward.
+    NSString *liveIdentity = ApolloPerAccountFavoritesLiveIdentity();
+    if ([liveIdentity hasPrefix:@"u:"]) {
+        ApolloPerAccountFavoritesReconcileIdentity(liveIdentity,
+                                                    @"account persistence (live)",
+                                                    YES, YES);
+        return;
+    }
+
+    // A setter callback only proves that one asynchronous persistence write
+    // completed. If live state is temporarily unreadable, the just-written
+    // index may belong to an earlier A→B leg of a rapid A→B→C switch. Keep
+    // the current projection quarantined until AccountManager resolves again.
+    if (liveIdentity.length == 0 &&
+        sApolloPerAccountFavoritesMaterializedIdentity.length > 0) {
+        ApolloPerAccountFavoritesReconcileIdentity(nil,
+                                                    @"account persistence without live identity",
+                                                    YES, NO);
+        return;
+    }
+
+    NSString *persistedIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+    if ([liveIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity] &&
+        persistedIdentity.length > 0 && ![persistedIdentity isEqualToString:liveIdentity]) {
+        if ([sApolloPerAccountFavoritesMaterializedIdentity isEqualToString:liveIdentity]) {
+            // The live notification already committed a real sign-out. Ignore
+            // the stale selection mirror while the empty array catches up.
+            ApolloPerAccountFavoritesReconcileIdentity(liveIdentity,
+                                                        @"account persistence (signed out)",
+                                                        YES, YES);
+            return;
+        }
+        // Live says signed out while the mirror still names an account. Neither
+        // is safe at this instant; the account notification/next coherent write
+        // will resolve it.
+        ApolloPerAccountFavoritesReconcileIdentity(nil, @"account persistence conflict", YES, NO);
+        return;
+    }
+    ApolloPerAccountFavoritesReconcileIdentity(persistedIdentity ?: liveIdentity,
+                                                @"account persistence", YES, YES);
+}
+
+void ApolloPerAccountFavoritesAccountsCollectionDidChange(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloPerAccountFavoritesAccountsCollectionDidChange();
+        });
+        return;
+    }
+    if (!sApolloPerAccountFavoritesStarted || !sPerAccountFavoritesEnabled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    ApolloPerAccountFavoritesBeginIdentityRetryBurst();
+    // Array-only writes are unsafe during reorder, but a decoded empty array
+    // plus a live nil selection is a coherent sign-out. This closes the case
+    // where the index was removed first and no later selection write arrives.
+    NSString *liveIdentity = ApolloPerAccountFavoritesLiveIdentity();
+    NSString *persistedIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+    if ([liveIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity] &&
+        [persistedIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity]) {
+        ApolloPerAccountFavoritesReconcileIdentity(liveIdentity,
+                                                    @"empty account collection",
+                                                    YES, YES);
+    } else if (sApolloPerAccountFavoritesIdentityUnknown) {
+        ApolloPerAccountFavoritesScheduleIdentityRetry(@"account collection change");
+    }
+}
+
+void ApolloPerAccountFavoritesLiveAccountStateDidChange(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloPerAccountFavoritesLiveAccountStateDidChange(); });
+        return;
+    }
+    if (!sApolloPerAccountFavoritesStarted || !sPerAccountFavoritesEnabled ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    ApolloPerAccountFavoritesBeginIdentityRetryBurst();
+    ApolloPerAccountFavoritesReconcileIdentity(ApolloPerAccountFavoritesLiveIdentity(),
+                                                @"live account notification", YES, YES);
+}
+
+void ApolloPerAccountFavoritesNativeFavoritesDidChange(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloPerAccountFavoritesNativeFavoritesDidChange(); });
+        return;
+    }
+    if (!sApolloPerAccountFavoritesStarted || !sPerAccountFavoritesEnabled ||
+        sApolloPerAccountFavoritesInstallingProjection ||
+        sApolloPerAccountFavoritesSuspendedForRestore) return;
+    if (sApolloPerAccountFavoritesIdentityUnknown) {
+        sApolloPerAccountFavoritesNativeMutationWhileUnknown = YES;
+        return;
+    }
+    ApolloPerAccountFavoritesSnapshotMaterializedList();
+}
+
+ApolloPerAccountFavoritesSetResult ApolloPerAccountFavoritesSetEnabled(BOOL enabled) {
+    if (![NSThread isMainThread]) {
+        __block ApolloPerAccountFavoritesSetResult result =
+            ApolloPerAccountFavoritesSetResultIdentityUnavailable;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = ApolloPerAccountFavoritesSetEnabled(enabled);
+        });
+        return result;
+    }
+    if (sApolloPerAccountFavoritesSuspendedForRestore) {
+        return ApolloPerAccountFavoritesSetResultIdentityUnavailable;
+    }
+
+    BOOL wasEnabled = sPerAccountFavoritesEnabled;
+    if (wasEnabled == enabled) return ApolloPerAccountFavoritesSetResultApplied;
+
+    if (!enabled) {
+        BOOL preserveUnknownMutation = sApolloPerAccountFavoritesIdentityUnknown &&
+            sApolloPerAccountFavoritesNativeMutationWhileUnknown;
+        NSArray<NSString *> *unknownMutationFavorites = preserveUnknownMutation
+            ? ApolloPerAccountFavoritesNativeList() : nil;
+        ApolloPerAccountFavoritesSnapshotMaterializedList();
+
+        NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = nil;
+        NSArray<NSString *> *sharedFavorites = nil;
+        if (ApolloPerAccountFavoritesLoadBuckets(&buckets) == ApolloPerAccountFavoritesStoreReady) {
+            // An edit made while account identity was quarantined cannot safely
+            // be assigned to either account. Disabling has an unambiguous
+            // destination, though: preserve exactly what the user currently
+            // sees as Apollo's restored shared list instead of overwriting it.
+            if (unknownMutationFavorites) {
+                sharedFavorites = unknownMutationFavorites;
+                buckets[kApolloPerAccountFavoritesSharedIdentity] = sharedFavorites;
+                ApolloPerAccountFavoritesSaveBuckets(buckets);
+            } else {
+                sharedFavorites = buckets[kApolloPerAccountFavoritesSharedIdentity];
+            }
+            if (!sharedFavorites) {
+                // Older v1 stores did not carry a feature-off scope. Seed it
+                // from the current projection without changing what is shown.
+                sharedFavorites = ApolloPerAccountFavoritesNativeList();
+                buckets[kApolloPerAccountFavoritesSharedIdentity] = sharedFavorites;
+                ApolloPerAccountFavoritesSaveBuckets(buckets);
+            }
+        }
+
+        sPerAccountFavoritesEnabled = NO;
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyPerAccountFavoritesEnabled];
+        sApolloPerAccountFavoritesMaterializedIdentity = nil;
+        sApolloPerAccountFavoritesIdentityUnknown = NO;
+        sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+        ApolloPerAccountFavoritesCancelIdentityRetries();
+        if (sharedFavorites && ApolloPerAccountFavoritesInstallNativeList(sharedFavorites)) {
+            ApolloPerAccountFavoritesScheduleNativeRefresh();
+        }
+        ApolloLog(@"[PerAccountFavorites] disabled; restored Apollo's shared favorites list");
+        return ApolloPerAccountFavoritesSetResultApplied;
+    }
+
+    // Enabling is transactional from the user's perspective: resolve the
+    // account and validate the envelope before persisting ON or replacing the
+    // native list. A failed attempt therefore leaves Apollo exactly as it was.
+    NSString *activeIdentity = ApolloPerAccountFavoritesLiveIdentity();
+    if (activeIdentity.length == 0) activeIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+    if (activeIdentity.length == 0) {
+        return ApolloPerAccountFavoritesSetResultIdentityUnavailable;
+    }
+
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = nil;
+    ApolloPerAccountFavoritesStoreStatus storeStatus =
+        ApolloPerAccountFavoritesLoadBuckets(&buckets);
+    if (storeStatus == ApolloPerAccountFavoritesStoreInvalid ||
+        storeStatus == ApolloPerAccountFavoritesStoreUnsupported) {
+        ApolloPerAccountFavoritesFailClosedForStoreStatus(storeStatus);
+        return ApolloPerAccountFavoritesSetResultForStoreStatus(storeStatus);
+    }
+
+    BOOL created = NO;
+    if (storeStatus == ApolloPerAccountFavoritesStoreMissing) {
+        buckets = ApolloPerAccountFavoritesCreateInitialBuckets(activeIdentity);
+        if (!buckets) return ApolloPerAccountFavoritesSetResultIdentityUnavailable;
+        created = YES;
+    }
+
+    // Capture every edit made while the feature was off before projecting an
+    // account bucket over the native key. This shared scope returns intact on
+    // the next disable instead of being silently destroyed by re-enable.
+    if (!created) {
+        NSArray<NSString *> *sharedFavorites = ApolloPerAccountFavoritesNativeList();
+        if (![buckets[kApolloPerAccountFavoritesSharedIdentity] isEqualToArray:sharedFavorites]) {
+            buckets[kApolloPerAccountFavoritesSharedIdentity] = sharedFavorites;
+        }
+    }
+
+    NSArray<NSString *> *activeFavorites = buckets[activeIdentity];
+    if (!activeFavorites) {
+        // Missing from an established store means this account was added after
+        // the first migration. Never overwrite another account's saved bucket
+        // with the shared projection left behind while the feature was off.
+        activeFavorites = @[];
+        buckets[activeIdentity] = activeFavorites;
+    }
+    ApolloPerAccountFavoritesSaveBuckets(buckets);
+
+    sPerAccountFavoritesEnabled = YES;
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:UDKeyPerAccountFavoritesEnabled];
+    sApolloPerAccountFavoritesMaterializedIdentity = [activeIdentity copy];
+    sApolloPerAccountFavoritesIdentityUnknown = NO;
+    sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+    ApolloPerAccountFavoritesCancelIdentityRetries();
+    ApolloPerAccountFavoritesInstallNativeList(activeFavorites);
+    ApolloPerAccountFavoritesScheduleNativeRefresh();
+    ApolloLog(@"[PerAccountFavorites] enabled (%@ store, %lu active favorites)",
+              created ? @"migrated" : @"existing", (unsigned long)activeFavorites.count);
+    return ApolloPerAccountFavoritesSetResultApplied;
+}
+
+NSDictionary<NSString *, id> *ApolloPerAccountFavoritesCopyBackupPreferenceValues(void) {
+    if (![NSThread isMainThread]) {
+        __block NSDictionary<NSString *, id> *snapshot = nil;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            snapshot = ApolloPerAccountFavoritesCopyBackupPreferenceValues();
+        });
+        return snapshot;
+    }
+    if (sApolloPerAccountFavoritesSuspendedForRestore) return nil;
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *buckets = nil;
+    ApolloPerAccountFavoritesStoreStatus status = ApolloPerAccountFavoritesLoadBuckets(&buckets);
+    NSArray<NSString *> *capturedNative = nil;
+    id capturedEnvelope = nil;
+
+    if (sPerAccountFavoritesEnabled &&
+        (status == ApolloPerAccountFavoritesStoreInvalid ||
+         status == ApolloPerAccountFavoritesStoreUnsupported)) {
+        ApolloPerAccountFavoritesFailClosedForStoreStatus(status);
+    }
+
+    // Invalid/future stores deliberately fail closed at runtime: the module
+    // leaves Apollo's native list untouched. Preserve that exact pair in the
+    // backup as well rather than trying to repair data we do not understand.
+    if (!sPerAccountFavoritesEnabled ||
+        status == ApolloPerAccountFavoritesStoreInvalid ||
+        status == ApolloPerAccountFavoritesStoreUnsupported) {
+        capturedNative = ApolloPerAccountFavoritesNativeList();
+        capturedEnvelope = [defaults objectForKey:UDKeyPerAccountFavoriteSubreddits];
+    } else {
+        if (sApolloPerAccountFavoritesIdentityUnknown ||
+            sApolloPerAccountFavoritesMaterializedIdentity.length == 0) {
+            NSString *liveIdentity = ApolloPerAccountFavoritesLiveIdentity();
+            if ([liveIdentity isEqualToString:kApolloPerAccountFavoritesAnonymousIdentity]) {
+                // As at launch, AccountManager's nil index is not sufficient by
+                // itself: it can mean keychain-backed accounts have not loaded.
+                // Require the persisted mirror to confirm a genuine sign-out.
+                NSString *persistedIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+                if (![persistedIdentity isEqualToString:liveIdentity]) liveIdentity = nil;
+            }
+            if (liveIdentity.length == 0) {
+                ApolloLog(@"[PerAccountFavorites] backup deferred while account identity is unavailable");
+                return nil;
+            }
+            ApolloPerAccountFavoritesReconcileIdentity(liveIdentity,
+                                                        @"backup snapshot",
+                                                        NO, YES);
+            if (sApolloPerAccountFavoritesIdentityUnknown ||
+                sApolloPerAccountFavoritesMaterializedIdentity.length == 0) {
+                return nil;
+            }
+        }
+
+        // Reconcile may have initialized or replaced the store, so load it
+        // again before taking the actual snapshot.
+        status = ApolloPerAccountFavoritesLoadBuckets(&buckets);
+        if (status == ApolloPerAccountFavoritesStoreMissing) {
+            BOOL created = NO;
+            BOOL retryable = NO;
+            ApolloPerAccountFavoritesStoreStatus retryStatus = status;
+            buckets = ApolloPerAccountFavoritesBucketsForIdentity(
+                sApolloPerAccountFavoritesMaterializedIdentity, &created, &retryable,
+                &retryStatus);
+            if (!buckets) {
+                if (retryStatus == ApolloPerAccountFavoritesStoreInvalid ||
+                    retryStatus == ApolloPerAccountFavoritesStoreUnsupported) {
+                    ApolloPerAccountFavoritesFailClosedForStoreStatus(retryStatus);
+                }
+                return nil;
+            }
+        } else if (status != ApolloPerAccountFavoritesStoreReady) {
+            // A concurrent external store mutation is unexpected, but the
+            // fail-closed representation remains coherent and recoverable.
+            capturedNative = ApolloPerAccountFavoritesNativeList();
+            capturedEnvelope = [defaults objectForKey:UDKeyPerAccountFavoriteSubreddits];
+        }
+
+        if (!capturedNative) {
+            // Read Apollo's native list exactly once, write that same immutable
+            // value into the active bucket, and return both. A background native
+            // write landing before this read is included; one landing afterward
+            // is queued for the next main-thread snapshot and cannot make this
+            // backup pair internally inconsistent.
+            capturedNative = ApolloPerAccountFavoritesNativeList();
+            buckets[sApolloPerAccountFavoritesMaterializedIdentity] = capturedNative;
+            capturedEnvelope = ApolloPerAccountFavoritesEnvelopeForBuckets(buckets);
+            [defaults setObject:capturedEnvelope forKey:UDKeyPerAccountFavoriteSubreddits];
+        }
+    }
+
+    return @{
+        UDKeyPerAccountFavoritesEnabled: @(sPerAccountFavoritesEnabled),
+        UDKeyApolloFavoriteSubreddits: capturedNative ?: @[],
+        UDKeyPerAccountFavoriteSubreddits: capturedEnvelope ?: [NSNull null],
+    };
+}
+
+void ApolloPerAccountFavoritesSuspendForPreferencesRestore(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            ApolloPerAccountFavoritesSuspendForPreferencesRestore();
+        });
+        return;
+    }
+    sApolloPerAccountFavoritesSuspendedForRestore = YES;
+    ApolloPerAccountFavoritesCancelIdentityRetries();
+    ApolloLog(@"[PerAccountFavorites] suspended for preferences restore until relaunch");
+}
+
+void ApolloPerAccountFavoritesStart(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloPerAccountFavoritesStart(); });
+        return;
+    }
+    if (sApolloPerAccountFavoritesStarted) return;
+    sApolloPerAccountFavoritesStarted = YES;
+
+    // The pre-post NSNotificationCenter hook handles quick switching before any
+    // native observer can read the old projection. This observer remains as a
+    // fallback for alternate notification APIs or future Apollo call paths.
+    for (NSNotificationName name in @[
+        @"com.christianselig.RedditCurrentAccountChanged",
+        @"com.christianselig.RedditAccountChanged",
+    ]) {
+        [[NSNotificationCenter defaultCenter] addObserverForName:name
+                                                          object:nil
+                                                           queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(__unused NSNotification *note) {
+            ApolloPerAccountFavoritesLiveAccountStateDidChange();
+        }];
+    }
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloFavoriteSubredditsUpdatedNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(__unused NSNotification *note) {
+        ApolloPerAccountFavoritesNativeFavoritesDidChange();
+    }];
+
+    if (!sPerAccountFavoritesEnabled) return;
+
+    NSMutableDictionary<NSString *, NSArray<NSString *> *> *preflightBuckets = nil;
+    ApolloPerAccountFavoritesStoreStatus preflightStatus =
+        ApolloPerAccountFavoritesLoadBuckets(&preflightBuckets);
+    if (preflightStatus == ApolloPerAccountFavoritesStoreInvalid ||
+        preflightStatus == ApolloPerAccountFavoritesStoreUnsupported) {
+        ApolloPerAccountFavoritesFailClosedForStoreStatus(preflightStatus);
+        return;
+    }
+
+    NSString *activeIdentity = ApolloPerAccountFavoritesPersistedIdentity();
+    if (activeIdentity.length == 0) {
+        ApolloPerAccountFavoritesEnterUnknownIdentity(@"launch", YES);
+        return;
+    }
+
+    BOOL created = NO;
+    BOOL retryable = NO;
+    ApolloPerAccountFavoritesStoreStatus storeStatus = preflightStatus;
+    NSMutableDictionary *buckets =
+        ApolloPerAccountFavoritesBucketsForIdentity(activeIdentity, &created, &retryable,
+                                                     &storeStatus);
+    if (!buckets) {
+        if (storeStatus == ApolloPerAccountFavoritesStoreInvalid ||
+            storeStatus == ApolloPerAccountFavoritesStoreUnsupported) {
+            ApolloPerAccountFavoritesFailClosedForStoreStatus(storeStatus);
+            return;
+        }
+        sApolloPerAccountFavoritesIdentityUnknown = YES;
+        if (retryable) ApolloPerAccountFavoritesScheduleIdentityRetry(@"launch");
+        return;
+    }
+
+    NSArray<NSString *> *activeFavorites = buckets[activeIdentity];
+    if (!activeFavorites) {
+        activeFavorites = @[];
+        buckets[activeIdentity] = activeFavorites;
+        ApolloPerAccountFavoritesSaveBuckets(buckets);
+    }
+    sApolloPerAccountFavoritesMaterializedIdentity = [activeIdentity copy];
+    sApolloPerAccountFavoritesIdentityUnknown = NO;
+    if (ApolloPerAccountFavoritesInstallNativeList(activeFavorites)) {
+        ApolloPerAccountFavoritesScheduleNativeRefresh();
+    }
+    ApolloLog(@"[PerAccountFavorites] active at launch (%lu favorites, %@ store)",
+              (unsigned long)activeFavorites.count, created ? @"migrated" : @"existing");
+}

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -272,6 +272,9 @@ typedef NS_ENUM(NSInteger, ApolloSubredditFeedLayout) {
 extern NSInteger sSubredditFeedIconStyle;
 extern NSInteger sSubredditFeedLayout;
 
+// Opt-in per-account FavoriteSubreddits projection. Defaults OFF; see
+// ApolloPerAccountFavorites.{h,m}.
+extern BOOL sPerAccountFavoritesEnabled;
 // Hide the description subtitles under the subreddit list's built-in feed rows
 // (see UDKeyHideSubredditListDescriptions). Independent of the enhancements master.
 extern BOOL sHideSubredditListDescriptions;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -75,6 +75,7 @@ BOOL sModernSubredditDividers = YES;
 BOOL sSubredditListEnhancements = YES;
 NSInteger sSubredditFeedIconStyle = ApolloSubredditFeedIconStyleClassic;
 NSInteger sSubredditFeedLayout = ApolloSubredditFeedLayoutRows;
+BOOL sPerAccountFavoritesEnabled = NO;
 BOOL sHideSubredditListDescriptions = NO;
 BOOL sHideMultiredditDescriptions = NO;
 BOOL sEnableFlairColors = NO;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -34,6 +34,7 @@
 #import "ApolloWebSessionStore.h"
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloAccountCredentials.h"
+#import "ApolloPerAccountFavorites.h"
 #import "crash/ApolloCrashManager.h"
 #import "crash/ApolloCrashContext.h"
 #import "crash/ApolloCrashPromptCoordinator.h"
@@ -3588,12 +3589,37 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
            [key isEqualToString:@"CurrentRedditAccountIndex"];
 }
 
+static BOOL ApolloDefaultsKeyChangesSelectedAccount(NSString *key) {
+    return [key isEqualToString:@"CurrentRedditAccountIndex"];
+}
+
+static BOOL ApolloDefaultsKeyChangesAccountCollection(NSString *key) {
+    return [key isEqualToString:@"RedditAccounts2"];
+}
+
+static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
+    return [key isEqualToString:UDKeyApolloFavoriteSubreddits];
+}
+
 %hook NSUserDefaults
 
 - (void)setObject:(id)value forKey:(NSString *)key {
     %orig;
     if (ApolloDefaultsKeyChangesActiveAccount(key)) {
         ApolloInvalidateActiveAccountUsernameCache();
+    }
+    // Do not project on a RedditAccounts2-only write: account reordering can
+    // persist the reordered array before its matching index, making the old
+    // numeric index briefly point at the wrong username. The selection write
+    // below, or Apollo's eventual account notification, sees the coherent pair.
+    if (ApolloDefaultsKeyChangesSelectedAccount(key)) {
+        ApolloPerAccountFavoritesAccountStateDidChange();
+    }
+    if (ApolloDefaultsKeyChangesAccountCollection(key)) {
+        ApolloPerAccountFavoritesAccountsCollectionDidChange();
+    }
+    if (ApolloDefaultsKeyChangesNativeFavorites(key)) {
+        ApolloPerAccountFavoritesNativeFavoritesDidChange();
     }
 }
 
@@ -3602,6 +3628,9 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
     if (ApolloDefaultsKeyChangesActiveAccount(key)) {
         ApolloInvalidateActiveAccountUsernameCache();
     }
+    if (ApolloDefaultsKeyChangesSelectedAccount(key)) {
+        ApolloPerAccountFavoritesAccountStateDidChange();
+    }
 }
 
 - (void)removeObjectForKey:(NSString *)key {
@@ -3609,6 +3638,31 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
     if (ApolloDefaultsKeyChangesActiveAccount(key)) {
         ApolloInvalidateActiveAccountUsernameCache();
     }
+    if (ApolloDefaultsKeyChangesSelectedAccount(key)) {
+        ApolloPerAccountFavoritesAccountStateDidChange();
+    }
+    if (ApolloDefaultsKeyChangesAccountCollection(key)) {
+        ApolloPerAccountFavoritesAccountsCollectionDidChange();
+    }
+    if (ApolloDefaultsKeyChangesNativeFavorites(key)) {
+        ApolloPerAccountFavoritesNativeFavoritesDidChange();
+    }
+}
+
+%end
+
+// AccountManager updates its live Swift selection, posts this notification,
+// and only then persists CurrentRedditAccountIndex asynchronously. Project the
+// live account's favorites before any notification observer sees the old list;
+// the module's observer remains as an idempotent fallback.
+%hook NSNotificationCenter
+
+- (void)postNotificationName:(NSNotificationName)name object:(id)object {
+    if ([name isEqualToString:@"com.christianselig.RedditCurrentAccountChanged"] ||
+        [name isEqualToString:@"com.christianselig.RedditAccountChanged"]) {
+        ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    }
+    %orig;
 }
 
 %end
@@ -3657,6 +3711,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
                                     UDKeySubredditListEnhancements: @YES,
                                     UDKeySubredditFeedIconStyle: @(ApolloSubredditFeedIconStyleClassic),
                                     UDKeySubredditFeedLayout: @(ApolloSubredditFeedLayoutRows),
+                                    UDKeyPerAccountFavoritesEnabled: @NO,
                                     UDKeyModernSubredditDividers: @YES,
                                     UDKeyShowDeletedComments: @NO,
                                     UDKeyTapToRevealDeletedComments: @NO,
@@ -4036,6 +4091,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
         sSubredditFeedLayout = ApolloSubredditFeedLayoutRows;
         [standardDefaults setInteger:sSubredditFeedLayout forKey:UDKeySubredditFeedLayout];
     }
+    sPerAccountFavoritesEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPerAccountFavoritesEnabled];
     sHideSubredditListDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideSubredditListDescriptions];
     sHideMultiredditDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideMultiredditDescriptions];
     sEnableFlairColors = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFlairColors];
@@ -4375,6 +4431,11 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
     // over from a mid-session web login is now resolved — clear the indicator.
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:UDKeyWebJSONPendingRestart];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:UDKeyWebJSONPendingRestartUsername];
+
+    // Start only after every setting is loaded and any launch-time account
+    // synthesis has finished, so the first projection sees the final persisted
+    // account array. The feature is dormant when its opt-in flag is off.
+    ApolloPerAccountFavoritesStart();
 
     // Mirror the selected app icon for Bark notification icon passthrough.
     ApolloBarkCaptureInitialIconSelection();

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -50,6 +50,18 @@ static NSString *const UDKeyHideRPopularRedditList = @"HideRPopularRedditList";
 static NSString *const UDKeyHideRAllRedditList = @"HideRAllRedditList";
 static NSString *const UDKeyHideModeratorRedditList = @"HideModeratorRedditList";
 static NSString *const ApolloFeedShortcutsChangedNotification = @"ApolloFeedShortcutsChangedNotification";
+// Keep an independent FavoriteSubreddits list for each Reddit account. Opt-in:
+// default NO via registerDefaults. ApolloPerAccountFavorites projects the active
+// account's bucket back through Apollo's native FavoriteSubreddits key so every
+// stock reader/mutator continues to work unchanged.
+static NSString *const UDKeyPerAccountFavoritesEnabled = @"PerAccountFavoritesEnabled";
+// Versioned envelope: { "version": 1, "buckets": { "u:name": [subreddits],
+// "anonymous": [subreddits] } }. Missing bucket and explicit empty bucket are
+// intentionally distinct; accounts created after the first migration start empty.
+static NSString *const UDKeyPerAccountFavoriteSubreddits = @"PerAccountFavoriteSubreddits";
+// Apollo's own active favorites projection and its native refresh notification.
+static NSString *const UDKeyApolloFavoriteSubreddits = @"FavoriteSubreddits";
+static NSString *const ApolloFavoriteSubredditsUpdatedNotification = @"com.christianselig.FavoriteSubredditsUpdated";
 // Subreddits the user moderates but chose to hide from the Subreddits list
 // (Reddit offers no way to leave or delete some dead subreddits). Array of
 // display names, compared case-insensitively.

--- a/src/settings/ApolloBackupRestore.m
+++ b/src/settings/ApolloBackupRestore.m
@@ -1,6 +1,7 @@
 #import "settings/ApolloBackupRestore.h"
 
 #import "ApolloCommon.h"
+#import "ApolloPerAccountFavorites.h"
 #import "ApolloState.h"
 #import "ApolloTranslation.h"
 #import "UserDefaultConstants.h"
@@ -203,15 +204,40 @@ NSURL *ApolloBackupRestoreCreateBackupZip(NSError **error) {
         return nil;
     }
 
-    // The on-disk plist may be stale (cfprefsd manages persistence timing),
-    // so patch in the current in-memory ReadPostIDs directly.
-    NSArray *currentReadPostIDs = [[NSUserDefaults standardUserDefaults] arrayForKey:@"ReadPostIDs"];
+    // The on-disk plist may be stale (cfprefsd manages persistence timing), so
+    // patch state whose most recent value must be captured atomically. This is
+    // especially important for the per-account bucket envelope: a favorite can
+    // be changed and backed up before cfprefsd flushes the new scope.
+    NSUserDefaults *liveDefaults = [NSUserDefaults standardUserDefaults];
+    NSMutableDictionary *plist = [NSMutableDictionary dictionaryWithContentsOfFile:mainDestPath];
+    if (!plist) {
+        [fileManager removeItemAtPath:backupDir error:nil];
+        if (error) *error = ApolloBackupRestoreError(@"Could not read the copied preferences file.");
+        return nil;
+    }
+    NSArray *currentReadPostIDs = [liveDefaults arrayForKey:@"ReadPostIDs"];
     if (currentReadPostIDs.count > 0) {
-        NSMutableDictionary *plist = [NSMutableDictionary dictionaryWithContentsOfFile:mainDestPath];
-        if (plist) {
-            plist[@"ReadPostIDs"] = currentReadPostIDs;
-            [plist writeToFile:mainDestPath atomically:YES];
+        plist[@"ReadPostIDs"] = currentReadPostIDs;
+    }
+    NSDictionary<NSString *, id> *favoritesState =
+        ApolloPerAccountFavoritesCopyBackupPreferenceValues();
+    if (!favoritesState) {
+        [fileManager removeItemAtPath:backupDir error:nil];
+        if (error) {
+            *error = ApolloBackupRestoreError(
+                @"Could not capture favorites while the active account is changing. Please try again.");
         }
+        return nil;
+    }
+    for (NSString *key in favoritesState) {
+        id currentValue = favoritesState[key];
+        if (currentValue && currentValue != [NSNull null]) plist[key] = currentValue;
+        else [plist removeObjectForKey:key];
+    }
+    if (![plist writeToFile:mainDestPath atomically:YES]) {
+        [fileManager removeItemAtPath:backupDir error:nil];
+        if (error) *error = ApolloBackupRestoreError(@"Could not capture the latest preferences for backup.");
+        return nil;
     }
 
     if ([fileManager fileExistsAtPath:groupPlistPath]) {
@@ -289,6 +315,13 @@ BOOL ApolloBackupRestoreRestoreFromZipURL(NSURL *zipURL, NSString **outErrorTitl
         if (outErrorMessage) *outErrorMessage = @"The preferences file in the backup is corrupted or invalid.";
         return NO;
     }
+
+    // Restore is intentionally a one-way transaction: the success UI force-exits
+    // and launch reloads every setting. Suspend live favorites callbacks before
+    // unordered key replay so FavoriteSubreddits cannot be snapshotted into the
+    // old session's materialized account while its restored envelope/account
+    // state is only partially installed.
+    ApolloPerAccountFavoritesSuspendForPreferencesRestore();
 
     // Restore main preferences, skipping analytics/tracking keys
     NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -17,6 +17,7 @@
 #import "settings/ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
 #import "ApolloAccountCredentials.h"
+#import "ApolloPerAccountFavorites.h"
 #import "ApolloState.h"
 #import "ApolloTagFilters.h"
 #import "ApolloBadgeBookScraper.h"   // ApolloBadgeBookInvalidate() — Clear Tweak Caches
@@ -2509,6 +2510,19 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     return [parts componentsJoinedByString:@" · "];
 }
 
+- (ApolloSettingsSection *)buildSubredditsFavoritesSection {
+    __weak typeof(self) weakSelf = self;
+    ApolloSettingsRow *perAccountFavorites =
+        [ApolloSettingsRow switchRowWithID:@"sub.perAccountFavorites"
+                                     title:@"Per-Account Favorites"
+                                      isOn:^BOOL { return sPerAccountFavoritesEnabled; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf perAccountFavoritesSwitchToggled:sender]; }];
+
+    return [ApolloSettingsSection sectionWithTitle:@"Favorites"
+                                            footer:@"Keeps an independent Favorites list for each account. First enable copies the current list to existing accounts; new accounts start empty. Turning it off restores Apollo's shared list."
+                                              rows:@[ perAccountFavorites ]];
+}
+
 - (NSString *)subredditLayoutSummaryText {
     if (!sShowSubredditHeaders) return @"Native (Apollo)";
     NSMutableArray<NSString *> *parts = [NSMutableArray array];
@@ -3963,6 +3977,24 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
 // Subreddit Sections screen now (ApolloSubredditSectionsViewController),
 // beside the live preview that shows what they change.
 
+- (void)perAccountFavoritesSwitchToggled:(UISwitch *)sender {
+    ApolloPerAccountFavoritesSetResult result =
+        ApolloPerAccountFavoritesSetEnabled(sender.isOn);
+    if (result == ApolloPerAccountFavoritesSetResultApplied) return;
+
+    [sender setOn:sPerAccountFavoritesEnabled animated:YES];
+    if (result == ApolloPerAccountFavoritesSetResultUnsupportedStore) {
+        [self showAlertWithTitle:@"Newer Favorites Data Found"
+                         message:@"Per-Account Favorites stayed off because this data was created by a newer version of Apollo Reborn. Your favorites were not changed. Update Apollo Reborn before enabling it here."];
+    } else if (result == ApolloPerAccountFavoritesSetResultInvalidStore) {
+        [self showAlertWithTitle:@"Favorites Data Couldn’t Be Read"
+                         message:@"Per-Account Favorites stayed off and your current favorites were not changed. Restore a known-good settings backup before trying again."];
+    } else {
+        [self showAlertWithTitle:@"Account Still Loading"
+                         message:@"Apollo could not safely identify the active account yet, so Per-Account Favorites stayed off. Wait a moment, then try again."];
+    }
+}
+
 - (void)hideSubredditListDescriptionsSwitchToggled:(UISwitch *)sender {
     sHideSubredditListDescriptions = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sHideSubredditListDescriptions forKey:UDKeyHideSubredditListDescriptions];
@@ -4369,6 +4401,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
 - (NSString *)apollo_screenTitle { return @"Subreddits"; }
 - (NSArray<ApolloSettingsSection *> *)buildForm {
     return @[ [self buildSubredditsMainSection],
+              [self buildSubredditsFavoritesSection],
               [self buildSubredditsSourcesSection] ];
 }
 - (void)viewWillAppear:(BOOL)animated {

--- a/tests/per_account_favorites_manual_checklist.md
+++ b/tests/per_account_favorites_manual_checklist.md
@@ -1,0 +1,41 @@
+# Per-Account Favorites Validation
+
+Run the Foundation-only regression harness on macOS:
+
+```sh
+sh tests/run_per_account_favorites_tests.sh
+```
+
+The harness compiles the production favorites state machine, mocks account
+identity, and uses isolated preferences. It covers the queued-refresh race and
+genuine edits, but does not exercise Apollo's runtime hooks or visible UI.
+
+Before device testing, export a settings backup. Use at least two accounts with
+distinct subscriptions. The setting is under Apollo Reborn > Subreddits >
+Favorites > Per-Account Favorites.
+
+- With the setting off (the default), confirm favorites remain shared across
+  accounts and normal favorite/unfavorite/reorder actions still work.
+- Enable it for the first time. Confirm every existing account begins with the
+  previous shared favorites in the same order.
+- Give accounts A and B different favorites and different favorite orders. Use
+  quick switching repeatedly in both directions; confirm favorites refresh
+  immediately and the Account tab, subscriptions, and selected account agree.
+- Switch using the full account picker too. Drag inactive account B to another
+  position while A is active; confirm this does not change the active account,
+  subscriptions, or favorites. This checks the account-switcher fix inherited
+  from main, not an additional favorites patch.
+- Add a new account after opting in; confirm its favorites start empty without
+  changing existing accounts. Check the logged-out list separately, then sign
+  back in and confirm each saved list is intact.
+- Disable the setting. Confirm the original shared list returns. Edit that list
+  while off, re-enable, and confirm the saved per-account lists return. Disable
+  again and confirm the shared edits made while off remain intact.
+- Relaunch with the setting on and then off; confirm the setting, favorites,
+  and favorite ordering persist in each mode.
+- Export and restore a settings backup with distinct account/shared lists.
+  After the required relaunch, verify the toggle and every saved list. Also
+  check that a backup without per-account data keeps the default shared mode.
+- Repeat the switching and toggle checks in the Liquid Glass device IPA that
+  will be used for acceptance testing; verify both visible favorites surfaces
+  and the native account state rather than only the Account tab label.

--- a/tests/per_account_favorites_tests.m
+++ b/tests/per_account_favorites_tests.m
@@ -1,0 +1,304 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#import "ApolloAccountCredentials.h"
+#import "ApolloPerAccountFavorites.h"
+#import "UserDefaultConstants.h"
+
+// The runner compiles the production implementation, with only its UIKit-based
+// logging import replaced. Each case gets a new process and a unique defaults
+// suite, so it needs neither a production reset API nor the simulator's data.
+// The three identity providers stand in for AccountManager's runtime state.
+BOOL sPerAccountFavoritesEnabled = NO;
+static ApolloPersistedAccountIdentityStatus sTestLiveStatus = ApolloPersistedAccountIdentitySignedIn;
+static ApolloPersistedAccountIdentityStatus sTestPersistedStatus = ApolloPersistedAccountIdentitySignedIn;
+static NSString *sTestLiveUsername = @"a";
+static NSString *sTestPersistedUsername = @"a";
+static NSUInteger sTestIdentityLookups = 0;
+static NSUserDefaults *sTestDefaults = nil;
+
+ApolloPersistedAccountIdentityStatus ApolloResolveLiveActiveAccountIdentity(
+    NSString **outNormalizedUsername) {
+    sTestIdentityLookups++;
+    if (outNormalizedUsername) *outNormalizedUsername = sTestLiveUsername;
+    return sTestLiveStatus;
+}
+
+ApolloPersistedAccountIdentityStatus ApolloResolvePersistedActiveAccountIdentity(
+    NSString **outNormalizedUsername) {
+    sTestIdentityLookups++;
+    if (outNormalizedUsername) *outNormalizedUsername = sTestPersistedUsername;
+    return sTestPersistedStatus;
+}
+
+BOOL ApolloResolvePersistedAccountUsernames(NSSet<NSString *> **outUsernames) {
+    sTestIdentityLookups++;
+    if (outUsernames) *outUsernames = [NSSet setWithArray:@[@"a", @"b"]];
+    return YES;
+}
+
+@interface ApolloFavoritesTestDefaults : NSUserDefaults
+- (void)setNativeFavoritesWithoutSetterHook:(NSArray<NSString *> *)favorites;
+@end
+
+@implementation ApolloFavoritesTestDefaults
+
+- (void)setObject:(id)value forKey:(NSString *)key {
+    [super setObject:value forKey:key];
+    // Match the relevant Tweak.xm hook: every actual native-key setter calls
+    // the public mutation entry point, including writes during a notification.
+    // Production projection writes must suppress themselves in the real module.
+    if ([key isEqualToString:UDKeyApolloFavoriteSubreddits]) {
+        ApolloPerAccountFavoritesNativeFavoritesDidChange();
+    }
+}
+
+- (void)setNativeFavoritesWithoutSetterHook:(NSArray<NSString *> *)favorites {
+    // Model an alternate native persistence path so the unmarked-notification
+    // fallback is tested independently of our normal setter-hook shim.
+    [super setObject:favorites forKey:UDKeyApolloFavoriteSubreddits];
+}
+
+@end
+
+static NSUserDefaults *TestStandardUserDefaults(id receiver, SEL selector) {
+    (void)receiver;
+    (void)selector;
+    return sTestDefaults;
+}
+
+static void Require(BOOL condition, NSString *message) {
+    if (!condition) {
+        @throw [NSException exceptionWithName:@"PerAccountFavoritesTestFailure"
+                                       reason:message userInfo:nil];
+    }
+}
+
+static NSArray<NSString *> *NativeFavorites(void) {
+    return [sTestDefaults objectForKey:UDKeyApolloFavoriteSubreddits];
+}
+
+static NSDictionary<NSString *, NSArray<NSString *> *> *Buckets(void) {
+    return [sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits][@"buckets"];
+}
+
+static void RequireList(NSArray *actual, NSArray *expected, NSString *message) {
+    Require([actual isEqualToArray:expected],
+            [NSString stringWithFormat:@"%@ (expected %@; got %@)", message, expected, actual]);
+}
+
+static void SeedReadyStore(void) {
+    [sTestDefaults setObject:@{
+        @"version": @1,
+        @"buckets": @{
+            @"anonymous": @[@"anonymous"],
+            @"shared": @[@"shared"],
+            @"u:a": @[@"a"],
+            @"u:b": @[@"b"],
+        },
+    } forKey:UDKeyPerAccountFavoriteSubreddits];
+    [sTestDefaults setObject:@[@"shared"] forKey:UDKeyApolloFavoriteSubreddits];
+    [sTestDefaults setBool:YES forKey:UDKeyPerAccountFavoritesEnabled];
+    sPerAccountFavoritesEnabled = YES;
+}
+
+static void DrainMainQueue(void) {
+    // Drain the real dispatch_async refresh. The marker is enqueued after it;
+    // there is no test-only call into the observer or implementation internals.
+    __block BOOL drained = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{ drained = YES; });
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:1.0];
+    while (!drained && [deadline timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                               beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+    Require(drained, @"main queue drain completes");
+}
+
+static void StartAndEnterUnknownIdentity(void) {
+    SeedReadyStore();
+    ApolloPerAccountFavoritesStart();
+    RequireList(NativeFavorites(), @[@"a"], @"startup projects A's favorites");
+
+    // Start has queued its own refresh but it has not been delivered yet.
+    // The persisted mirror still names A while AccountManager is unreadable.
+    sTestLiveStatus = ApolloPersistedAccountIdentityUnknown;
+    sTestLiveUsername = nil;
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    RequireList(NativeFavorites(), @[@"a"], @"unknown identity retains A's projection");
+}
+
+static void ResolveAccountB(void) {
+    sTestLiveStatus = ApolloPersistedAccountIdentitySignedIn;
+    sTestLiveUsername = @"b";
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+}
+
+static void DisableFavorites(void) {
+    Require(ApolloPerAccountFavoritesSetEnabled(NO) == ApolloPerAccountFavoritesSetResultApplied,
+            @"disabling succeeds while identity is unknown");
+    Require(!sPerAccountFavoritesEnabled, @"feature flag is off after disabling");
+}
+
+static void TestInternalRefreshThenSwitch(void) {
+    StartAndEnterUnknownIdentity();
+    __block NSUInteger delivered = 0;
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloFavoriteSubredditsUpdatedNotification
+                    object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+        delivered++;
+    }];
+    DrainMainQueue();
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    Require(delivered == 1, @"native consumers still receive the queued projection refresh");
+
+    ResolveAccountB();
+    RequireList(Buckets()[@"shared"], @[@"shared"],
+                @"an internal refresh must not overwrite the shared bucket on switch");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"A's bucket is unchanged");
+    RequireList(NativeFavorites(), @[@"b"], @"B's favorites are projected");
+}
+
+static void TestInternalRefreshThenDisable(void) {
+    StartAndEnterUnknownIdentity();
+    DrainMainQueue();
+    DisableFavorites();
+    RequireList(Buckets()[@"shared"], @[@"shared"],
+                @"an internal refresh must not overwrite the shared bucket on disable");
+    RequireList(NativeFavorites(), @[@"shared"], @"disabling restores the original shared list");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"A's saved favorites remain intact");
+}
+
+static void TestNativeWriteThenSwitch(void) {
+    StartAndEnterUnknownIdentity();
+    DrainMainQueue();
+    [sTestDefaults setObject:@[@"edited"] forKey:UDKeyApolloFavoriteSubreddits];
+    ResolveAccountB();
+    RequireList(Buckets()[@"shared"], @[@"edited"],
+                @"a genuine unattributed native write is preserved on switch");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"an unknown-identity write cannot cross-write A");
+    RequireList(NativeFavorites(), @[@"b"], @"B's saved favorites replace the quarantined list");
+}
+
+static void TestNativeWriteThenDisable(void) {
+    StartAndEnterUnknownIdentity();
+    DrainMainQueue();
+    [sTestDefaults setObject:@[@"edited"] forKey:UDKeyApolloFavoriteSubreddits];
+    DisableFavorites();
+    RequireList(Buckets()[@"shared"], @[@"edited"],
+                @"a genuine unattributed native write is preserved on disable");
+    RequireList(NativeFavorites(), @[@"edited"], @"disabling does not erase the genuine edit");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"A's saved favorites remain intact");
+}
+
+static void TestReentrantNativeWriteDuringRefresh(void) {
+    StartAndEnterUnknownIdentity();
+    __block BOOL wroteDuringRefresh = NO;
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloFavoriteSubredditsUpdatedNotification
+                    object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+        wroteDuringRefresh = YES;
+        [sTestDefaults setObject:@[@"edited"] forKey:UDKeyApolloFavoriteSubreddits];
+    }];
+    DrainMainQueue();
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    Require(wroteDuringRefresh, @"a native consumer performed a real setter during refresh delivery");
+
+    ResolveAccountB();
+    RequireList(Buckets()[@"shared"], @[@"edited"],
+                @"filtering the internal refresh must not suppress a reentrant genuine setter");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"the reentrant edit cannot cross-write A");
+    RequireList(NativeFavorites(), @[@"b"], @"B still receives its own projection");
+}
+
+static void TestUnmarkedNativeNotification(void) {
+    StartAndEnterUnknownIdentity();
+    DrainMainQueue();
+    [(ApolloFavoritesTestDefaults *)sTestDefaults setNativeFavoritesWithoutSetterHook:@[@"edited"]];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    ResolveAccountB();
+    RequireList(Buckets()[@"shared"], @[@"edited"],
+                @"an ordinary unmarked notification still captures a genuine native edit");
+    RequireList(Buckets()[@"u:a"], @[@"a"], @"the notification fallback cannot cross-write A");
+    RequireList(NativeFavorites(), @[@"b"], @"the notification fallback leaves B's projection intact");
+}
+
+static void TestFeatureOffIsDormant(void) {
+    [sTestDefaults setObject:@[@"shared"] forKey:UDKeyApolloFavoriteSubreddits];
+    ApolloPerAccountFavoritesStart();
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    ApolloPerAccountFavoritesAccountStateDidChange();
+    ApolloPerAccountFavoritesAccountsCollectionDidChange();
+    [sTestDefaults setObject:@[@"off-edit"] forKey:UDKeyApolloFavoriteSubreddits];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    DrainMainQueue();
+    Require(sTestIdentityLookups == 0, @"the feature-off path never resolves account identity");
+    Require(!sPerAccountFavoritesEnabled, @"ordinary native activity never opts in");
+    Require([sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits] == nil,
+            @"ordinary native activity does not create an account store");
+    RequireList(NativeFavorites(), @[@"off-edit"], @"native shared favorites keep working while off");
+}
+
+static void TestFirstEnableClonesSharedFavorites(void) {
+    [sTestDefaults setObject:@[@"shared", @"ordered"] forKey:UDKeyApolloFavoriteSubreddits];
+    ApolloPerAccountFavoritesStart();
+    Require(ApolloPerAccountFavoritesSetEnabled(YES) == ApolloPerAccountFavoritesSetResultApplied,
+            @"first opt-in succeeds with known accounts");
+    for (NSString *scope in @[@"shared", @"anonymous", @"u:a", @"u:b"]) {
+        RequireList(Buckets()[scope], @[@"shared", @"ordered"],
+                    [NSString stringWithFormat:@"migration clones the ordered shared list to %@", scope]);
+    }
+    RequireList(NativeFavorites(), @[@"shared", @"ordered"], @"first enable is non-destructive");
+    Require(sPerAccountFavoritesEnabled, @"the explicit opt-in enables the feature");
+}
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        if (argc != 2) {
+            fprintf(stderr, "Usage: per_account_favorites_tests <scenario>\n");
+            return 2;
+        }
+        NSString *scenario = [NSString stringWithUTF8String:argv[1]];
+        NSString *suiteName = [@"app.apolloreborn.tests.per-account-favorites."
+            stringByAppendingString:[NSUUID UUID].UUIDString];
+        sTestDefaults = [[ApolloFavoritesTestDefaults alloc] initWithSuiteName:suiteName];
+        Require(sTestDefaults != nil, @"create an isolated test defaults suite");
+        Method standardDefaults = class_getClassMethod([NSUserDefaults class], @selector(standardUserDefaults));
+        IMP originalStandardDefaults = method_setImplementation(standardDefaults, (IMP)TestStandardUserDefaults);
+        int result = 0;
+        @try {
+            if ([scenario isEqualToString:@"internal-refresh-switch"]) {
+                TestInternalRefreshThenSwitch();
+            } else if ([scenario isEqualToString:@"internal-refresh-disable"]) {
+                TestInternalRefreshThenDisable();
+            } else if ([scenario isEqualToString:@"native-write-switch"]) {
+                TestNativeWriteThenSwitch();
+            } else if ([scenario isEqualToString:@"native-write-disable"]) {
+                TestNativeWriteThenDisable();
+            } else if ([scenario isEqualToString:@"reentrant-native-write"]) {
+                TestReentrantNativeWriteDuringRefresh();
+            } else if ([scenario isEqualToString:@"unmarked-native-notification"]) {
+                TestUnmarkedNativeNotification();
+            } else if ([scenario isEqualToString:@"feature-off"]) {
+                TestFeatureOffIsDormant();
+            } else if ([scenario isEqualToString:@"first-enable"]) {
+                TestFirstEnableClonesSharedFavorites();
+            } else {
+                Require(NO, [@"unknown scenario: " stringByAppendingString:scenario]);
+            }
+            printf("PASS %s\n", scenario.UTF8String);
+        } @catch (NSException *exception) {
+            fprintf(stderr, "FAIL %s: %s\n", scenario.UTF8String, exception.reason.UTF8String);
+            result = 1;
+        } @finally {
+            // Only this freshly generated test domain is removed. Never touch
+            // the host's standard preferences or an Apollo/simulator domain.
+            method_setImplementation(standardDefaults, originalStandardDefaults);
+            [sTestDefaults removePersistentDomainForName:suiteName];
+            [sTestDefaults synchronize];
+        }
+        return result;
+    }
+}

--- a/tests/run_per_account_favorites_tests.sh
+++ b/tests/run_per_account_favorites_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+# Build the actual feature module as a macOS Foundation executable. Each named
+# scenario runs in its own process to isolate the production module's statics.
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-per-account-favorites-tests.XXXXXX")
+test_binary="$test_build_dir/per_account_favorites_tests"
+trap 'rm -f -- "$test_binary"; rmdir -- "$test_build_dir"' EXIT HUP INT TERM
+
+xcrun --sdk macosx clang -fobjc-arc -fblocks -Wall -Wextra -Werror \
+    -framework Foundation -DAPOLLO_PER_ACCOUNT_FAVORITES_TESTING \
+    -I "$test_repo_root/src" \
+    "$test_repo_root/src/ApolloPerAccountFavorites.m" \
+    "$test_repo_root/tests/per_account_favorites_tests.m" \
+    -o "$test_binary"
+
+test_failures=0
+for test_scenario in \
+    internal-refresh-switch \
+    internal-refresh-disable \
+    native-write-switch \
+    native-write-disable \
+    reentrant-native-write \
+    unmarked-native-notification \
+    feature-off \
+    first-enable; do
+    if ! "$test_binary" "$test_scenario"; then
+        test_failures=$((test_failures + 1))
+    fi
+done
+
+if [ "$test_failures" -ne 0 ]; then
+    printf 'per_account_favorites_tests: %s scenario(s) failed\n' "$test_failures" >&2
+    exit 1
+fi
+printf 'per_account_favorites_tests: all 8 scenarios passed\n'


### PR DESCRIPTION
## Summary 

Adds an option to have a separate set of subreddit favorites for each account. This is opt-in and off by default.

## How it works

Favorites automatically refresh when switching accounts, including quick account switching.
- First time enabling it copies your current favorites to existing accounts.
- New accounts added after that start with an empty list.
- Turning it off restores the shared favorites list.
- Turning it back on brings back your saved per-account lists.
- Favorites and the setting are included in backup/restore.

Tested on device.