### PR TITLE
Restore Posts tab return to the subreddit list

### DIFF
--- a/src/ApolloSearchNativeBar.xm
+++ b/src/ApolloSearchNativeBar.xm
@@ -1099,6 +1099,48 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 
 %end
 
+// MARK: - Posts tab re-selection
+//
+// Apollo's native top check ignores the inset UIKit adds for native search.
+// Use adjustedContentInset for both the check and scroll destination,
+// preserving Apollo's one-level back navigation when already at the top.
+%hook _TtC6Apollo13SceneDelegate
+
+- (BOOL)tabBarController:(UITabBarController *)tabBarController
+ shouldSelectViewController:(UIViewController *)viewController {
+    if (ApolloNativeFeedSearchEnabled() && tabBarController.selectedIndex == 0 &&
+        viewController == tabBarController.selectedViewController &&
+        [viewController isKindOfClass:objc_getClass("_TtC6Apollo26ApolloNavigationController")]) {
+        UINavigationController *nav = (UINavigationController *)viewController;
+        UIViewController *feed = nav.topViewController;
+        if ([feed isKindOfClass:objc_getClass("_TtC6Apollo19PostsViewController")]) {
+            UIScrollView *table = NSBTableForVC(feed);
+            if (table && objc_getAssociatedObject(table, kNSBFeedTableKey) != nil) {
+                CGFloat topInset = table.adjustedContentInset.top;
+                BOOL atTop = round(table.contentOffset.y) == -round(topInset);
+                if (NSBTraceEnabled()) {
+                    ApolloLog(@"[NSBTrace] Posts re-tap -> %@ (y=%.1f inTop=%.1f adjTop=%.1f)",
+                              atTop ? @"pop" : @"scroll", table.contentOffset.y,
+                              table.contentInset.top, topInset);
+                }
+                if (atTop) {
+                    [nav popViewControllerAnimated:YES];
+                } else {
+                    // Use Apollo's table-node entry point, as its native handler
+                    // does, with the same full inset used by the predicate.
+                    id tableNode = ApolloNSBObjectIvar(feed, "tableNode");
+                    ((void (*)(id, SEL, CGPoint, BOOL))objc_msgSend)(tableNode,
+                        @selector(setContentOffset:animated:), CGPointMake(0.0, -topInset), YES);
+                }
+                return NO;
+            }
+        }
+    }
+    return %orig(tabBarController, viewController);
+}
+
+%end
+
 // MARK: - Apollo's field must never take focus
 //
 // Apollo re-focuses its own field when restoring a search on return-to-feed


### PR DESCRIPTION
## Summary

Fixes an issue where tapping Posts scrolled the feed to the top, but tapping it again no longer returned to the subreddit list.

## Testing

- First Posts tap scrolls to the top, the next returns to the subreddit list.
- Switching back from another tab preserves the current subreddit.