### PR TITLE
Liquid Glass: keep the top fade through tab switches, and make swipe-back track the nav bar (title/search bar)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
     $(SRC_DIR)/ApolloTabBarTitles.xm \
     $(SRC_DIR)/ApolloScrollEdgePopFix.xm \
+    $(SRC_DIR)/ApolloInterruptibleNavTransition.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloModmailSubjectCounter.xm \

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -158,6 +158,11 @@ void ApolloLGTitleCenteringModeChanged(void);
 // Keeps the Liquid Glass title capsule in sync with a custom title view's
 // independently-faded content (defined in ApolloLiquidGlass.xm; no-op off LG).
 void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alpha);
+// Re-run the title capsule install/recentre for every title control in the bar (used when a
+// navigation transition settles). ApolloLiquidGlass.xm.
+void ApolloNavigationTitleGlassRefreshNavigationBar(UINavigationBar *bar);
+// YES while ApolloInterruptibleNavTransition is running a push/pop (Liquid Glass only).
+BOOL ApolloNavTransitionInFlight(void);
 
 // Apollo's main ApolloTabBarController, found via the scene/app delegate's
 // tabBarController ivar or by walking window root VCs. Returns nil while the

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -161,7 +161,7 @@ void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alph
 // Re-run the title capsule install/recentre for every title control in the bar (used when a
 // navigation transition settles). ApolloLiquidGlass.xm.
 void ApolloNavigationTitleGlassRefreshNavigationBar(UINavigationBar *bar);
-// YES while ApolloInterruptibleNavTransition is running a push/pop (Liquid Glass only).
+// YES through interactive push/pop setup and UIKit's completion cleanup (Liquid Glass only).
 BOOL ApolloNavTransitionInFlight(void);
 
 // Apollo's main ApolloTabBarController, found via the scene/app delegate's

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -40,12 +40,31 @@
 //   0.225s linear when interactive, 0.5s spring (damping 1.0, initial velocity 4.0) otherwise.
 // Apollo's search-mode special cases (hiding the bar while a search is presented) are not
 // reproduced: on Liquid Glass the native search bar module keeps the bar in place anyway.
+//
+// TWO THINGS THE INTERRUPTIBLE PATH CHANGES, HANDLED HERE
+// - UIKit only disables user interaction on the transitioning views for NON-interruptible
+//   animators. Left interactive, the finger that started the edge pan still delivers its
+//   delayed touch to the post cell under it, which lit up the cell's highlight for two
+//   frames at the start of every swipe. Both views are made non-interactive for the
+//   transition and restored on completion, matching what UIKit did before.
+// - The bar now genuinely cross-fades, so the incoming title control exists at partial alpha
+//   for the whole drag. ApolloLiquidGlass installs its title capsule on any title control
+//   that appears, which put a translucent capsule at the incoming title's (differently
+//   centred) position — the "faded bubble in an odd spot" on a cancelled swipe. The capsule
+//   code consults ApolloNavTransitionInFlight() and skips new installs/recentres while an
+//   INTERACTIVE transition runs; the completion below asks it to refresh the settled bar,
+//   where the winning title's capsule fades in. Timed push/pop is left exactly as before.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
 
 static const void *kApolloNavAnimatorKey = &kApolloNavAnimatorKey;
+static NSUInteger sApolloNavTransitionsInFlight;
+
+BOOL ApolloNavTransitionInFlight(void) {
+    return sApolloNavTransitionsInFlight > 0;
+}
 static const CGFloat kApolloNavParallaxDivisor = 3.0;
 static const NSTimeInterval kApolloNavInteractiveDuration = 0.225;
 static const NSTimeInterval kApolloNavNonInteractiveDuration = 0.5;
@@ -108,7 +127,21 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         [container insertSubview:dim belowSubview:shadow];
     }
 
+    // UIKit does this itself for non-interruptible animators; without it the touch that
+    // began the edge pan keeps feeding the cell under the finger (delayed highlight flash).
+    BOOL fromWasInteractive = fromView.userInteractionEnabled;
+    BOOL toWasInteractive = toView.userInteractionEnabled;
+    fromView.userInteractionEnabled = NO;
+    toView.userInteractionEnabled = NO;
+    UINavigationBar *navigationBar = toVC.navigationController.navigationBar
+        ?: fromVC.navigationController.navigationBar;
+
     BOOL interactive = ctx.isInteractive;
+    // Only an interactive transition holds the title capsules back: a finger-driven cross-fade
+    // can sit at partial alpha indefinitely and then reverse, which is where a capsule on the
+    // incoming title reads as a stray bubble. A timed push/pop cross-fades capsule and title
+    // together in half a second, exactly as it always did.
+    if (interactive) sApolloNavTransitionsInFlight++;
     NSTimeInterval duration = interactive ? kApolloNavInteractiveDuration : kApolloNavNonInteractiveDuration;
     UIViewPropertyAnimator *animator;
     if (interactive) {
@@ -144,7 +177,13 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
             // Reversal already put the views back; make the rest frames exact.
             fromView.frame = fromRest;
         }
+        fromView.userInteractionEnabled = fromWasInteractive;
+        toView.userInteractionEnabled = toWasInteractive;
+        if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
         [ctx completeTransition:!cancelled];
+        // The bar has settled on whichever item won; give the title capsules that were held
+        // back during the cross-fade their chance now (they fade in rather than pop).
+        if (interactive) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);
         id strong = weakAnimatorObject;
         if (strong) objc_setAssociatedObject(strong, kApolloNavAnimatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }];

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -27,11 +27,11 @@
 // whole thing smoothly. This module puts Apollo's transition on that path.
 //
 // WHAT IT DOES
-// Registers interruptibleAnimatorForTransition: (and animationEnded:) on Apollo's animator
-// class, Liquid Glass only (the methods are added by %init of a gated group, so pre-26 builds
-// keep Apollo's class untouched). animateTransition: then just starts that animator. The
-// animator reproduces Apollo's own geometry, recovered from the binary and confirmed with a
-// live capture (sub_100683738 pop / sub_100682b04 push / sub_1006845bc shadow):
+// Registers interruptibleAnimatorForTransition: on Apollo's animator class, Liquid Glass only
+// (the method is added by %init of a gated group, so pre-26 builds keep Apollo's class
+// untouched). animateTransition: then just starts that animator. The animator reproduces
+// Apollo's own geometry, recovered from the binary and confirmed with a live capture
+// (sub_100683738 pop / sub_100682b04 push / sub_1006845bc shadow):
 //   pop:  incoming view starts at x = -width/3 and slides to 0 under a black 15% dim that
 //         fades out; outgoing view slides to x = width with a shadow view (black, alpha 0.25
 //         light / 0.05 dark, offset (-5,0), radius 4, opacity 0.3) that fades out with it.
@@ -40,6 +40,23 @@
 //   0.225s linear when interactive, 0.5s spring (damping 1.0, initial velocity 4.0) otherwise.
 // Apollo's search-mode special cases (hiding the bar while a search is presented) are not
 // reproduced: on Liquid Glass the native search bar module keeps the bar in place anyway.
+//
+// ONE ANIMATOR PER TRANSITION, FOUND BY ITS CONTEXT
+// ApolloNavigationController keeps a single ApolloNavigationAnimator and reuses it for every
+// push and pop (it only flips isPresenting), so "the animator cached on that object" cannot
+// tell transitions apart. UIKit asks interruptibleAnimatorForTransition: several times per
+// transition (the bar's alongside animations, the percent-driven scrub, and our own
+// animateTransition:) and every ask for one context must get the same UIViewPropertyAnimator,
+// while a different context must always get a fresh one. Transitions also overlap on the
+// stack: completeTransition: runs the navigation controller's completion synchronously, and a
+// push or pop issued from there (didShowViewController: and friends) is built and started
+// before the finishing transition's completion block even returns, with UIKit's own
+// animationEnded: arriving last of all. So the cache is keyed on the context: the latest
+// animator is kept on Apollo's animator object, each animator remembers (weakly) the context
+// it was built for, and a lookup only hits when that context is the one asking. Nothing is
+// ever cleared. A finished animator simply sits there until the next transition replaces it,
+// and because the context reference is weak, a context that has been freed reads as nil, so a
+// new context recycled at the same address can never be handed a finished animator.
 //
 // TWO THINGS THE INTERRUPTIBLE PATH CHANGES, HANDLED HERE
 // - UIKit only disables user interaction on the transitioning views for NON-interruptible
@@ -59,8 +76,29 @@
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
 
+// Apollo's animator object -> the most recently built UIViewPropertyAnimator.
 static const void *kApolloNavAnimatorKey = &kApolloNavAnimatorKey;
+// UIViewPropertyAnimator -> ApolloNavContextRef naming the transition context it was built for.
+static const void *kApolloNavAnimatorContextKey = &kApolloNavAnimatorContextKey;
 static NSUInteger sApolloNavTransitionsInFlight;
+
+// Weak on purpose: the context must not outlive UIKit's own interest in it (a popped controller
+// deallocates with its transition, not at the next one), and a freed context reads as nil here
+// rather than aliasing whatever gets allocated at its address next.
+@interface ApolloNavContextRef : NSObject
+@property (nonatomic, weak) id<UIViewControllerContextTransitioning> context;
+@end
+@implementation ApolloNavContextRef
+@end
+
+static UIViewPropertyAnimator *ApolloNavAnimatorForContext(id animatorObject,
+                                                            id<UIViewControllerContextTransitioning> ctx) {
+    UIViewPropertyAnimator *animator = objc_getAssociatedObject(animatorObject, kApolloNavAnimatorKey);
+    if (!animator || !ctx) return nil;
+    ApolloNavContextRef *ref = objc_getAssociatedObject(animator, kApolloNavAnimatorContextKey);
+    id<UIViewControllerContextTransitioning> owner = ref.context;
+    return (owner && owner == ctx) ? animator : nil;
+}
 
 BOOL ApolloNavTransitionInFlight(void) {
     return sApolloNavTransitionsInFlight > 0;
@@ -108,12 +146,14 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     UIView *shadow = nil;
     UIView *dim = [[UIView alloc] initWithFrame:container.bounds];
     dim.backgroundColor = [UIColor colorWithWhite:0.0 alpha:kApolloNavDimAlpha];
+    dim.accessibilityIdentifier = @"ApolloNavTransitionDim";
 
     if (push) {
         [container addSubview:toView];
         toView.frame = CGRectOffset(toRest, width, 0.0);
         fromView.frame = fromRest;
         shadow = ApolloNavMakeShadowView(toView.frame, container.traitCollection);
+        shadow.accessibilityIdentifier = @"ApolloNavTransitionShadow";
         [container insertSubview:shadow belowSubview:toView];
         dim.alpha = 0.0;
         [container insertSubview:dim belowSubview:shadow];
@@ -122,6 +162,7 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         fromView.frame = fromRest;
         toView.frame = CGRectOffset(toRest, -parallax, 0.0);
         shadow = ApolloNavMakeShadowView(fromRest, container.traitCollection);
+        shadow.accessibilityIdentifier = @"ApolloNavTransitionShadow";
         [container insertSubview:shadow belowSubview:fromView];
         dim.alpha = 1.0;
         [container insertSubview:dim belowSubview:shadow];
@@ -137,6 +178,9 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         ?: fromVC.navigationController.navigationBar;
 
     BOOL interactive = ctx.isInteractive;
+    ApolloLog(@"[InterruptibleNav] built %s animator for ctx %p (interactive=%d, %@ -> %@)",
+              push ? "push" : "pop", (void *)ctx, interactive,
+              NSStringFromClass(fromVC.class), NSStringFromClass(toVC.class));
     // Only an interactive transition holds the title capsules back: a finger-driven cross-fade
     // can sit at partial alpha indefinitely and then reverse, which is where a capsule on the
     // incoming title reads as a stray bubble. A timed push/pop cross-fades capsule and title
@@ -168,7 +212,6 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
             dim.alpha = 0.0;
         }
     }];
-    __weak id weakAnimatorObject = animatorObject;
     [animator addCompletion:^(UIViewAnimatingPosition position) {
         [shadow removeFromSuperview];
         [dim removeFromSuperview];
@@ -180,13 +223,18 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         fromView.userInteractionEnabled = fromWasInteractive;
         toView.userInteractionEnabled = toWasInteractive;
         if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
+        ApolloLog(@"[InterruptibleNav] %s animator for ctx %p finished (cancelled=%d)",
+                  push ? "push" : "pop", (void *)ctx, cancelled);
+        // No cache bookkeeping here: this may synchronously start the next transition (a push or
+        // pop issued from didShowViewController:), whose animator must survive untouched. The
+        // per-context lookup in interruptibleAnimatorForTransition: keeps the two apart.
         [ctx completeTransition:!cancelled];
         // The bar has settled on whichever item won; give the title capsules that were held
         // back during the cross-fade their chance now (they fade in rather than pop).
         if (interactive) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);
-        id strong = weakAnimatorObject;
-        if (strong) objc_setAssociatedObject(strong, kApolloNavAnimatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }];
+    // The animator's blocks hold ctx, the views and the dim/shadow until it finishes;
+    // UIViewPropertyAnimator drops them then, so nothing here outlives the transition.
     return animator;
 }
 
@@ -196,9 +244,13 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
 
 %new
 - (id<UIViewImplicitlyAnimating>)interruptibleAnimatorForTransition:(id<UIViewControllerContextTransitioning>)ctx {
-    UIViewPropertyAnimator *animator = objc_getAssociatedObject(self, kApolloNavAnimatorKey);
+    if (!ctx) return nil;
+    UIViewPropertyAnimator *animator = ApolloNavAnimatorForContext(self, ctx);
     if (animator) return animator;
     animator = ApolloNavBuildAnimator(self, ctx);
+    ApolloNavContextRef *ref = [ApolloNavContextRef new];
+    ref.context = ctx;
+    objc_setAssociatedObject(animator, kApolloNavAnimatorContextKey, ref, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(self, kApolloNavAnimatorKey, animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return animator;
 }
@@ -210,10 +262,10 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     [animator startAnimation];
 }
 
-%new
-- (void)animationEnded:(BOOL)transitionCompleted {
-    objc_setAssociatedObject(self, kApolloNavAnimatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
+// No animationEnded: on purpose. UIKit sends it from completeTransition: after the navigation
+// controller's completion handler has run, so by then the next transition may already own the
+// cache slot, and with one shared animator object there is no way to tell which transition the
+// call is about. The per-context lookup above makes it unnecessary.
 
 %end
 

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -1,0 +1,192 @@
+// ApolloInterruptibleNavTransition — run Apollo's push/pop animation through an interruptible
+// UIViewPropertyAnimator on Liquid Glass, so UIKit drives the navigation bar the way it does
+// for its own transitions.
+//
+// THE SYMPTOM
+// On iOS 26, starting a swipe-back on a feed snaps the navigation bar to the previous screen
+// the instant the edge pan is recognised: the title flips (Home -> Subreddits), the search
+// palette collapses and the bar loses its height, all before the finger has moved more than a
+// few points and while the feed is still fully on screen. Letting go (cancel) snaps it all
+// back, with a one-frame layout jump under the bar. The right-hand pills never change, so the
+// bar is visibly not cross-fading — it is being re-displayed.
+//
+// THE CAUSE (traced against decompiled UIKitCore 23B85 + a live sim trace)
+// Apollo's ApolloNavigationAnimator is a plain UIViewControllerAnimatedTransitioning: it
+// implements transitionDuration:/animateTransition: only, driving UIView block animations.
+// For such a NON-interruptible animator, UINavigationController falls back to
+// "tracked animations" for the bar: _UINavigationBarTransitionAssistant starts a
+// UIViewPropertyAnimator tracking scope, runs the bar's item change inside it, and later
+// scrubs the tracked animator with the gesture percent. That scope captures nothing from the
+// iOS 26 bar (assistant animationCount stays 0; the item change lands as a plain layout), so
+// the bar swaps immediately and the scrubbing has nothing to move.
+//
+// UIKit's own navigation transition is INTERRUPTIBLE (interruptibleAnimatorForTransition:),
+// and on that path the bar's transition animations are added alongside the interruptible
+// animator and scrubbed through its fractionComplete by the percent-driven interaction — the
+// title cross-fades with the finger, the palette height animates, and a cancel reverses the
+// whole thing smoothly. This module puts Apollo's transition on that path.
+//
+// WHAT IT DOES
+// Registers interruptibleAnimatorForTransition: (and animationEnded:) on Apollo's animator
+// class, Liquid Glass only (the methods are added by %init of a gated group, so pre-26 builds
+// keep Apollo's class untouched). animateTransition: then just starts that animator. The
+// animator reproduces Apollo's own geometry, recovered from the binary and confirmed with a
+// live capture (sub_100683738 pop / sub_100682b04 push / sub_1006845bc shadow):
+//   pop:  incoming view starts at x = -width/3 and slides to 0 under a black 15% dim that
+//         fades out; outgoing view slides to x = width with a shadow view (black, alpha 0.25
+//         light / 0.05 dark, offset (-5,0), radius 4, opacity 0.3) that fades out with it.
+//   push: mirror image — incoming view slides in from x = width with the shadow, outgoing
+//         view slides to x = -width/3 under the dim fading in.
+//   0.225s linear when interactive, 0.5s spring (damping 1.0, initial velocity 4.0) otherwise.
+// Apollo's search-mode special cases (hiding the bar while a search is presented) are not
+// reproduced: on Liquid Glass the native search bar module keeps the bar in place anyway.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+static const void *kApolloNavAnimatorKey = &kApolloNavAnimatorKey;
+static const CGFloat kApolloNavParallaxDivisor = 3.0;
+static const NSTimeInterval kApolloNavInteractiveDuration = 0.225;
+static const NSTimeInterval kApolloNavNonInteractiveDuration = 0.5;
+static const CGFloat kApolloNavDimAlpha = 0.15;
+
+static BOOL ApolloNavAnimatorIsPresenting(id animator) {
+    Ivar ivar = class_getInstanceVariable([animator class], "isPresenting");
+    if (!ivar) return YES;
+    return *(BOOL *)((char *)(__bridge void *)animator + ivar_getOffset(ivar));
+}
+
+static UIView *ApolloNavMakeShadowView(CGRect frame, UITraitCollection *traits) {
+    UIView *shadow = [[UIView alloc] initWithFrame:frame];
+    shadow.backgroundColor = UIColor.clearColor;
+    shadow.clipsToBounds = NO;
+    BOOL dark = traits.userInterfaceStyle == UIUserInterfaceStyleDark;
+    CALayer *layer = shadow.layer;
+    layer.shadowColor = [UIColor colorWithWhite:0.0 alpha:dark ? 0.05 : 0.25].CGColor;
+    layer.shadowOffset = CGSizeMake(-5.0, 0.0);
+    layer.shadowRadius = 4.0;
+    layer.shadowOpacity = 0.3f;
+    layer.shadowPath = [UIBezierPath bezierPathWithRect:shadow.bounds].CGPath;
+    layer.shouldRasterize = YES;
+    layer.rasterizationScale = UIScreen.mainScreen.scale;
+    return shadow;
+}
+
+static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
+                                                       id<UIViewControllerContextTransitioning> ctx) {
+    UIView *container = ctx.containerView;
+    UIViewController *fromVC = [ctx viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIViewController *toVC = [ctx viewControllerForKey:UITransitionContextToViewControllerKey];
+    UIView *fromView = [ctx viewForKey:UITransitionContextFromViewKey] ?: fromVC.view;
+    UIView *toView = [ctx viewForKey:UITransitionContextToViewKey] ?: toVC.view;
+    BOOL push = ApolloNavAnimatorIsPresenting(animatorObject);
+    CGFloat width = CGRectGetWidth(container.bounds);
+    CGFloat parallax = width / kApolloNavParallaxDivisor;
+
+    CGRect fromRest = (CGRect){CGPointZero, fromView.bounds.size};
+    CGRect toRest = (CGRect){CGPointZero, toView.bounds.size};
+    UIView *shadow = nil;
+    UIView *dim = [[UIView alloc] initWithFrame:container.bounds];
+    dim.backgroundColor = [UIColor colorWithWhite:0.0 alpha:kApolloNavDimAlpha];
+
+    if (push) {
+        [container addSubview:toView];
+        toView.frame = CGRectOffset(toRest, width, 0.0);
+        fromView.frame = fromRest;
+        shadow = ApolloNavMakeShadowView(toView.frame, container.traitCollection);
+        [container insertSubview:shadow belowSubview:toView];
+        dim.alpha = 0.0;
+        [container insertSubview:dim belowSubview:shadow];
+    } else {
+        [container insertSubview:toView belowSubview:fromView];
+        fromView.frame = fromRest;
+        toView.frame = CGRectOffset(toRest, -parallax, 0.0);
+        shadow = ApolloNavMakeShadowView(fromRest, container.traitCollection);
+        [container insertSubview:shadow belowSubview:fromView];
+        dim.alpha = 1.0;
+        [container insertSubview:dim belowSubview:shadow];
+    }
+
+    BOOL interactive = ctx.isInteractive;
+    NSTimeInterval duration = interactive ? kApolloNavInteractiveDuration : kApolloNavNonInteractiveDuration;
+    UIViewPropertyAnimator *animator;
+    if (interactive) {
+        animator = [[UIViewPropertyAnimator alloc] initWithDuration:duration
+                                                              curve:UIViewAnimationCurveLinear
+                                                         animations:nil];
+    } else {
+        UISpringTimingParameters *spring =
+            [[UISpringTimingParameters alloc] initWithDampingRatio:1.0 initialVelocity:CGVectorMake(4.0, 0.0)];
+        animator = [[UIViewPropertyAnimator alloc] initWithDuration:duration timingParameters:spring];
+    }
+
+    [animator addAnimations:^{
+        if (push) {
+            toView.frame = toRest;
+            shadow.frame = toRest;
+            fromView.frame = CGRectOffset(fromRest, -parallax, 0.0);
+            dim.alpha = 1.0;
+        } else {
+            fromView.frame = CGRectOffset(fromRest, width, 0.0);
+            shadow.frame = CGRectOffset(fromRest, width, 0.0);
+            shadow.alpha = 0.0;
+            toView.frame = toRest;
+            dim.alpha = 0.0;
+        }
+    }];
+    __weak id weakAnimatorObject = animatorObject;
+    [animator addCompletion:^(UIViewAnimatingPosition position) {
+        [shadow removeFromSuperview];
+        [dim removeFromSuperview];
+        BOOL cancelled = ctx.transitionWasCancelled;
+        if (cancelled) {
+            // Reversal already put the views back; make the rest frames exact.
+            fromView.frame = fromRest;
+        }
+        [ctx completeTransition:!cancelled];
+        id strong = weakAnimatorObject;
+        if (strong) objc_setAssociatedObject(strong, kApolloNavAnimatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }];
+    return animator;
+}
+
+%group ApolloInterruptibleNav
+
+%hook _TtC6Apollo24ApolloNavigationAnimator
+
+%new
+- (id<UIViewImplicitlyAnimating>)interruptibleAnimatorForTransition:(id<UIViewControllerContextTransitioning>)ctx {
+    UIViewPropertyAnimator *animator = objc_getAssociatedObject(self, kApolloNavAnimatorKey);
+    if (animator) return animator;
+    animator = ApolloNavBuildAnimator(self, ctx);
+    objc_setAssociatedObject(self, kApolloNavAnimatorKey, animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return animator;
+}
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)ctx {
+    UIViewPropertyAnimator *animator = (UIViewPropertyAnimator *)
+        [(id<UIViewControllerAnimatedTransitioning>)self interruptibleAnimatorForTransition:ctx];
+    if (!animator) { %orig; return; }
+    [animator startAnimation];
+}
+
+%new
+- (void)animationEnded:(BOOL)transitionCompleted {
+    objc_setAssociatedObject(self, kApolloNavAnimatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+%end
+
+%end
+
+%ctor {
+    if (!IsLiquidGlass()) return;
+    Class animatorClass = objc_getClass("_TtC6Apollo24ApolloNavigationAnimator");
+    if (!animatorClass || !class_getInstanceVariable(animatorClass, "isPresenting")) {
+        ApolloLog(@"[InterruptibleNav] ApolloNavigationAnimator not found or changed shape; inactive");
+        return;
+    }
+    %init(ApolloInterruptibleNav);
+    ApolloLog(@"[InterruptibleNav] hook installed (push/pop run through an interruptible animator)");
+}

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -75,6 +75,7 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
+#import "ApolloSearchNativeBar.h"
 
 // Apollo's animator object -> the most recently built UIViewPropertyAnimator.
 static const void *kApolloNavAnimatorKey = &kApolloNavAnimatorKey;
@@ -132,12 +133,19 @@ static UIView *ApolloNavMakeShadowView(CGRect frame, UITraitCollection *traits) 
 
 static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
                                                        id<UIViewControllerContextTransitioning> ctx) {
+    BOOL interactive = ctx.isInteractive;
+    // Loading the views and setting frames can synchronously lay out the bar.
+    // Cover setup too, so transient title controls cannot install capsules.
+    if (interactive) sApolloNavTransitionsInFlight++;
     UIView *container = ctx.containerView;
     UIViewController *fromVC = [ctx viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toVC = [ctx viewControllerForKey:UITransitionContextToViewControllerKey];
     UIView *fromView = [ctx viewForKey:UITransitionContextFromViewKey] ?: fromVC.view;
     UIView *toView = [ctx viewForKey:UITransitionContextToViewKey] ?: toVC.view;
     BOOL push = ApolloNavAnimatorIsPresenting(animatorObject);
+    UISearchController *fromSearch = fromVC.navigationItem.searchController;
+    BOOL restoreSearchOnCancel = ApolloNativeFeedSearchEnabled() && !fromSearch.active &&
+                                 CGRectGetHeight(fromSearch.searchBar.bounds) > 1.0;
     CGFloat width = CGRectGetWidth(container.bounds);
     CGFloat parallax = width / kApolloNavParallaxDivisor;
 
@@ -177,7 +185,6 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     UINavigationBar *navigationBar = toVC.navigationController.navigationBar
         ?: fromVC.navigationController.navigationBar;
 
-    BOOL interactive = ctx.isInteractive;
     ApolloLog(@"[InterruptibleNav] built %s animator for ctx %p (interactive=%d, %@ -> %@)",
               push ? "push" : "pop", (void *)ctx, interactive,
               NSStringFromClass(fromVC.class), NSStringFromClass(toVC.class));
@@ -185,7 +192,6 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     // can sit at partial alpha indefinitely and then reverse, which is where a capsule on the
     // incoming title reads as a stray bubble. A timed push/pop cross-fades capsule and title
     // together in half a second, exactly as it always did.
-    if (interactive) sApolloNavTransitionsInFlight++;
     NSTimeInterval duration = interactive ? kApolloNavInteractiveDuration : kApolloNavNonInteractiveDuration;
     UIViewPropertyAnimator *animator;
     if (interactive) {
@@ -222,13 +228,18 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         }
         fromView.userInteractionEnabled = fromWasInteractive;
         toView.userInteractionEnabled = toWasInteractive;
-        if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
         ApolloLog(@"[InterruptibleNav] %s animator for ctx %p finished (cancelled=%d)",
                   push ? "push" : "pop", (void *)ctx, cancelled);
         // No cache bookkeeping here: this may synchronously start the next transition (a push or
         // pop issued from didShowViewController:), whose animator must survive untouched. The
         // per-context lookup in interruptibleAnimatorForTransition: keeps the two apart.
         [ctx completeTransition:!cancelled];
+        // completeTransition: synchronously restores the item stack and feed
+        // geometry on cancellation. Keep the guard up through that cleanup.
+        if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
+        if (cancelled && restoreSearchOnCancel) {
+            ApolloNativeFeedSearchRestoreCancelledNavigation(fromVC);
+        }
         // The bar has settled on whichever item won; give the title capsules that were held
         // back during the cross-fade their chance now (they fade in rather than pop).
         if (interactive) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -908,6 +908,9 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
 @property (nonatomic, strong) UIVisualEffectView *glassView;
 @property (nonatomic) BOOL refreshScheduled;
 @property (nonatomic) BOOL observationValid;
+// Set by ApolloNavigationTitleGlassRefreshNavigationBar: the next capsule install fades in
+// instead of appearing, because it lands right as an interactive transition settles.
+@property (nonatomic) BOOL fadeNextInstall;
 @property (nonatomic) CGRect observedTitleFrame;
 @property (nonatomic) CGRect observedTitleBounds;
 @property (nonatomic) NSUInteger observedTitleSubviewCount;
@@ -1054,12 +1057,25 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         self.glassHostView = hostView;
     }
     if (!self.glassView) {
+        // A title control that first shows up mid push/pop is the incoming item's, cross-fading
+        // at partial alpha and not yet at its settled position. A capsule installed now reads
+        // as a translucent bubble floating beside the current title (cancelled swipe on the
+        // feed). Skip it; the transition's completion refreshes the bar and installs it then.
+        if (ApolloNavTransitionInFlight()) return;
         self.glassView = [self newRegularGlassView];
         if (!self.glassView) return;
         self.glassView.frame = targetFrame;
         UILabel *profileTitleLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
-        self.glassView.alpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
+        CGFloat targetAlpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
+        self.glassView.alpha = targetAlpha;
         [hostView insertSubview:self.glassView atIndex:0];
+        if (self.fadeNextInstall) {
+            self.fadeNextInstall = NO;
+            UIVisualEffectView *installed = self.glassView;
+            installed.alpha = 0.0;
+            [UIView animateWithDuration:0.2 delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState
+                             animations:^{ installed.alpha = targetAlpha; } completion:nil];
+        }
         ApolloLog(@"[NavigationTitleGlass] installed %@ capsule frame=%@",
                   NSStringFromClass(hostView.class), NSStringFromCGRect(self.glassView.frame));
         return;
@@ -1214,6 +1230,22 @@ static void ApolloUpdateNavigationTitleGlass(UIView *titleControl) {
     [controller scheduleTargetRefresh];
 }
 
+void ApolloNavigationTitleGlassRefreshNavigationBar(UINavigationBar *bar) {
+    if (!IsLiquidGlass() || !bar) return;
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:(UIView *)bar];
+    for (NSUInteger index = 0; index < queue.count && index < 400; index++) {
+        UIView *view = queue[index];
+        if ([NSStringFromClass(view.class) isEqualToString:@"_UINavigationBarTitleControl"]) {
+            ApolloUpdateNavigationTitleGlass(view);
+            ApolloNavigationTitleGlassController *controller =
+                objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
+            if (controller && !controller.glassView) controller.fadeNextInstall = YES;
+            continue;
+        }
+        for (UIView *child in view.subviews) [queue addObject:child];
+    }
+}
+
 void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alpha) {
     if (!IsLiquidGlass() || !contentView) return;
     UIView *titleControl = contentView;
@@ -1248,8 +1280,10 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     }
     if (!bar) return NO;
 
-    // Skip during push/pop so we don't fight UIKit's transition animations.
-    if (bar.layer.animationKeys.count > 0) return NO;
+    // Skip during push/pop so we don't fight UIKit's transition animations. The interruptible
+    // animator on Liquid Glass drives the bar without animation keys on the bar's own layer,
+    // so ask it directly as well.
+    if (bar.layer.animationKeys.count > 0 || ApolloNavTransitionInFlight()) return NO;
 
     // Measure pre-transform position by subtracting our own previous tx.
     CGFloat existingTx = titleControl.transform.tx;

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -1,5 +1,5 @@
 // ApolloScrollEdgePopFix — keep the Liquid Glass scroll-edge fades alive across navigation
-// transitions.
+// transitions and tab switches.
 //
 // THE SYMPTOM
 // On iOS 26 the blurred/dimmed bands that mask content scrolling under the floating nav pills
@@ -69,6 +69,22 @@
 // resettles everything itself from clean geometry. (Earlier attempts froze ONLY
 // _updatePockets and still flickered — the mask rebuild in layoutSubviews was the unpatched
 // half of the storm.)
+//
+// THE TAB SWITCH (same kill switch, different transition)
+// Tapping another tab while the current feed is scrolled flashes the raw content under the
+// status bar / nav pills for a few frames before the new tab fades in. iOS 26 switches tabs
+// with a cross-fade (`_UITabCrossFadeTransition`, vended by the tab bar controller's visual
+// style), which leaves the outgoing view on screen at full opacity for a good ~300ms after
+// `transitionFromViewController:toViewController:transition:shouldSetSelected:` returns and
+// only then fades it. But the very first layout pass after that call — inside the same
+// CATransaction commit — already runs `_updatePockets` on the outgoing scroll views with the
+// outgoing navigation bar's pocket registration inactive, and tears down their TOP effect
+// views (a per-frame sampler of the outgoing view: 4 effect views → 2, the two bottom ones,
+// with `removeFromSuperview` called from `-[UIScrollView _updatePockets]`; presentation
+// opacity of the outgoing view still 1.0 at that point). Bottom pockets survive, exactly like
+// the nav case. Same remedy: freeze the outgoing tab's subtree for the lifetime of the
+// tab-bar controller's transition, resettle on completion. Once the cross-fade finishes UIKit
+// removes the outgoing view from the window anyway, so the deferred resettle is free.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -86,7 +102,7 @@ static const NSUInteger kApolloEdgeBottom = 4;
 // UIKit.ScrollEdgeEffectView, resolved once in the ctor (Swift-side class).
 static Class sScrollEdgeEffectViewClass;
 
-// Non-zero while at least one navigation transition is running.
+// Non-zero while at least one navigation transition or tab switch is running.
 static NSUInteger sTransitionsInFlight;
 
 // Bumped whenever the count drops to zero, so a late safety timeout can tell whether the
@@ -119,6 +135,16 @@ static void ApolloEdgeCollectScrollViews(UIView *view, NSMutableArray<UIScrollVi
     for (UIView *sub in view.subviews) ApolloEdgeCollectScrollViews(sub, out);
 }
 
+// Freeze only: the outgoing view keeps its frame, so there is no parked geometry to redirect
+// away from — the recompute itself is what has to be held off.
+static void ApolloEdgeFreezeSubtree(UIView *outgoingView) {
+    NSMutableArray<UIScrollView *> *scrollViews = [NSMutableArray array];
+    ApolloEdgeCollectScrollViews(outgoingView, scrollViews);
+    for (UIScrollView *scrollView in scrollViews) {
+        [sFrozenScrollViews addObject:scrollView];
+    }
+}
+
 static void ApolloEdgeRedirectGeometry(UIView *outgoingView, UIView *stableView) {
     NSMutableArray<UIScrollView *> *scrollViews = [NSMutableArray array];
     ApolloEdgeCollectScrollViews(outgoingView, scrollViews);
@@ -130,7 +156,7 @@ static void ApolloEdgeRedirectGeometry(UIView *outgoingView, UIView *stableView)
     }
 }
 
-static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation);
+static void ApolloEdgeArmSafetyTimeout(UIViewController *host, NSUInteger generation);
 
 static void ApolloEdgeEndTransition(NSUInteger generation) {
     if (generation != sTransitionGeneration || sTransitionsInFlight == 0) return;
@@ -159,21 +185,43 @@ static void ApolloEdgeEndTransition(NSUInteger generation) {
     [sFrozenScrollViews removeAllObjects];
 }
 
-// Re-arms for as long as the navigation controller still reports a live transition, so a held
+// Re-arms for as long as the host controller still reports a live transition, so a held
 // gesture stays covered while a genuinely finished one is always released. A fixed timeout
 // would expire mid-drag, which is exactly the case this fix exists for.
-static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation) {
-    __weak UINavigationController *weakNav = nav;
+static void ApolloEdgeArmSafetyTimeout(UIViewController *host, NSUInteger generation) {
+    __weak UIViewController *weakHost = host;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
         if (generation != sTransitionGeneration || sTransitionsInFlight == 0) return;
-        UINavigationController *strongNav = weakNav;
-        if (strongNav && strongNav.transitionCoordinator) {
-            ApolloEdgeArmSafetyTimeout(strongNav, generation);   // still being dragged
+        UIViewController *strongHost = weakHost;
+        if (strongHost && strongHost.transitionCoordinator) {
+            ApolloEdgeArmSafetyTimeout(strongHost, generation);   // still being dragged
             return;
         }
         ApolloEdgeEndTransition(generation);
     });
+}
+
+// Counts the transition in and releases it when the host's coordinator completes (fires for
+// completed AND cancelled transitions, which is exactly the lifetime we want). Without a
+// coordinator there is nothing animated to cover, so release on the next runloop turn.
+static void ApolloEdgeTrackTransition(UIViewController *host) {
+    sTransitionsInFlight++;
+    NSUInteger generation = sTransitionGeneration;
+
+    id<UIViewControllerTransitionCoordinator> coordinator = host.transitionCoordinator;
+    if (coordinator) {
+        [coordinator animateAlongsideTransition:nil
+                                     completion:^(id<UIViewControllerTransitionCoordinatorContext> ctx) {
+            ApolloEdgeEndTransition(generation);
+        }];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloEdgeEndTransition(generation); });
+    }
+
+    // A stuck counter would leave the override installed indefinitely, so never let one
+    // outlive the transition it was armed for.
+    ApolloEdgeArmSafetyTimeout(host, generation);
 }
 
 static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewController *outgoing) {
@@ -184,25 +232,7 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
     if (outgoing.isViewLoaded && nav.isViewLoaded) {
         ApolloEdgeRedirectGeometry(outgoing.view, nav.view);
     }
-
-    sTransitionsInFlight++;
-    NSUInteger generation = sTransitionGeneration;
-
-    id<UIViewControllerTransitionCoordinator> coordinator = nav.transitionCoordinator;
-    if (coordinator) {
-        // Fires for completed AND cancelled transitions, which is exactly the lifetime we want.
-        [coordinator animateAlongsideTransition:nil
-                                     completion:^(id<UIViewControllerTransitionCoordinatorContext> ctx) {
-            ApolloEdgeEndTransition(generation);
-        }];
-    } else {
-        // Non-animated navigation: nothing to cover beyond this turn of the runloop.
-        dispatch_async(dispatch_get_main_queue(), ^{ ApolloEdgeEndTransition(generation); });
-    }
-
-    // A stuck counter would leave the override installed indefinitely, so never let one
-    // outlive the transition it was armed for.
-    ApolloEdgeArmSafetyTimeout(nav, generation);
+    ApolloEdgeTrackTransition(nav);
 }
 
 %group ScrollEdgePopFix
@@ -269,6 +299,31 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
 
 %end
 
+%hook UITabBarController
+
+// The single funnel every tab change goes through (tab bar tap, selectedIndex, keyboard
+// shortcuts). After %orig the outgoing view is still in the window at full opacity; the
+// cross-fade that eventually fades it is scheduled for after the CATransaction commits, and
+// the pocket teardown lands in the layout pass of that same commit — so the freeze has to be
+// in place before this call returns to the run loop.
+- (void)transitionFromViewController:(UIViewController *)fromViewController
+                    toViewController:(UIViewController *)toViewController
+                          transition:(NSInteger)transition
+                   shouldSetSelected:(BOOL)shouldSetSelected {
+    %orig;
+    if (!fromViewController || fromViewController == toViewController ||
+        !fromViewController.isViewLoaded) {
+        return;
+    }
+    // No coordinator means UIKit switched instantly (Reduce Motion, first selection, an
+    // unanimated programmatic change): the outgoing view is already gone, nothing to cover.
+    if (!self.transitionCoordinator) return;
+    ApolloEdgeFreezeSubtree(fromViewController.view);
+    ApolloEdgeTrackTransition(self);
+}
+
+%end
+
 %end
 
 %ctor {
@@ -290,5 +345,5 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
     sRedirectedScrollViews = [NSHashTable weakObjectsHashTable];
     sFrozenScrollViews = [NSHashTable weakObjectsHashTable];
     %init(ScrollEdgePopFix, ScrollEdgeEffectView = sScrollEdgeEffectViewClass);
-    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket recompute frozen + geometry redirected during nav transitions)");
+    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket recompute frozen + geometry redirected during nav transitions and tab switches)");
 }

--- a/src/ApolloSearchNativeBar.h
+++ b/src/ApolloSearchNativeBar.h
@@ -11,3 +11,6 @@ BOOL ApolloNativeFeedSearchEnabled(void);
 
 // YES while THIS feed table is mid-native-search with a non-empty query.
 BOOL ApolloNativeFeedSearchActiveQuery(UIScrollView *tableView);
+
+// Flush and restore an expanded feed search before a cancelled navigation is drawn.
+void ApolloNativeFeedSearchRestoreCancelledNavigation(UIViewController *vc);

--- a/src/ApolloSearchNativeBar.xm
+++ b/src/ApolloSearchNativeBar.xm
@@ -875,62 +875,106 @@ static CGFloat NSBNavBottomForTable(UIScrollView *table, UIViewController *vc) {
     return navBottomW - tableTopW;
 }
 
+// Navigation can temporarily collapse the search bar, including a deferred
+// layout after cancellation. Scope recovery to one visible appearance, and
+// restore the geometry and scroll policy together before another frame is drawn.
+@interface ApolloNativeSearchRestingState : NSObject
+@property (nonatomic) BOOL visible;
+@property (nonatomic) NSUInteger generation;
+@property (nonatomic) BOOL revealInFlight;
+@property (nonatomic) BOOL revealAttemptedAtTop;
+@property (nonatomic) BOOL revealCheckPending;
+@property (nonatomic) BOOL revealAfterRefreshPending;
+@end
+@implementation ApolloNativeSearchRestingState
+@end
+
+static const void *kNSBRestingStateKey = &kNSBRestingStateKey;
+
+static ApolloNativeSearchRestingState *NSBRestingStateForVC(UIViewController *vc) {
+    if (!vc) return nil;
+    ApolloNativeSearchRestingState *state = objc_getAssociatedObject(vc, kNSBRestingStateKey);
+    if (!state) {
+        state = [ApolloNativeSearchRestingState new];
+        objc_setAssociatedObject(vc, kNSBRestingStateKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return state;
+}
+
+static BOOL NSBHasSettledFeedGeometry(UIViewController *vc, UIScrollView *table) {
+    if (!vc || !table.window || table.window != vc.viewIfLoaded.window) return NO;
+    ApolloNativeSearchRestingState *state = NSBRestingStateForVC(vc);
+    UINavigationController *nav = vc.navigationController;
+    return state.visible && nav.topViewController == vc && nav.visibleViewController == vc &&
+           !ApolloNavTransitionInFlight() && !nav.transitionCoordinator && !vc.transitionCoordinator;
+}
+
+static void NSBInvalidateRestingSearch(UIViewController *vc) {
+    ApolloNativeSearchRestingState *state = objc_getAssociatedObject(vc, kNSBRestingStateKey);
+    if (!state) return;
+    state.visible = NO;
+    state.generation++;
+    state.revealCheckPending = NO;
+    state.revealAfterRefreshPending = NO;
+    state.revealAttemptedAtTop = NO;
+    BOOL wasRevealing = state.revealInFlight;
+    state.revealInFlight = NO;
+    // End only our own temporary reveal, before the appearance callback lets
+    // UIKit capture the navigation item's policy for the transition.
+    if (wasRevealing && !(sNSBDismissWindow && vc == sNSBSessionVC)) {
+        vc.navigationItem.hidesSearchBarWhenScrolling = YES;
+    }
+}
+
+static void NSBApplyScrollAwayPolicy(UIViewController *vc, UIScrollView *table) {
+    if (!NSBHasSettledFeedGeometry(vc, table)) return;
+    UINavigationItem *item = vc.navigationItem;
+    if (item.searchController && !item.hidesSearchBarWhenScrolling &&
+        objc_getAssociatedObject(vc, kNSBAppearedKey) != nil &&
+        !NSBRestingStateForVC(vc).revealInFlight && !sNSBDismissWindow) {
+        item.hidesSearchBarWhenScrolling = YES;
+    }
+}
+
 // Resting at the very top with the palette collapsed is a dead-end state: it
 // is reached through pull-to-refresh spring-backs and programmatic snaps (the
 // collapse tracking only re-expands on a settling drag), and it leaves the bar
 // unreachable without another pull. When the feed settles exactly at its top
-// rest with the bar away, force the reveal with the #975 flip: expand via
-// hidesSearchBarWhenScrolling = NO, then restore the scroll-away policy a beat
-// later. No-op while the search is active or a reveal is already in flight.
-static BOOL sNSBRevealInFlight = NO;
+// rest with the bar away, expand and re-anchor it in one layout transaction.
+// Restore the scroll-away policy before returning to the run loop, so a new
+// drag can never cache a non-collapsible search bar.
 // Poll a live refresh out and then re-run the reveal check. Bounded so a stuck
 // refresh cannot keep this alive forever.
-static BOOL sNSBRevealAfterRefreshPending = NO;
 static void NSBScheduleRevealCheck(UIScrollView *table);
-static void NSBRecheckRevealAfterRefresh(UIScrollView *table, NSUInteger attempt) {
+static void NSBRecheckRevealAfterRefresh(UIViewController *vc, UIScrollView *table,
+                                        NSUInteger generation, NSUInteger attempt) {
+    __weak UIViewController *weakVC = vc;
     __weak UIScrollView *weakTable = table;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
         UIScrollView *sv = weakTable;
-        if (!sv) { sNSBRevealAfterRefreshPending = NO; return; }
+        ApolloNativeSearchRestingState *state = NSBRestingStateForVC(strongVC);
+        if (!state || state.generation != generation) return;
+        if (!NSBHasSettledFeedGeometry(strongVC, sv)) {
+            state.revealAfterRefreshPending = NO;
+            return;
+        }
         UIRefreshControl *rc = [sv respondsToSelector:@selector(refreshControl)]
             ? [(UITableView *)sv refreshControl] : nil;
         if (attempt < 25 && (rc.isRefreshing || sv.isDragging || sv.isTracking)) {
-            NSBRecheckRevealAfterRefresh(sv, attempt + 1);
+            NSBRecheckRevealAfterRefresh(strongVC, sv, generation, attempt + 1);
             return;
         }
-        sNSBRevealAfterRefreshPending = NO;
+        state.revealAfterRefreshPending = NO;
         NSBScheduleRevealCheck(sv);
     });
 }
 
-// Re-arm the scroll-away policy once the feed is genuinely settled. Bounded so
-// a table that never stops moving cannot hold the reveal open forever.
-static void NSBScheduleScrollAwayRestore(UIViewController *vc, UIScrollView *table,
-                                         NSUInteger attempt) {
-    __weak UIViewController *weakVC = vc;
-    __weak UIScrollView *weakTable = table;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.6 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-        UIViewController *strongVC = weakVC;
-        UIScrollView *sv = weakTable;
-        UIRefreshControl *rc = [sv respondsToSelector:@selector(refreshControl)]
-            ? [(UITableView *)sv refreshControl] : nil;
-        if (attempt < 10 && sv &&
-            (sv.isDragging || sv.isTracking || sv.isDecelerating || rc.isRefreshing)) {
-            NSBScheduleScrollAwayRestore(strongVC, sv, attempt + 1);
-            return;
-        }
-        sNSBRevealInFlight = NO;
-        if (!strongVC) return;
-        if (!strongVC.navigationItem.hidesSearchBarWhenScrolling) {
-            strongVC.navigationItem.hidesSearchBarWhenScrolling = YES;
-        }
-    });
-}
-
 static void NSBEnsureBarRevealedAtTop(UIViewController *vc, UIScrollView *table) {
-    if (sNSBRevealInFlight || !vc || !table) return;
+    if (!NSBHasSettledFeedGeometry(vc, table)) return;
+    ApolloNativeSearchRestingState *state = NSBRestingStateForVC(vc);
+    if (state.revealInFlight || state.revealAttemptedAtTop || sNSBDismissWindow) return;
     if (table.isDragging || table.isDecelerating || table.isTracking) return;
     UINavigationItem *navItem = vc.navigationItem;
     UISearchController *sc = navItem.searchController;
@@ -949,26 +993,37 @@ static void NSBEnsureBarRevealedAtTop(UIViewController *vc, UIScrollView *table)
     if (rc.isRefreshing) return;
     if (fabs(table.contentOffset.y + table.adjustedContentInset.top) > 2.0) return; // not at the rest
     if (CGRectGetHeight(sc.searchBar.bounds) > 1.0) return;            // already revealed
-    sNSBRevealInFlight = YES;
-    navItem.hidesSearchBarWhenScrolling = NO;
-    // Expanding the palette grows the feed's top inset, which leaves the
-    // existing offset reading as "scrolled by a bar's height" — enough for
-    // UIKit to collapse the bar straight back again. Re-park at the new top on
-    // the next turn so the reveal sticks.
-    __weak UIScrollView *weakTable = table;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        UIScrollView *sv = weakTable;
-        if (!sv || sv.isDragging || sv.isTracking || sv.isDecelerating) return;
-        CGFloat top = -sv.adjustedContentInset.top;
-        if (sv.contentOffset.y > top && sv.contentOffset.y < top + 120.0) {
-            sv.contentOffset = CGPointMake(sv.contentOffset.x, top);
-        }
-    });
-    // Restoring the scroll-away policy re-enables collapse tracking, which can
-    // shrink the palette by a bar's height in one frame. Landing that mid-pull
-    // moves the top inset — and the hosted spinner with it — out from under the
-    // gesture, so hold the reveal open and try again rather than applying blind.
-    NSBScheduleScrollAwayRestore(vc, table, 0);
+    state.revealInFlight = YES;
+    state.revealAttemptedAtTop = YES;
+    // A delayed policy restore kept the bar non-collapsible through the next
+    // drag; a delayed offset correction exposed the collapsed frame on cancel.
+    // Flush UIKit's expanded inset before re-anchoring, then re-enable collapse
+    // while the table is still at that expanded top. No timer owns the policy.
+    [UIView performWithoutAnimation:^{
+        navItem.hidesSearchBarWhenScrolling = NO;
+        UIView *navigationView = vc.navigationController.view;
+        [navigationView setNeedsLayout];
+        [navigationView layoutIfNeeded];
+        [table setContentOffset:CGPointMake(table.contentOffset.x, -table.adjustedContentInset.top) animated:NO];
+        navItem.hidesSearchBarWhenScrolling = YES;
+        [navigationView layoutIfNeeded];
+    }];
+    state.revealInFlight = NO;
+}
+
+void ApolloNativeFeedSearchRestoreCancelledNavigation(UIViewController *vc) {
+    if (!ApolloNativeFeedSearchEnabled() || !vc || !NSBIsNativeSearchFeedVC(vc)) return;
+    UIScrollView *table = NSBTableForVC(vc);
+    if (!NSBHasSettledFeedGeometry(vc, table)) return;
+    // completeTransition: restores the item stack before UIKit's next layout
+    // collapses the returned search. Flush that layout and repair in the same
+    // transaction, while the presentation still has the pre-cancel geometry.
+    [UIView performWithoutAnimation:^{
+        UIView *navigationView = vc.navigationController.view;
+        [navigationView setNeedsLayout];
+        [navigationView layoutIfNeeded];
+        NSBEnsureBarRevealedAtTop(vc, table);
+    }];
 }
 
 // The reveal above only ever ran from the controller's layout pass, and a
@@ -976,37 +1031,51 @@ static void NSBEnsureBarRevealedAtTop(UIViewController *vc, UIScrollView *table)
 // does not trigger one, so the bar stayed collapsed at the top until the user
 // pulled it down by hand. The feed's own geometry setters DO run on those
 // paths, so ask from there as well, coalesced to one check per runloop turn.
-static BOOL sNSBRevealCheckPending = NO;
 static void NSBScheduleRevealCheck(UIScrollView *table) {
-    if (sNSBRevealCheckPending || !table || sNSBRevealInFlight) return;
+    if (!table) return;
     if (objc_getAssociatedObject(table, kNSBFeedTableKey) == nil) return;
+    UIViewController *vc = NSBFeedVCForView(table);
+    ApolloNativeSearchRestingState *state = NSBRestingStateForVC(vc);
+    if (!state.visible || state.revealCheckPending || state.revealInFlight) return;
+    // One repair per arrival at the top, not one per layout pass if UIKit
+    // declines the reveal. New scrolling permits another recovery at its end.
+    if (table.isDragging || table.isTracking ||
+        fabs(table.contentOffset.y + table.adjustedContentInset.top) > 2.0) {
+        state.revealAttemptedAtTop = NO;
+    }
     if (table.isDragging || table.isTracking) return; // a live drag reveals on its own
+    NSUInteger generation = state.generation;
     // A refresh in flight holds the feed above its rest and owns the band the
     // palette would expand into, so the reveal has to wait it out — but it must
     // still happen afterwards, or a pull-to-refresh leaves the bar collapsed
     // (the very thing 63765ad fixed). Come back and look again.
     if ([table respondsToSelector:@selector(refreshControl)] &&
         [(UITableView *)table refreshControl].isRefreshing) {
-        if (!sNSBRevealAfterRefreshPending) {
-            sNSBRevealAfterRefreshPending = YES;
-            NSBRecheckRevealAfterRefresh(table, 0);
+        if (!state.revealAfterRefreshPending) {
+            state.revealAfterRefreshPending = YES;
+            NSBRecheckRevealAfterRefresh(vc, table, generation, 0);
         }
         return;
     }
-    sNSBRevealCheckPending = YES;
+    state.revealCheckPending = YES;
+    __weak UIViewController *weakVC = vc;
     __weak UIScrollView *weakTable = table;
     dispatch_async(dispatch_get_main_queue(), ^{
-        sNSBRevealCheckPending = NO;
+        UIViewController *strongVC = weakVC;
+        ApolloNativeSearchRestingState *currentState = NSBRestingStateForVC(strongVC);
+        if (!currentState || currentState.generation != generation) return;
+        currentState.revealCheckPending = NO;
         UIScrollView *sv = weakTable;
         if (!sv || sv.isDecelerating || sv.isDragging || sv.isTracking) return;
-        UIViewController *vc = NSBFeedVCForView(sv);
-        if (vc) NSBEnsureBarRevealedAtTop(vc, sv);
+        NSBApplyScrollAwayPolicy(strongVC, sv);
+        NSBEnsureBarRevealedAtTop(strongVC, sv);
     });
 }
 
 %hook _TtC6Apollo21ASTableViewController
 
 - (void)viewWillAppear:(BOOL)animated {
+    if (ApolloNativeFeedSearchEnabled()) NSBInvalidateRestingSearch((UIViewController *)self);
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
     NSBAttachNativeSearch((UIViewController *)self);
@@ -1040,13 +1109,12 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
     // search controller is attached late this is the only thing that tells that
     // pass the first appearance is behind us.
     objc_setAssociatedObject(self, kNSBAppearedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSBRestingStateForVC((UIViewController *)self).visible = YES;
     UINavigationItem *navItem = [(UIViewController *)self navigationItem];
     if (!navItem.searchController) return;
-    // Scroll-away policy. Flipped here, after the first layout, so the bar is
-    // never parked off-screen on arrival (#975's lesson).
-    if (!navItem.hidesSearchBarWhenScrolling) {
-        navItem.hidesSearchBarWhenScrolling = YES;
-    }
+    // Cancellation sends didAppear from inside completeTransition:, before
+    // UIKit finishes restoring the palette. Read its geometry next turn.
+    NSBScheduleRevealCheck(NSBTableForVC((UIViewController *)self));
     // Safety net for the return-to-live-query path: if Apollo's search-active
     // layout hid the nav bar before the guard armed, put it back.
     UINavigationBar *nav = [(UIViewController *)self navigationController].navigationBar;
@@ -1057,6 +1125,7 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    if (ApolloNativeFeedSearchEnabled()) NSBInvalidateRestingSearch((UIViewController *)self);
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
     sNSBTransitioning = YES;
@@ -1076,25 +1145,14 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
     // lazily here too (idempotent — bails once a searchController exists).
     NSBAttachNativeSearch((UIViewController *)self);
     NSBHideApolloToolbar((UIViewController *)self);
-    // Apply the scroll-away policy here as well as in viewDidAppear. The
-    // controller is attached lazily on some paths (the toolbar ivars can still
-    // be nil at willAppear), so viewDidAppear can run before there is anything
-    // to configure and leave the bar pinned. It then still collapses — UIKit
-    // owns the inset now, so the palette compresses with the scroll either way
-    // — but every path that puts it back is gated on the scroll-away policy
-    // being on, so the bar would stay collapsed until pulled down by hand.
-    UINavigationItem *policyItem = [(UIViewController *)self navigationItem];
-    if (policyItem.searchController && !policyItem.hidesSearchBarWhenScrolling &&
-        objc_getAssociatedObject(self, kNSBAppearedKey) != nil &&
-        !sNSBRevealInFlight && !sNSBDismissWindow) {
-        policyItem.hidesSearchBarWhenScrolling = YES;
-    }
-
+    // Late attachment can happen after didAppear; schedule the policy update
+    // here too, without driving another layout from this callback.
     UIScrollView *table = NSBTableForVC((UIViewController *)self);
     if (table && table == sNSBSessionTable) {
         NSBSetHeaderHidden(table, NSBIsSurfaced(table));
     }
-    NSBEnsureBarRevealedAtTop((UIViewController *)self, table);
+    // Recovery drives layout itself; never re-enter it from a layout callback.
+    NSBScheduleRevealCheck(table);
 }
 
 %end

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -547,6 +547,10 @@ static void ApolloSimDebugNavChurn(NSString *mode) {
     });
 }
 
+// Grouped on purpose: an ungrouped %hook makes Logos append its registration
+// after the closing #endif, where the device build (no APOLLO_SIM_BUILD) has
+// none of these declarations. %init(ApolloSimNavChurn) lives in the %ctor below.
+%group ApolloSimNavChurn
 %hook UIViewController
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
@@ -560,6 +564,7 @@ static void ApolloSimDebugNavChurn(NSString *mode) {
               "(non-nil means the push started synchronously, inside the pop's completeTransition:)",
               NSStringFromClass(popped.class), nav.transitionCoordinator);
 }
+%end
 %end
 
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
@@ -721,6 +726,7 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
 }
 
 %ctor {
+    %init(ApolloSimNavChurn);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL,
         ApolloSimDebugTapNotification, CFSTR("apollofix.debugtap"), NULL,
         CFNotificationSuspensionBehaviorDeliverImmediately);

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -161,7 +161,10 @@ static void ApolloSimDebugPerformHold(CGPoint point) {
 // "swipe x1 y1 x2 y2" command: a real drag (began → moved steps → ended) so a
 // scroll view actually scrolls, unlike the single tap above. Reuses the same
 // synthesized-touch delivery path.
-static void ApolloSimDebugPerformSwipe(CGPoint start, CGPoint end) {
+// steps/interval control the drag speed: the default 12 x 12 ms is a flick that
+// commits an interactive pop; a slow, short drag (e.g. 30 x 20 ms to x=45) ends
+// below UIKit's commit threshold and cancels it instead.
+static void ApolloSimDebugPerformSwipeTimed(CGPoint start, CGPoint end, int steps, NSTimeInterval interval) {
     UIWindow *window = nil;
     for (UIWindow *candidate in ApolloAllWindows()) {
         if (candidate.isKeyWindow) { window = candidate; break; }
@@ -183,9 +186,8 @@ static void ApolloSimDebugPerformSwipe(CGPoint start, CGPoint end) {
     [touch setPhase:UITouchPhaseBegan];
     ApolloSimDebugSendTouch(touch);
 
-    const int steps = 12;
     for (int i = 1; i <= steps; i++) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(i * 0.012 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(i * interval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             CGFloat t = (CGFloat)i / steps;
             CGPoint p = CGPointMake(start.x + (end.x - start.x) * t, start.y + (end.y - start.y) * t);
             [touch _setLocationInWindow:p resetPrevious:NO];
@@ -193,11 +195,12 @@ static void ApolloSimDebugPerformSwipe(CGPoint start, CGPoint end) {
             ApolloSimDebugSendTouch(touch);
         });
     }
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((steps * 0.012 + 0.02) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((steps * interval + 0.02) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [touch _setLocationInWindow:end resetPrevious:NO];
         [touch setPhase:UITouchPhaseEnded];
         ApolloSimDebugSendTouch(touch);
-        ApolloLog(@"[SimDebugTap] swipe delivered (%.0f,%.0f)->(%.0f,%.0f)", start.x, start.y, end.x, end.y);
+        ApolloLog(@"[SimDebugTap] swipe delivered (%.0f,%.0f)->(%.0f,%.0f) over %d x %.0f ms",
+                  start.x, start.y, end.x, end.y, steps, interval * 1000.0);
     });
 }
 
@@ -470,6 +473,95 @@ static void ApolloSimDebugMeasureGIFMemory(NSString *source) {
     }
 }
 
+// "navchurn" command: pop the top controller and push it straight back in the
+// same turn. UIKit queues the push and starts it synchronously from inside the
+// pop's completeTransition: (the same shape as a push issued from
+// didShowViewController:, which nickclyde raised on #1018), so two transitions
+// overlap on the stack and ApolloInterruptibleNavTransition must hand each its
+// own animator. 1.5 s later this logs what the pair left behind: the stack, the
+// interaction flags UIKit/our completion should have restored, the interactive
+// in-flight counter, and every sibling of the top view in the transition
+// container (a leftover dim/shadow view shows up there as a plain UIView).
+static UINavigationController *ApolloSimDebugNavChurnNavigationController(void) {
+    UIViewController *vc = nil;
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (window.isKeyWindow) { vc = window.rootViewController; break; }
+    }
+    while (vc.presentedViewController) vc = vc.presentedViewController;
+    if ([vc isKindOfClass:UITabBarController.class]) vc = ((UITabBarController *)vc).selectedViewController;
+    if ([vc isKindOfClass:UINavigationController.class]) return (UINavigationController *)vc;
+    return vc.navigationController;
+}
+
+static void ApolloSimDebugNavChurnReport(UINavigationController *nav, NSString *phase) {
+    UIViewController *top = nav.topViewController;
+    UIViewController *below = nav.viewControllers.count >= 2
+        ? nav.viewControllers[nav.viewControllers.count - 2] : nil;
+    NSMutableArray<NSString *> *siblings = [NSMutableArray array];
+    for (UIView *view in top.view.superview.subviews) {
+        [siblings addObject:[NSString stringWithFormat:@"%@%@%@", NSStringFromClass(view.class),
+            view.accessibilityIdentifier ? [@"#" stringByAppendingString:view.accessibilityIdentifier] : @"",
+            view == top.view ? @"(top)" : @""]];
+    }
+    ApolloLog(@"[SimDebugTap] navchurn %@: stack=%lu top=%@ topInteractive=%d belowInteractive=%d "
+              "inFlight=%d containerSubviews=[%@]",
+              phase, (unsigned long)nav.viewControllers.count, NSStringFromClass(top.class),
+              top.view.userInteractionEnabled, below.view.userInteractionEnabled,
+              ApolloNavTransitionInFlight(), [siblings componentsJoinedByString:@", "]);
+}
+
+// "navchurn appear" variant: the push is issued from the revealed controller's
+// viewDidAppear:, which UIKit runs inside the pop's completeTransition:, so the
+// pop's completion block is still on the stack when the push is requested.
+static __weak UIViewController *sApolloSimNavChurnRevealed;
+static __weak UIViewController *sApolloSimNavChurnPopped;
+
+static void ApolloSimDebugNavChurn(NSString *mode) {
+    UINavigationController *nav = ApolloSimDebugNavChurnNavigationController();
+    if ([mode isEqualToString:@"report"] && nav) {
+        ApolloSimDebugNavChurnReport(nav, @"report");
+        return;
+    }
+    if (!nav || nav.viewControllers.count < 2) {
+        ApolloLog(@"[SimDebugTap] navchurn: needs a pushed controller (nav=%@ depth=%lu)",
+                  nav, (unsigned long)nav.viewControllers.count);
+        return;
+    }
+    ApolloSimDebugNavChurnReport(nav, @"before");
+    UIViewController *top = nav.topViewController;
+    if ([mode isEqualToString:@"appear"]) {
+        sApolloSimNavChurnRevealed = nav.viewControllers[nav.viewControllers.count - 2];
+        sApolloSimNavChurnPopped = top;
+        ApolloLog(@"[SimDebugTap] navchurn appear: pop %@, push it back from %@'s viewDidAppear:",
+                  NSStringFromClass(top.class), NSStringFromClass(sApolloSimNavChurnRevealed.class));
+        [nav popViewControllerAnimated:YES];
+    } else {
+        ApolloLog(@"[SimDebugTap] navchurn: pop %@ and push it back in the same turn",
+                  NSStringFromClass(top.class));
+        [nav popViewControllerAnimated:YES];
+        [nav pushViewController:top animated:YES];
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloSimDebugNavChurnReport(nav, @"after");
+    });
+}
+
+%hook UIViewController
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    UIViewController *popped = sApolloSimNavChurnPopped;
+    if (!popped || self != sApolloSimNavChurnRevealed) return;
+    sApolloSimNavChurnRevealed = nil;
+    sApolloSimNavChurnPopped = nil;
+    UINavigationController *nav = self.navigationController;
+    [nav pushViewController:popped animated:YES];
+    ApolloLog(@"[SimDebugTap] navchurn appear: pushed %@ from viewDidAppear:; coordinator now %@ "
+              "(non-nil means the push started synchronously, inside the pop's completeTransition:)",
+              NSStringFromClass(popped.class), nav.transitionCoordinator);
+}
+%end
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -514,6 +606,12 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
             NSString *payload = [[contents substringFromIndex:6] stringByTrimmingCharactersInSet:
                 NSCharacterSet.whitespaceAndNewlineCharacterSet];
             ApolloSimDebugPerformCrash(payload);
+            return;
+        }
+        if ([contents hasPrefix:@"navchurn"]) {
+            NSString *mode = [[contents substringFromIndex:8] stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugNavChurn(mode);
             return;
         }
         if ([contents hasPrefix:@"insight "]) {
@@ -594,8 +692,12 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
         for (NSString *part in parts) if (part.length > 0) [numbers addObject:part];
         if (isSwipe) {
             if (numbers.count < 4) { ApolloLog(@"[SimDebugTap] malformed swipe: %@", contents); return; }
-            ApolloSimDebugPerformSwipe(CGPointMake(numbers[0].doubleValue, numbers[1].doubleValue),
-                                       CGPointMake(numbers[2].doubleValue, numbers[3].doubleValue));
+            // Optional 5th/6th numbers: step count and per-step interval in seconds.
+            int steps = numbers.count >= 5 ? MAX(1, numbers[4].intValue) : 12;
+            NSTimeInterval interval = numbers.count >= 6 ? MAX(0.001, numbers[5].doubleValue) : 0.012;
+            ApolloSimDebugPerformSwipeTimed(CGPointMake(numbers[0].doubleValue, numbers[1].doubleValue),
+                                            CGPointMake(numbers[2].doubleValue, numbers[3].doubleValue),
+                                            steps, interval);
             return;
         }
         if (isHold) {


### PR DESCRIPTION
## Symptom

On iOS 26 (Liquid Glass), scroll the feed a bit, then tap another tab (Settings in the video). For ~5 frames the raw feed content under the status bar / nav pills shows through sharp and undimmed, then the cross-fade to the new tab runs. Same thing in the other direction.

This looked like a regression in the latest test build, but it reproduces identically on plain `main` and has been there since iOS 26 — it's the same kill switch #693 fixed for swipe-back, on a transition that fix never covered (tab switches).

## Cause

iOS 26 switches tabs with a native cross-fade (`_UITabCrossFadeTransition`, vended by the tab bar controller's visual style). After `-[UITabBarController transitionFromViewController:toViewController:transition:shouldSetSelected:]` returns, the outgoing view is still in the window at full presentation opacity for a good while before the fade actually runs. But the very first layout pass of that same CATransaction runs `-[UIScrollView _updatePockets]` on the outgoing scroll views while the outgoing navigation bar's pocket registration is toggled inactive (`_UIScrollPocketContainerInteraction _setActive:` flips inside UIKit's own bar layout during the switch), and that recompute tears down the **top** edge-effect views.

Measured with a per-frame sampler on the outgoing view (sim, iOS 26.5):

```
t=0.001  presOpacity=1.00  effects=4   (top + bottom for both scroll views)
t=0.132  presOpacity=1.00  effects=2   (only the two bottom ones left)
t=0.316  presOpacity=0.81              (cross-fade finally starts)
```

The `removeFromSuperview` backtrace for the top effect views is `-[UIScrollView _updatePockets]` ← `layoutSubviews` ← CA commit. Bottom pockets survive, exactly like the swipe-back case. No tweak code is involved in the teardown.

## Fix

Extend `ApolloScrollEdgePopFix` to tab switches: hook the tab bar controller's transition funnel, and when the switch is animated (transition coordinator present) freeze the outgoing subtree's pocket recompute (`_updatePockets` + `ScrollEdgeEffectView.layoutSubviews`, the same freeze the nav case uses) for the lifetime of that transition, then resettle on completion. Nothing needs redirecting here — the outgoing frame isn't parked off-screen — so it's freeze only. Unanimated switches (Reduce Motion, first selection) have no coordinator and are left alone. Once the cross-fade finishes UIKit removes the outgoing view from the window anyway, so the deferred resettle is free.

The shared timeout/track helpers were generalised from `UINavigationController` to `UIViewController` so both paths use the same bookkeeping.

## Testing

- Sim (iOS 26.5, glass, Hide Bars on Scroll ON / Left, Header Style Soft), recorded and analysed frame by frame: before = band vanishes 5 frames before the cross-fade; after = band intact straight into the cross-fade. Verified on `main` + fix and on the all-open-PRs integration build + fix.
- Round trip Settings → Home: the feed comes back with its band intact and it keeps tracking on scroll (no zombie pocket).
- Non-glass: module is LG-gated as before; the legacy opaque nav bar has no edge effect to lose, switch works normally.
- Device (iPhone 17 Pro, iOS 26): confirmed fixed.

---

## Second commit: nav bar snapping on swipe-back (and the cancelled-swipe flash / stuck search bar)

Reported while testing the first fix: start an edge swipe on the feed and the nav bar snaps to the previous screen immediately (title flips, the feed's search bar disappears, the bar shrinks) before the finger has moved anywhere; let go and it snaps back with a one-frame layout jump under the bar. JeffreyCA's variant: after a cancelled swipe the search bar sticks through the next scroll.

**Cause.** Apollo's `ApolloNavigationAnimator` is a plain, non-interruptible `UIViewControllerAnimatedTransitioning`. For that case UIKit's navigation controller drives the bar with its "tracked animations" fallback (`_UINavigationBarTransitionAssistant` opens a property-animator tracking scope around the item change, then scrubs it with the gesture percent). Traced live in the sim: the scope captures nothing on the iOS 26 bar (assistant `animationCount` stays 0, the item change lands as a plain layout), so the bar re-displays instantly and the scrubbing has nothing to move. Cancel re-displays the old item instantly too, which is where the palette is left mid-state. UIKit's own transitions are interruptible, and on that path the bar's animations ride the interruptible animator's `fractionComplete`.

**Fix.** `ApolloInterruptibleNavTransition.xm` adds `interruptibleAnimatorForTransition:` / `animationEnded:` to Apollo's animator class on Liquid Glass (added by `%init` of a gated group, so pre-26 builds keep Apollo's class untouched) and starts that animator from `animateTransition:`. The animator reproduces Apollo's own geometry, recovered from the binary and confirmed with a live capture: incoming view from x = −width/3 under a black 15% dim, outgoing view to x = width with its edge shadow (offset (−5,0), radius 4, opacity 0.3) fading out, mirrored for push; 0.225s linear when interactive, 0.5s spring (damping 1, velocity 4) otherwise. Apollo's search-mode special case (hiding the bar while a legacy search is presented) is not reproduced; the native search bar module keeps the bar in place on glass anyway.

**Result (sim, iOS 26.5 glass):** during the drag the current title and search bar stay put and the incoming title cross-fades with the finger; cancel reverses smoothly with no palette/nav spike; a cancelled swipe followed by a scroll compresses the search bar normally (no stick); push, back-button pop and a committed fast swipe all cross-fade title and search bar correctly. Non-glass: module inert, Apollo's own animator unchanged.

**Follow-up (third commit, from device testing on the Home feed):** two side effects of the interruptible path, fixed. (1) UIKit only disables interaction on the transitioning views for non-interruptible animators, so the finger that started the edge pan kept feeding its delayed touch to the post cell under it and lit the cell highlight for two frames at the start of every swipe; the animator now disables interaction on both views for the transition and restores it on completion, as UIKit did before. (2) The bar now genuinely cross-fades, so the incoming title control exists at partial alpha for the whole drag, and the Liquid Glass title capsule got installed on it the moment it appeared — a translucent bubble beside "Home" at the incoming title's (differently centred) position that lingered through a cancelled swipe. The capsule code now skips installs and the recentre while an interactive transition runs, and the animator's completion refreshes the settled bar so the winning title's capsule fades in. Timed push/pop are unchanged (capsule still cross-fades with the title).


---

## Fourth commit (JeffreyCA, via icpryde/Apollo-Reborn#9): the stuck search bar after a cancelled swipe, for real

The interruptible animator fixed the bar *during* the drag, but Jeff could still reproduce the stuck search bar on device after a cancelled edge swipe on the Home feed, plus a one-frame jump at the moment of the cancel.

**Cause.** After a cancelled pop, UIKit runs a deferred layout that briefly collapses the native search bar. The top-rest reveal in `ApolloSearchNativeBar` then corrected the feed offset on a later run-loop turn and held the scroll-away policy off until the feed stopped moving, so the next scroll couldn't compress the bar and it snapped shut at the end instead. Both halves of the report came from the same recovery code.

**Fix.** The reveal now expands the bar, re-anchors the feed at the new top and restores the scroll-away policy in one layout transaction (no animation, no timer owning the policy any more), and a cancelled navigation flushes that layout inside the transition completion, before the collapsed state can reach the screen. Reveal state and its queued callbacks are scoped per feed appearance instead of module-wide globals, with guards against re-entrant or repeated recovery, and the title-capsule suppression now covers the animator's setup and UIKit's completion cleanup as well.

**Result (sim, iOS 26.5 glass, frame-by-frame recordings of the same slow cancelled swipe):** before, one frame with the search bar collapsed and the feed shifted at the cancel; after, the search bar band is flat through the whole gesture and the scroll that follows compresses the bar normally. The other paths that code owns still behave: a programmatic snap to the top reveals the bar, the pull-to-refresh spring-back leaves it expanded, and back-button pop, committed swipe-back and a Settings tab round trip all bring the feed back with the bar at rest. Jeff confirmed the fix on device.

Also merged current `main` into the branch; the only conflict was the sim-only debug bridge file, where both sides' commands were kept.
