### PR TITLE
Rich Link Previews: live preview follows each mode + shared pinned preview host (stacked on #1022)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloMemoryDiagnostics.m \
     $(SRC_DIR)/settings/ApolloSettingsTableViewController.m \
     $(SRC_DIR)/settings/ApolloSettingsForm.m \
+    $(SRC_DIR)/settings/ApolloSettingsPinnedPreview.m \
     $(SRC_DIR)/settings/ApolloContributors.m \
     $(SRC_DIR)/settings/ApolloBackupRestore.m \
     $(SRC_DIR)/settings/ApolloThanksToViewController.m \

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3693,6 +3693,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
                                     UDKeyInlineMediaPreviewPinned: @YES,
                                     UDKeyLinkPreviewBodyMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCommentsMode: @(ApolloLinkPreviewModeFull),
+                                    UDKeyLinkPreviewPreviewPinned: @YES,
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),
                                     UDKeyImageUploadProvider: @(ImageUploadProviderImgur),
                                     UDKeyCommentLinkHost: @(CommentLinkHostOff),

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3690,6 +3690,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
                                     UDKeyInlineImageAlignment: @(ApolloInlineImageAlignmentCenter),
                                     UDKeyAutoplayInlineGIFs: @(ApolloAutoplayInlineGIFModeDefault),
                                     UDKeyInlineMediaSizePercent: @100,
+                                    UDKeyInlineMediaPreviewPinned: @YES,
                                     UDKeyLinkPreviewBodyMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCommentsMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -636,6 +636,11 @@ static NSString *const UDKeyLinkPreviewCardColor = @"LinkPreviewCardColor";
 // means "Default" (no custom fill — the standard neutral card). A non-empty
 // hex paints the whole card that exact color, with auto-contrasted text.
 static NSString *const UDKeyLinkPreviewCardColorHex = @"LinkPreviewCardColorHex";
+// Whether the Rich Link Previews screen's live preview stays pinned while the
+// rows scroll beneath it (default) or scrolls away with them. Tap the card to
+// toggle (ApolloSettingsPinnedPreview); one key per screen, like
+// UDKeyInlineMediaPreviewPinned.
+static NSString *const UDKeyLinkPreviewPreviewPinned = @"LinkPreviewPreviewPinned";
 static NSString *const ApolloLinkPreviewModeDidChangeNotification = @"ApolloLinkPreviewModeDidChangeNotification";
 // Posted by the Inline Media settings screen when size/alignment changes so
 // visible comments re-measure their inline media immediately.

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -317,6 +317,11 @@ static NSString *const UDKeyAutoplayInlineGIFs = @"AutoplayInlineGIFs";
 // percentage of the row width: 50, 75, or 100 (default).
 static NSString *const UDKeyInlineMediaSizePercent = @"InlineMediaSizePercent";
 
+// Inline Media settings screen: whether the live preview (title + card) stays
+// pinned below the nav bar while the list scrolls (default) or scrolls with it.
+// Toggled by tapping the preview card.
+static NSString *const UDKeyInlineMediaPreviewPinned = @"InlineMediaPreviewPinned";
+
 // Bulk translation feature
 static NSString *const UDKeyEnableBulkTranslation = @"EnableBulkTranslation";
 static NSString *const UDKeyAutoTranslateOnAppear = @"AutoTranslateOnAppear";

--- a/src/settings/ApolloLinkPreviewSettingsViewController.h
+++ b/src/settings/ApolloLinkPreviewSettingsViewController.h
@@ -1,8 +1,14 @@
 #import "ApolloSettingsForm.h"
 
-// "Rich Link Previews" sub-screen: live sample cards, Body/Comments preview
-// modes, and the card color picker + quick swatches + conditional reset row.
-// Declarative form — see -buildForm.
+// "Rich Link Previews" sub-screen: a live preview card pinned above the form
+// (ApolloSettingsPinnedPreview — tap the card to pin/unpin), the Body /
+// Comments preview modes, and the card color picker + quick swatches +
+// conditional reset row. The preview shows one sample per area drawn exactly
+// as that area's current setting renders a link: Full → the hero card,
+// Compact → the thumbnail row, Off → Apollo's classic link button; it
+// re-renders with an animated cross-fade when a mode changes and recolors in
+// place (including mid-drag in the system color picker) when the card color
+// changes. Declarative form — see -buildForm.
 @interface ApolloLinkPreviewSettingsViewController : ApolloSettingsFormViewController
 // Invoked whenever a setting on this screen changes, with the affected area
 // ("body" / "comments" / "card-color"). The presenting settings controller uses

--- a/src/settings/ApolloLinkPreviewSettingsViewController.m
+++ b/src/settings/ApolloLinkPreviewSettingsViewController.m
@@ -3,7 +3,33 @@
 #import "ApolloCommon.h"
 #import "ApolloSettingsForm.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "UserDefaultConstants.h"
+#import "settings/ApolloSettingsPinnedPreview.h"
+
+#import <objc/runtime.h>
+
+// The live preview is hosted by the shared pinned-preview machinery
+// (ApolloSettingsPinnedPreview.h): the "Preview" section holds one transparent
+// spacer row, and the card itself is a direct subview of the table that sits on
+// that row at rest and sticks below the nav bar — together with a copy of the
+// section title — once the row would scroll away, so the Body / Comments mode
+// rows and the card color controls are adjusted with the preview in view. Tap
+// the card to pin/unpin it (remembered per screen).
+//
+// The preview shows one sample per area — BODY and COMMENTS — rendered the
+// way that area's current setting renders a link:
+//   Full    → the large hero-image card
+//   Compact → the small thumbnail row
+//   Off     → Apollo's classic link button (thumbnail, title, URL, chevron)
+// so flipping a mode row changes exactly the sample it governs. Each sample
+// carries a KEY (its area) and a SIGNATURE (its mode): on a refresh a sample
+// whose mode changed cross-fades into its new look while the other slides to
+// its new place, and the spacer row (hence the card) springs to the new
+// height. The card color is applied to the Full / Compact samples in place
+// (no rebuild), which is what keeps the system color picker's continuous
+// drags smooth; Off samples never take the color, matching the real
+// renderer, which leaves Apollo's native button alone.
 
 // Vivid quick-pick palette (Apple system colors). These write the same hex the
 // full picker would, so the two paths stay consistent. Kept to nine so the row
@@ -13,62 +39,102 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
              @"007AFF", @"5856D6", @"AF52DE", @"FF2D55"];
 }
 
-#pragma mark - Live Preview Cards
+static NSString *ApolloLPModeName(NSInteger mode) {
+    switch (mode) {
+        case ApolloLinkPreviewModeOff:     return @"Off";
+        case ApolloLinkPreviewModeCompact: return @"Compact";
+        case ApolloLinkPreviewModeFull:
+        default:                           return @"Full";
+    }
+}
 
-// A small UIKit mock of a rich link preview card (full + compact) that recolors
-// to mirror the real renderer: a solid fill of the chosen color with title /
-// site / description text auto-contrasted to black or white. Lets the user see
-// their color on a fake card while picking, without needing a real link.
-@interface ApolloLPPreviewCardsView : UIView
-- (void)applyCardColorHex:(NSString *)hex;
+static NSInteger ApolloLPNormalizedMode(NSInteger mode) {
+    if (mode < ApolloLinkPreviewModeOff || mode > ApolloLinkPreviewModeFull) return ApolloLinkPreviewModeFull;
+    return mode;
+}
+
+#pragma mark - Preview model
+
+static NSString * const kApolloLPPreviewKeyBody = @"body";
+static NSString * const kApolloLPPreviewKeyComments = @"comments";
+
+static const CGFloat kApolloLPPreviewTopPadding = 10.0;    // centres the first caption on the pin glyph
+static const CGFloat kApolloLPPreviewBottomPadding = 8.0;
+static const CGFloat kApolloLPPreviewHorizontalPadding = 10.0;
+static const CGFloat kApolloLPPreviewBlockSpacing = 10.0;
+static const CGFloat kApolloLPPreviewCaptionSpacing = 4.0;
+
+@interface ApolloLPPreviewState : NSObject
+@property (nonatomic) NSInteger bodyMode;
+@property (nonatomic) NSInteger commentsMode;
+@property (nonatomic, copy) NSString *cardColorHex; // "" = Default (neutral)
+@property (nonatomic) CGFloat previewHeight;        // measured for the card width
 @end
 
-@implementation ApolloLPPreviewCardsView {
-    UIView *_fullCard;
-    UIImageView *_fullImage;
-    UILabel *_fullSite;
-    UILabel *_fullTitle;
-    UILabel *_fullDesc;
-    UIView *_compactCard;
-    UIImageView *_compactThumb;
-    UILabel *_compactSite;
-    UILabel *_compactTitle;
-    UILabel *_compactDesc;
+@implementation ApolloLPPreviewState
+@end
+
+static ApolloLPPreviewState *ApolloLPCurrentPreviewState(void) {
+    ApolloLPPreviewState *state = [ApolloLPPreviewState new];
+    state.bodyMode = ApolloLPNormalizedMode(sLinkPreviewBodyMode);
+    state.commentsMode = ApolloLPNormalizedMode(sLinkPreviewCommentsMode);
+    state.cardColorHex = [sLinkPreviewCardColorHex isKindOfClass:[NSString class]] ? sLinkPreviewCardColorHex : @"";
+    return state;
+}
+
+#pragma mark - Preview view
+
+// One recolorable sample: the card view plus the labels painted onto it.
+@interface ApolloLPColorableCard : NSObject
+@property (nonatomic, strong) UIView *card;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, copy) NSArray<UILabel *> *secondaryLabels;
+@end
+
+@implementation ApolloLPColorableCard
+@end
+
+@interface ApolloLPPreviewView : UIView
+@property (nonatomic, strong) ApolloLPPreviewState *previewState;
+// The rendered sample blocks and their signatures, keyed by area — what the
+// container's refresh diffs against the previous rendering.
+@property (nonatomic, copy) NSDictionary<NSString *, UIView *> *itemViewsByKey;
+@property (nonatomic, copy) NSDictionary<NSString *, NSString *> *itemSignaturesByKey;
+- (void)apollo_configurePreview;
+- (void)apollo_applyCardColorHex:(NSString *)hex;
+- (CGFloat)apollo_heightForWidth:(CGFloat)width;
+@end
+
+@implementation ApolloLPPreviewView {
+    NSMutableArray<ApolloLPColorableCard *> *_colorableCards;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
-    if (self) {
-        [self buildCards];
-        [self applyCardColorHex:sLinkPreviewCardColorHex];
-    }
+    if (!self) return nil;
+    self.backgroundColor = UIColor.clearColor;
+    self.opaque = NO;
+    _colorableCards = [NSMutableArray array];
     return self;
 }
 
-- (UILabel *)labelSize:(CGFloat)size weight:(UIFontWeight)weight lines:(NSInteger)lines {
+#pragma mark Building blocks
+
+- (UILabel *)apollo_labelSize:(CGFloat)size weight:(UIFontWeight)weight {
     UILabel *label = [UILabel new];
     label.font = [UIFont systemFontOfSize:size weight:weight];
-    label.numberOfLines = lines;
+    label.numberOfLines = 1;
     label.lineBreakMode = NSLineBreakByTruncatingTail;
     label.translatesAutoresizingMaskIntoConstraints = NO;
     return label;
 }
 
-- (UILabel *)caption:(NSString *)text {
-    UILabel *label = [UILabel new];
-    label.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
-    label.textColor = [UIColor secondaryLabelColor];
-    label.text = [text uppercaseString];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    return label;
-}
-
-- (UIImageView *)imagePlaceholder {
+- (UIImageView *)apollo_imagePlaceholderWithCornerRadius:(CGFloat)radius {
     UIImageView *view = [[UIImageView alloc] init];
     view.translatesAutoresizingMaskIntoConstraints = NO;
     view.contentMode = UIViewContentModeCenter;
     view.clipsToBounds = YES;
-    view.layer.cornerRadius = 8.0;
+    view.layer.cornerRadius = radius;
     view.backgroundColor = [UIColor systemGray4Color];
     if (@available(iOS 13.0, *)) {
         view.image = [UIImage systemImageNamed:@"photo"];
@@ -77,126 +143,473 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     return view;
 }
 
-- (UIView *)roundedCard {
+- (UIView *)apollo_roundedCardWithRadius:(CGFloat)radius {
     UIView *card = [UIView new];
     card.translatesAutoresizingMaskIntoConstraints = NO;
-    card.layer.cornerRadius = 10.0;
+    card.layer.cornerRadius = radius;
+    card.layer.cornerCurve = kCACornerCurveContinuous;
     card.clipsToBounds = YES;
     return card;
 }
 
-- (void)buildCards {
-    self.translatesAutoresizingMaskIntoConstraints = NO;
+// "BODY · Full": the area and its current mode, left-aligned (the card's
+// top-right corner is the pin glyph's).
+- (UIView *)apollo_captionRowForArea:(NSString *)area mode:(NSInteger)mode {
+    UILabel *label = [self apollo_labelSize:12.0 weight:UIFontWeightSemibold];
+    UIColor *color = ApolloThemeRuntimeColor(ApolloThemeTokenSecondaryLabel) ?: UIColor.secondaryLabelColor;
+    NSMutableAttributedString *text = [[NSMutableAttributedString alloc]
+        initWithString:[area uppercaseString]
+            attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold],
+                          NSForegroundColorAttributeName: color }];
+    [text appendAttributedString:[[NSAttributedString alloc]
+        initWithString:[NSString stringWithFormat:@" · %@", ApolloLPModeName(mode)]
+            attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:12.0 weight:UIFontWeightRegular],
+                          NSForegroundColorAttributeName: color }]];
+    label.attributedText = text;
 
-    // ---- Full (hero) card: image on top, text below ----
-    _fullCard = [self roundedCard];
-    _fullImage = [self imagePlaceholder];
-    _fullSite = [self labelSize:11.0 weight:UIFontWeightSemibold lines:1];
-    _fullTitle = [self labelSize:15.0 weight:UIFontWeightSemibold lines:2];
-    _fullDesc = [self labelSize:13.0 weight:UIFontWeightRegular lines:1];
-    [_fullCard addSubview:_fullImage];
-    [_fullCard addSubview:_fullSite];
-    [_fullCard addSubview:_fullTitle];
-    [_fullCard addSubview:_fullDesc];
+    UIView *row = [UIView new];
+    row.translatesAutoresizingMaskIntoConstraints = NO;
+    [row addSubview:label];
     [NSLayoutConstraint activateConstraints:@[
-        [_fullImage.topAnchor constraintEqualToAnchor:_fullCard.topAnchor constant:10.0],
-        [_fullImage.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:10.0],
-        [_fullImage.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-10.0],
-        [_fullImage.heightAnchor constraintEqualToConstant:88.0],
-        [_fullSite.topAnchor constraintEqualToAnchor:_fullImage.bottomAnchor constant:9.0],
-        [_fullSite.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
-        [_fullSite.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
-        [_fullTitle.topAnchor constraintEqualToAnchor:_fullSite.bottomAnchor constant:3.0],
-        [_fullTitle.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
-        [_fullTitle.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
-        [_fullDesc.topAnchor constraintEqualToAnchor:_fullTitle.bottomAnchor constant:3.0],
-        [_fullDesc.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
-        [_fullDesc.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
-        [_fullDesc.bottomAnchor constraintEqualToAnchor:_fullCard.bottomAnchor constant:-11.0],
+        [label.leadingAnchor constraintEqualToAnchor:row.leadingAnchor constant:2.0],
+        [label.trailingAnchor constraintLessThanOrEqualToAnchor:row.trailingAnchor constant:-40.0], // clear of the pin
+        [label.topAnchor constraintEqualToAnchor:row.topAnchor],
+        [label.bottomAnchor constraintEqualToAnchor:row.bottomAnchor],
     ]];
-
-    // ---- Compact card: thumbnail left, text right ----
-    _compactCard = [self roundedCard];
-    _compactThumb = [self imagePlaceholder];
-    _compactSite = [self labelSize:11.0 weight:UIFontWeightSemibold lines:1];
-    _compactTitle = [self labelSize:15.0 weight:UIFontWeightSemibold lines:1];
-    _compactDesc = [self labelSize:13.0 weight:UIFontWeightRegular lines:2];
-    [_compactCard addSubview:_compactThumb];
-    [_compactCard addSubview:_compactSite];
-    [_compactCard addSubview:_compactTitle];
-    [_compactCard addSubview:_compactDesc];
-    [NSLayoutConstraint activateConstraints:@[
-        [_compactThumb.topAnchor constraintEqualToAnchor:_compactCard.topAnchor constant:10.0],
-        [_compactThumb.leadingAnchor constraintEqualToAnchor:_compactCard.leadingAnchor constant:10.0],
-        [_compactThumb.widthAnchor constraintEqualToConstant:64.0],
-        [_compactThumb.heightAnchor constraintEqualToConstant:64.0],
-        [_compactThumb.bottomAnchor constraintLessThanOrEqualToAnchor:_compactCard.bottomAnchor constant:-10.0],
-        [_compactSite.topAnchor constraintEqualToAnchor:_compactCard.topAnchor constant:11.0],
-        [_compactSite.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
-        [_compactSite.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
-        [_compactTitle.topAnchor constraintEqualToAnchor:_compactSite.bottomAnchor constant:3.0],
-        [_compactTitle.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
-        [_compactTitle.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
-        [_compactDesc.topAnchor constraintEqualToAnchor:_compactTitle.bottomAnchor constant:3.0],
-        [_compactDesc.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
-        [_compactDesc.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
-        [_compactDesc.bottomAnchor constraintLessThanOrEqualToAnchor:_compactCard.bottomAnchor constant:-11.0],
-    ]];
-
-    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[
-        [self caption:@"Full"], _fullCard, [self caption:@"Compact"], _compactCard,
-    ]];
-    stack.axis = UILayoutConstraintAxisVertical;
-    stack.spacing = 6.0;
-    stack.translatesAutoresizingMaskIntoConstraints = NO;
-    [stack setCustomSpacing:14.0 afterView:_fullCard];
-    [self addSubview:stack];
-    [NSLayoutConstraint activateConstraints:@[
-        [stack.topAnchor constraintEqualToAnchor:self.topAnchor],
-        [stack.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
-        [stack.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
-        [stack.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-    ]];
-
-    _fullSite.text = @"WEBSITE.COM";
-    _fullTitle.text = @"Example link preview title";
-    _fullDesc.text = @"A short description of the linked page.";
-    _compactSite.text = @"WEBSITE.COM";
-    _compactTitle.text = @"Example link preview title";
-    _compactDesc.text = @"A short description of the linked page.";
+    return row;
 }
 
-- (void)applyCardColorHex:(NSString *)hex {
+// Full: hero image on top, site / title / description below.
+- (UIView *)apollo_fullCardSample {
+    UIView *card = [self apollo_roundedCardWithRadius:10.0];
+    UIImageView *image = [self apollo_imagePlaceholderWithCornerRadius:7.0];
+    UILabel *site = [self apollo_labelSize:11.0 weight:UIFontWeightSemibold];
+    UILabel *title = [self apollo_labelSize:14.0 weight:UIFontWeightSemibold];
+    UILabel *desc = [self apollo_labelSize:12.0 weight:UIFontWeightRegular];
+    site.text = @"WEBSITE.COM";
+    title.text = @"Example link preview title";
+    desc.text = @"A short description of the linked page.";
+    [card addSubview:image];
+    [card addSubview:site];
+    [card addSubview:title];
+    [card addSubview:desc];
+    [NSLayoutConstraint activateConstraints:@[
+        [image.topAnchor constraintEqualToAnchor:card.topAnchor constant:8.0],
+        [image.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:8.0],
+        [image.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-8.0],
+        [image.heightAnchor constraintEqualToConstant:52.0],
+        [site.topAnchor constraintEqualToAnchor:image.bottomAnchor constant:6.0],
+        [site.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:10.0],
+        [site.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [title.topAnchor constraintEqualToAnchor:site.bottomAnchor constant:2.0],
+        [title.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:10.0],
+        [title.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [desc.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:2.0],
+        [desc.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:10.0],
+        [desc.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [desc.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-8.0],
+    ]];
+
+    ApolloLPColorableCard *entry = [ApolloLPColorableCard new];
+    entry.card = card;
+    entry.titleLabel = title;
+    entry.secondaryLabels = @[ site, desc ];
+    [_colorableCards addObject:entry];
+    return card;
+}
+
+// Compact: thumbnail on the left, site / title / description on the right.
+- (UIView *)apollo_compactCardSample {
+    UIView *card = [self apollo_roundedCardWithRadius:10.0];
+    UIImageView *thumb = [self apollo_imagePlaceholderWithCornerRadius:7.0];
+    UILabel *site = [self apollo_labelSize:11.0 weight:UIFontWeightSemibold];
+    UILabel *title = [self apollo_labelSize:14.0 weight:UIFontWeightSemibold];
+    UILabel *desc = [self apollo_labelSize:12.0 weight:UIFontWeightRegular];
+    site.text = @"WEBSITE.COM";
+    title.text = @"Example link preview title";
+    desc.text = @"A short description of the linked page.";
+    [card addSubview:thumb];
+    [card addSubview:site];
+    [card addSubview:title];
+    [card addSubview:desc];
+    [NSLayoutConstraint activateConstraints:@[
+        [thumb.topAnchor constraintEqualToAnchor:card.topAnchor constant:8.0],
+        [thumb.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:8.0],
+        [thumb.widthAnchor constraintEqualToConstant:52.0],
+        [thumb.heightAnchor constraintEqualToConstant:52.0],
+        [thumb.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-8.0],
+        [site.topAnchor constraintEqualToAnchor:card.topAnchor constant:9.0],
+        [site.leadingAnchor constraintEqualToAnchor:thumb.trailingAnchor constant:10.0],
+        [site.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [title.topAnchor constraintEqualToAnchor:site.bottomAnchor constant:2.0],
+        [title.leadingAnchor constraintEqualToAnchor:thumb.trailingAnchor constant:10.0],
+        [title.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [desc.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:2.0],
+        [desc.leadingAnchor constraintEqualToAnchor:thumb.trailingAnchor constant:10.0],
+        [desc.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-10.0],
+        [desc.bottomAnchor constraintLessThanOrEqualToAnchor:card.bottomAnchor constant:-8.0],
+    ]];
+
+    ApolloLPColorableCard *entry = [ApolloLPColorableCard new];
+    entry.card = card;
+    entry.titleLabel = title;
+    entry.secondaryLabels = @[ site, desc ];
+    [_colorableCards addObject:entry];
+    return card;
+}
+
+// Off: Apollo's classic link button — a thumbnail square, the page title over
+// its URL, and a disclosure chevron — drawn in the standard fill, never the
+// custom card color (the real button is Apollo's own and ignores it).
+- (UIView *)apollo_classicButtonSample {
+    UIView *button = [self apollo_roundedCardWithRadius:8.0];
+    button.backgroundColor = UIColor.tertiarySystemFillColor;
+
+    UIImageView *thumb = [self apollo_imagePlaceholderWithCornerRadius:5.0];
+    UILabel *title = [self apollo_labelSize:14.0 weight:UIFontWeightSemibold];
+    title.text = @"Example link preview title";
+    title.textColor = ApolloThemeRuntimeColor(ApolloThemeTokenLabel) ?: UIColor.labelColor;
+    UILabel *url = [self apollo_labelSize:12.0 weight:UIFontWeightRegular];
+    url.text = @"website.com/example-page";
+    url.textColor = ApolloThemeRuntimeColor(ApolloThemeTokenSecondaryLabel) ?: UIColor.secondaryLabelColor;
+    UIImageView *chevron = [[UIImageView alloc] init];
+    chevron.translatesAutoresizingMaskIntoConstraints = NO;
+    chevron.contentMode = UIViewContentModeCenter;
+    if (@available(iOS 13.0, *)) {
+        chevron.image = [UIImage systemImageNamed:@"chevron.right"
+                                withConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:12.0
+                                                                                                   weight:UIImageSymbolWeightSemibold]];
+    }
+    chevron.tintColor = UIColor.tertiaryLabelColor;
+    [button addSubview:thumb];
+    [button addSubview:title];
+    [button addSubview:url];
+    [button addSubview:chevron];
+    [NSLayoutConstraint activateConstraints:@[
+        [thumb.topAnchor constraintEqualToAnchor:button.topAnchor constant:8.0],
+        [thumb.leadingAnchor constraintEqualToAnchor:button.leadingAnchor constant:8.0],
+        [thumb.widthAnchor constraintEqualToConstant:40.0],
+        [thumb.heightAnchor constraintEqualToConstant:40.0],
+        [thumb.bottomAnchor constraintEqualToAnchor:button.bottomAnchor constant:-8.0],
+        [chevron.centerYAnchor constraintEqualToAnchor:button.centerYAnchor],
+        [chevron.trailingAnchor constraintEqualToAnchor:button.trailingAnchor constant:-10.0],
+        [chevron.widthAnchor constraintEqualToConstant:12.0],
+        [title.topAnchor constraintEqualToAnchor:button.topAnchor constant:10.0],
+        [title.leadingAnchor constraintEqualToAnchor:thumb.trailingAnchor constant:10.0],
+        [title.trailingAnchor constraintEqualToAnchor:chevron.leadingAnchor constant:-8.0],
+        [url.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:2.0],
+        [url.leadingAnchor constraintEqualToAnchor:thumb.trailingAnchor constant:10.0],
+        [url.trailingAnchor constraintEqualToAnchor:chevron.leadingAnchor constant:-8.0],
+        [url.bottomAnchor constraintLessThanOrEqualToAnchor:button.bottomAnchor constant:-8.0],
+    ]];
+    return button;
+}
+
+- (UIView *)apollo_sampleForMode:(NSInteger)mode {
+    switch (mode) {
+        case ApolloLinkPreviewModeOff:     return [self apollo_classicButtonSample];
+        case ApolloLinkPreviewModeCompact: return [self apollo_compactCardSample];
+        case ApolloLinkPreviewModeFull:
+        default:                           return [self apollo_fullCardSample];
+    }
+}
+
+// One area's block: caption row over the sample its mode calls for.
+- (UIView *)apollo_blockForArea:(NSString *)area mode:(NSInteger)mode {
+    UIStackView *block = [[UIStackView alloc] initWithArrangedSubviews:@[
+        [self apollo_captionRowForArea:area mode:mode],
+        [self apollo_sampleForMode:mode],
+    ]];
+    block.axis = UILayoutConstraintAxisVertical;
+    block.alignment = UIStackViewAlignmentFill;
+    block.spacing = kApolloLPPreviewCaptionSpacing;
+    block.translatesAutoresizingMaskIntoConstraints = NO;
+    return block;
+}
+
+#pragma mark Configure / recolor / measure
+
+- (void)apollo_configurePreview {
+    for (UIView *view in self.subviews) [view removeFromSuperview];
+    [_colorableCards removeAllObjects];
+    ApolloLPPreviewState *state = self.previewState;
+    if (!state) return;
+
+    UIView *bodyBlock = [self apollo_blockForArea:@"Body" mode:state.bodyMode];
+    UIView *commentsBlock = [self apollo_blockForArea:@"Comments" mode:state.commentsMode];
+    self.itemViewsByKey = @{ kApolloLPPreviewKeyBody: bodyBlock, kApolloLPPreviewKeyComments: commentsBlock };
+    self.itemSignaturesByKey = @{
+        kApolloLPPreviewKeyBody: [NSString stringWithFormat:@"mode|%ld", (long)state.bodyMode],
+        kApolloLPPreviewKeyComments: [NSString stringWithFormat:@"mode|%ld", (long)state.commentsMode],
+    };
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ bodyBlock, commentsBlock ]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.alignment = UIStackViewAlignmentFill;
+    stack.spacing = kApolloLPPreviewBlockSpacing;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:kApolloLPPreviewHorizontalPadding],
+        [stack.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-kApolloLPPreviewHorizontalPadding],
+        [stack.topAnchor constraintEqualToAnchor:self.topAnchor constant:kApolloLPPreviewTopPadding],
+        [stack.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-kApolloLPPreviewBottomPadding],
+    ]];
+
+    [self apollo_applyCardColorHex:state.cardColorHex];
+}
+
+// Paint the Full / Compact samples the way the real renderer paints its
+// cards: a solid fill of the chosen color with title / site / description
+// text auto-contrasted to black or white, or the standard neutral fill.
+- (void)apollo_applyCardColorHex:(NSString *)hex {
     UIColor *custom = (hex.length > 0) ? ApolloColorFromHexString(hex) : nil;
     UIColor *cardColor;
     UIColor *titleColor;
     UIColor *secondaryColor;
     if (custom) {
-        // Mirror the real renderer: solid fill + auto-contrast ink.
         cardColor = custom;
         BOOL light = ApolloColorIsLight(custom);
         titleColor = light ? [UIColor colorWithWhite:0.0 alpha:1.0] : [UIColor colorWithWhite:1.0 alpha:1.0];
         secondaryColor = [titleColor colorWithAlphaComponent:light ? 0.62 : 0.78];
     } else {
-        // Default ("no color"): the standard neutral card look.
-        cardColor = [UIColor secondarySystemBackgroundColor];
-        titleColor = [UIColor labelColor];
-        secondaryColor = [UIColor secondaryLabelColor];
+        // Default ("no color"): the neutral card. A translucent system fill
+        // stays visible on any themed card background, light or dark.
+        cardColor = UIColor.tertiarySystemFillColor;
+        titleColor = ApolloThemeRuntimeColor(ApolloThemeTokenLabel) ?: UIColor.labelColor;
+        secondaryColor = ApolloThemeRuntimeColor(ApolloThemeTokenSecondaryLabel) ?: UIColor.secondaryLabelColor;
     }
-    _fullCard.backgroundColor = cardColor;
-    _compactCard.backgroundColor = cardColor;
-    _fullSite.textColor = secondaryColor;
-    _fullTitle.textColor = titleColor;
-    _fullDesc.textColor = secondaryColor;
-    _compactSite.textColor = secondaryColor;
-    _compactTitle.textColor = titleColor;
-    _compactDesc.textColor = secondaryColor;
+    for (ApolloLPColorableCard *entry in _colorableCards) {
+        entry.card.backgroundColor = cardColor;
+        entry.titleLabel.textColor = titleColor;
+        for (UILabel *label in entry.secondaryLabels) label.textColor = secondaryColor;
+    }
+}
+
+- (CGFloat)apollo_heightForWidth:(CGFloat)width {
+    if (width <= 0.0) return 0.0;
+    CGSize target = CGSizeMake(width, UILayoutFittingCompressedSize.height);
+    CGSize size = [self systemLayoutSizeFittingSize:target
+                      withHorizontalFittingPriority:UILayoutPriorityRequired
+                            verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+    return ceil(size.height);
 }
 
 @end
 
+#pragma mark - Preview content view (fills the pinned card)
+
+// The host's contentView: owns the current rendering, replaces it with an
+// animated keyed diff when the modes change, recolors it in place when the
+// card color changes, and knows how tall the card must be for a given width
+// and state (what the spacer row's height block asks).
+@interface ApolloLPPreviewContentView : UIView
+@property (nonatomic, strong) ApolloLPPreviewView *currentPreviewView;
+@property (nonatomic, strong) UIViewPropertyAnimator *previewAnimator;
+@property (nonatomic) NSUInteger previewTransitionGeneration;
+@property (nonatomic) BOOL previewRefreshPending;
++ (CGFloat)heightForCardWidth:(CGFloat)width state:(ApolloLPPreviewState *)state;
+- (void)apollo_refreshForWidth:(CGFloat)width animated:(BOOL)animated;
+- (void)apollo_applyCardColorHex:(NSString *)hex animated:(BOOL)animated;
+- (void)apollo_finishPreviewTransition;
+@end
+
+@implementation ApolloLPPreviewContentView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (!self) return nil;
+    self.backgroundColor = UIColor.clearColor;
+    self.clipsToBounds = YES;
+    return self;
+}
+
+// Measured by laying out a throwaway rendering; memoized per (width, modes)
+// since the row-height block is asked on every table layout.
++ (CGFloat)heightForCardWidth:(CGFloat)width state:(ApolloLPPreviewState *)state {
+    static NSMutableDictionary<NSString *, NSNumber *> *cache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ cache = [NSMutableDictionary dictionary]; });
+    if (width <= 0.0) return 0.0;
+    NSString *key = [NSString stringWithFormat:@"%.1f|%ld|%ld|%@", width, (long)state.bodyMode, (long)state.commentsMode,
+                     UIApplication.sharedApplication.preferredContentSizeCategory ?: @""];
+    NSNumber *cached = cache[key];
+    if (cached) return cached.doubleValue;
+    ApolloLPPreviewView *probe = [[ApolloLPPreviewView alloc] initWithFrame:CGRectZero];
+    probe.translatesAutoresizingMaskIntoConstraints = NO;
+    probe.previewState = state;
+    [probe apollo_configurePreview];
+    CGFloat height = [probe apollo_heightForWidth:width];
+    cache[key] = @(height);
+    return height;
+}
+
+- (ApolloLPPreviewView *)apollo_previewViewForState:(ApolloLPPreviewState *)state width:(CGFloat)width {
+    ApolloLPPreviewView *preview = [[ApolloLPPreviewView alloc] initWithFrame:CGRectZero];
+    preview.translatesAutoresizingMaskIntoConstraints = NO;
+    preview.previewState = state;
+    [preview apollo_configurePreview];
+    state.previewHeight = [preview apollo_heightForWidth:width];
+    return preview;
+}
+
+- (void)apollo_addPreviewView:(ApolloLPPreviewView *)preview height:(CGFloat)height {
+    [self addSubview:preview];
+    [NSLayoutConstraint activateConstraints:@[
+        [preview.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [preview.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [preview.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [preview.heightAnchor constraintEqualToConstant:height]
+    ]];
+}
+
+- (void)apollo_finishPreviewTransition {
+    UIViewPropertyAnimator *animator = self.previewAnimator;
+    if (!animator) return;
+    [animator stopAnimation:NO];
+    [animator finishAnimationAtPosition:UIViewAnimatingPositionEnd];
+}
+
+- (void)apollo_replacePreviewImmediately:(ApolloLPPreviewView *)preview state:(ApolloLPPreviewState *)state {
+    [self apollo_finishPreviewTransition];
+    for (UIView *subview in self.subviews) [subview removeFromSuperview];
+    [self apollo_addPreviewView:preview height:state.previewHeight];
+    preview.alpha = 1.0;
+    self.currentPreviewView = preview;
+    [UIView performWithoutAnimation:^{ [self layoutIfNeeded]; }];
+}
+
+// Re-paint the Full / Compact samples for the current card color without
+// rebuilding anything — every rendering currently in the card (the live one
+// and, mid-transition, the outgoing one) is recolored so a color change
+// landing during a mode animation never leaves a stale twin behind.
+- (void)apollo_applyCardColorHex:(NSString *)hex animated:(BOOL)animated {
+    void (^recolor)(void) = ^{
+        for (UIView *subview in self.subviews) {
+            if ([subview isKindOfClass:[ApolloLPPreviewView class]]) {
+                ((ApolloLPPreviewView *)subview).previewState.cardColorHex = hex;
+                [(ApolloLPPreviewView *)subview apollo_applyCardColorHex:hex];
+            }
+        }
+    };
+    if (!animated || UIAccessibilityIsReduceMotionEnabled()) {
+        recolor();
+        return;
+    }
+    // Label colors don't tween; a cross-dissolve of the whole card carries
+    // both the fill and the ink over together.
+    [UIView transitionWithView:self
+                      duration:0.22
+                       options:UIViewAnimationOptionTransitionCrossDissolve |
+                               UIViewAnimationOptionBeginFromCurrentState |
+                               UIViewAnimationOptionAllowUserInteraction
+                    animations:recolor
+                    completion:nil];
+}
+
+// Re-render for the current settings at the given card width. Animated: the
+// new rendering is laid out on top of the old one and each area's block is
+// matched by key — a block whose mode is unchanged slides from its old spot
+// to its new one (a pixel-identical twin swaps in silently), a block whose
+// mode changed cross-fades into its new look on the way. The screen animates
+// the spacer row (and so the card) to the new height alongside. A refresh
+// landing mid-animation is queued and replayed once the animation completes.
+- (void)apollo_refreshForWidth:(CGFloat)width animated:(BOOL)animated {
+    if (animated && self.previewAnimator.state == UIViewAnimatingStateActive) {
+        self.previewRefreshPending = YES;
+        return;
+    }
+    [self apollo_finishPreviewTransition];
+
+    ApolloLPPreviewState *state = ApolloLPCurrentPreviewState();
+    ApolloLPPreviewView *incoming = [self apollo_previewViewForState:state width:width];
+    ApolloLPPreviewView *outgoing = self.currentPreviewView;
+    if (!animated || UIAccessibilityIsReduceMotionEnabled() || !outgoing) {
+        [self apollo_replacePreviewImmediately:incoming state:state];
+        return;
+    }
+
+    [self layoutIfNeeded];
+    [self apollo_addPreviewView:incoming height:state.previewHeight];
+    [incoming layoutIfNeeded];
+    self.currentPreviewView = incoming;
+
+    NSDictionary<NSString *, UIView *> *oldItems = outgoing.itemViewsByKey;
+    NSDictionary<NSString *, UIView *> *newItems = incoming.itemViewsByKey;
+    NSMutableArray<UIView *> *departingItems = [NSMutableArray array]; // gone: scale-fade out in place
+    NSMutableArray<UIView *> *restyledItems = [NSMutableArray array];  // old look of a survivor: fade out in place
+    for (NSString *key in newItems) {
+        UIView *newItem = newItems[key];
+        UIView *oldItem = oldItems[key];
+        if (!oldItem) {
+            newItem.alpha = 0.0;
+            newItem.transform = CGAffineTransformMakeScale(0.88, 0.88);
+            continue;
+        }
+        CGRect oldFrame = [oldItem convertRect:oldItem.bounds toView:self];
+        CGRect newFrame = [newItem convertRect:newItem.bounds toView:self];
+        // Blocks are top-aligned, so anchor the slide on the top edge: a block
+        // whose height changes keeps its caption in place while the sample
+        // below it morphs, rather than drifting about its center.
+        newItem.transform = CGAffineTransformMakeTranslation(CGRectGetMinX(oldFrame) - CGRectGetMinX(newFrame),
+                                                              CGRectGetMinY(oldFrame) - CGRectGetMinY(newFrame));
+        BOOL sameLook = [outgoing.itemSignaturesByKey[key] isEqualToString:incoming.itemSignaturesByKey[key]];
+        if (sameLook) {
+            oldItem.alpha = 0.0; // the twin takes over from the very first frame
+        } else {
+            newItem.alpha = 0.0;
+            [restyledItems addObject:oldItem];
+        }
+    }
+    for (NSString *key in oldItems) {
+        if (!newItems[key]) [departingItems addObject:oldItems[key]];
+    }
+
+    NSUInteger generation = ++self.previewTransitionGeneration;
+    UISpringTimingParameters *timing = [[UISpringTimingParameters alloc] initWithDampingRatio:0.9];
+    UIViewPropertyAnimator *animator = [[UIViewPropertyAnimator alloc] initWithDuration:0.35
+                                                                      timingParameters:timing];
+    __weak typeof(self) weakSelf = self;
+    __weak UIViewPropertyAnimator *weakAnimator = animator;
+    [animator addAnimations:^{
+        for (UIView *item in newItems.allValues) {
+            item.alpha = 1.0;
+            item.transform = CGAffineTransformIdentity;
+        }
+        for (UIView *item in departingItems) {
+            item.alpha = 0.0;
+            item.transform = CGAffineTransformMakeScale(0.88, 0.88);
+        }
+        for (UIView *item in restyledItems) item.alpha = 0.0;
+    }];
+    [animator addCompletion:^(__unused UIViewAnimatingPosition finalPosition) {
+        [outgoing removeFromSuperview];
+        incoming.alpha = 1.0;
+        if (weakSelf.previewTransitionGeneration == generation &&
+            weakSelf.previewAnimator == weakAnimator) {
+            weakSelf.previewAnimator = nil;
+        }
+        if (weakSelf.previewRefreshPending) {
+            weakSelf.previewRefreshPending = NO;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf apollo_refreshForWidth:CGRectGetWidth(weakSelf.bounds) animated:YES];
+            });
+        }
+    }];
+    self.previewAnimator = animator;
+    [animator startAnimation];
+}
+
+@end
+
+#pragma mark - The screen
+
 @interface ApolloLinkPreviewSettingsViewController () <UIColorPickerViewControllerDelegate>
-@property (nonatomic, strong) ApolloLPPreviewCardsView *previewView;
+@property (nonatomic, strong) ApolloPinnedPreviewHost *previewHost;
+// Card width the spacer row was last measured for (0 = only the table's own
+// section inset was available). Updated from the real cell frame by the pinned
+// layout pass, which then asks for a one-row re-measure.
+@property (nonatomic) CGFloat previewCardWidth;
 @end
 
 @implementation ApolloLinkPreviewSettingsViewController
@@ -204,19 +617,52 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Rich Link Previews";
-    // The preview cell is taller than a stock row and self-sizes from its
-    // content (the form's heightForRow falls through to tableView.rowHeight).
+    // The swatch strip self-sizes from its content (the form's heightForRow
+    // falls through to tableView.rowHeight for rows without a height block).
     self.tableView.estimatedRowHeight = 60.0;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
+
+    // The pinned preview: shared layout pass on the table (the subclass adds no
+    // ivars, so isa-swizzling the existing table view is safe) + the host as a
+    // direct subview of it, never a cell, so it survives every reload.
+    if (![self.tableView isKindOfClass:[ApolloPinnedPreviewTableView class]]) {
+        object_setClass(self.tableView, [ApolloPinnedPreviewTableView class]);
+    }
+    ApolloPinnedPreviewHost *host = [[ApolloPinnedPreviewHost alloc] initWithFrame:CGRectZero];
+    host.contentView = [[ApolloLPPreviewContentView alloc] initWithFrame:CGRectZero];
+    __weak __typeof(self) weakSelf = self;
+    host.spacerIndexPath = ^NSIndexPath * {
+        return [weakSelf indexPathForRowID:@"preview"];
+    };
+    host.cardWidthDidChange = ^(CGFloat width) {
+        [weakSelf previewCardWidthDidChange:width];
+    };
+    host.pinned = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyLinkPreviewPreviewPinned];
+    host.pinDidChange = ^(BOOL pinned) {
+        [[NSUserDefaults standardUserDefaults] setBool:pinned forKey:UDKeyLinkPreviewPreviewPinned];
+        ApolloLog(@"[LinkPreviewSettings] preview %@", pinned ? @"pinned" : @"unpinned");
+        // Slide the block into (or out of) its pinned spot instead of snapping:
+        // the table's layout pass computes the new frames inside the animation.
+        UITableView *table = weakSelf.tableView;
+        [table setNeedsLayout];
+        [UIView animateWithDuration:0.35 delay:0 usingSpringWithDamping:0.9 initialSpringVelocity:0
+                            options:UIViewAnimationOptionBeginFromCurrentState
+                         animations:^{ [table layoutIfNeeded]; }
+                         completion:nil];
+    };
+    self.previewHost = host;
+    ApolloPinnedPreviewAttachHost(self.tableView, host);
+    [self applyThemeToPreviewHost];
+    [self.previewContentView apollo_refreshForWidth:[self previewCardWidthForTable:self.tableView] animated:NO];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self.tableView reloadData];
+- (void)viewWillDisappear:(BOOL)animated {
+    [self.previewContentView apollo_finishPreviewTransition];
+    [super viewWillDisappear:animated];
 }
 
-- (void)refreshPreview {
-    [self.previewView applyCardColorHex:sLinkPreviewCardColorHex];
+- (ApolloLPPreviewContentView *)previewContentView {
+    return (ApolloLPPreviewContentView *)self.previewHost.contentView;
 }
 
 #pragma mark - Form
@@ -224,24 +670,34 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 - (NSArray<ApolloSettingsSection *> *)buildForm {
     __weak __typeof(self) weakSelf = self;
 
-    // ---- Card Preview ----
+    // ---- Preview (the spacer row the pinned card sits on) ----
 
-    // Escape hatch (custom row): bespoke live-preview card cell; exact
-    // construction kept in -previewCell.
+    // Escape hatch (custom row): a transparent placeholder — the pinned host
+    // draws the card on top of (or, once scrolled, instead of) this slot. Its
+    // height is the card's height for the current modes and card width.
     ApolloSettingsRow *preview =
         [ApolloSettingsRow customRowWithID:@"preview"
                                       cell:^UITableViewCell *(__unused UITableView *tableView, __unused ApolloSettingsRow *row) {
-            return [weakSelf previewCell]
-                ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            ApolloPinnedPreviewSpacerCell *cell =
+                [[ApolloPinnedPreviewSpacerCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            ApolloPinnedPreviewClearSpacerCell(cell);
+            cell.isAccessibilityElement = NO;
+            return cell;
         }
                                   onSelect:nil];
+    preview.height = ^CGFloat {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return 0.0;
+        return [ApolloLPPreviewContentView heightForCardWidth:[strongSelf previewCardWidthForTable:strongSelf.tableView]
+                                                        state:ApolloLPCurrentPreviewState()];
+    };
 
     // ---- Previews (modes) ----
 
     ApolloSettingsRow *body =
         [ApolloSettingsRow valueRowWithID:@"body"
                                     title:@"Body"
-                                   detail:^NSString * { return [weakSelf modeTextForMode:sLinkPreviewBodyMode]; }
+                                   detail:^NSString * { return ApolloLPModeName(sLinkPreviewBodyMode); }
                                  onSelect:^{
             [weakSelf presentModeSheetForBody:YES fromCell:[weakSelf cellForRowID:@"body"]];
         }];
@@ -254,7 +710,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     ApolloSettingsRow *comments =
         [ApolloSettingsRow valueRowWithID:@"comments"
                                     title:@"Comments"
-                                   detail:^NSString * { return [weakSelf modeTextForMode:sLinkPreviewCommentsMode]; }
+                                   detail:^NSString * { return ApolloLPModeName(sLinkPreviewCommentsMode); }
                                  onSelect:^{
             [weakSelf presentModeSheetForBody:NO fromCell:[weakSelf cellForRowID:@"comments"]];
         }];
@@ -293,16 +749,98 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     reset.visible = ^BOOL { return [weakSelf hasCustomColor]; };
 
     return @[
-        [ApolloSettingsSection sectionWithTitle:@"Card Preview"
-                                         footer:@"Sample full and compact cards — they update live as you change the color below."
+        [ApolloSettingsSection sectionWithTitle:@"Preview"
+                                         footer:nil
                                            rows:@[ preview ]],
         [ApolloSettingsSection sectionWithTitle:@"Previews"
-                                         footer:@"Off hides the card, Compact shows a small thumbnail row, Full shows a large hero image card."
+                                         footer:@"Off keeps Apollo's classic link button, Compact shows a small thumbnail row, Full shows a large hero image card. The preview above follows each setting. Comments with more than one link always use compact cards, even when Full is selected, so long comments don't stack up hero images."
                                            rows:@[ body, comments ]],
         [ApolloSettingsSection sectionWithTitle:@"Card Color"
                                          footer:@"The card is painted the exact color you pick, the same in light and dark mode, with title and description text automatically set to black or white for contrast. Default keeps the standard neutral card."
                                            rows:@[ color, swatches, reset ]],
     ];
+}
+
+#pragma mark - Pinned preview plumbing
+
+// Card chrome follows the same theme walk as the real cells (cell colour,
+// section corner radius, table background for the stuck backdrop, accent for
+// the pin glyph), and the samples are re-rendered for the theme's ink.
+- (void)applyThemeToPreviewHost {
+    ApolloPinnedPreviewHost *host = self.previewHost;
+    if (!host) return;
+    host.card.backgroundColor = [self apollo_themeCellBackgroundColor];
+    host.card.layer.cornerRadius = ApolloPinnedPreviewSectionCornerRadius(self.tableView);
+    UIColor *tableBackground = self.tableView.backgroundColor;
+    UIColor *resolved = [tableBackground resolvedColorWithTraitCollection:self.tableView.traitCollection];
+    if (!resolved || CGColorGetAlpha(resolved.CGColor) < 0.99) {
+        tableBackground = [UIColor systemGroupedBackgroundColor];
+    }
+    host.backdropColor = tableBackground;
+    host.accentColor = [self apollo_themeAccentColor];
+    [self.previewContentView apollo_refreshForWidth:[self previewCardWidthForTable:self.tableView] animated:NO];
+}
+
+- (void)apollo_applyTheme {
+    [super apollo_applyTheme];
+    [self applyThemeToPreviewHost];
+}
+
+// The spacer row must stay invisible whatever the theme pass does to cells.
+- (void)apollo_applyThemeToCell:(UITableViewCell *)cell {
+    if ([cell isKindOfClass:[ApolloPinnedPreviewSpacerCell class]]) {
+        ApolloPinnedPreviewClearSpacerCell(cell);
+        return;
+    }
+    [super apollo_applyThemeToCell:cell];
+}
+
+// Width the spacer row's height is derived from: the measured cell width once
+// the layout pass has seen a real cell, else the table's reported section inset.
+- (CGFloat)previewCardWidthForTable:(UITableView *)tableView {
+    if (self.previewCardWidth > 0) return self.previewCardWidth;
+    UIEdgeInsets inset = ApolloPinnedPreviewSectionContentInset(tableView);
+    CGFloat width = CGRectGetWidth(tableView.bounds) - inset.left - inset.right;
+    if (width <= 0.0) width = CGRectGetWidth(UIScreen.mainScreen.bounds) - inset.left - inset.right;
+    return MAX(0.0, width);
+}
+
+- (void)previewCardWidthDidChange:(CGFloat)width {
+    if (width <= 0 || fabs(width - self.previewCardWidth) <= 0.5) return;
+    ApolloLPPreviewState *state = ApolloLPCurrentPreviewState();
+    CGFloat oldHeight = [ApolloLPPreviewContentView heightForCardWidth:[self previewCardWidthForTable:self.tableView] state:state];
+    self.previewCardWidth = width;
+    CGFloat newHeight = [ApolloLPPreviewContentView heightForCardWidth:width state:state];
+    ApolloLog(@"[LinkPreviewSettings] card width %.1f → spacer row %.1f → %.1f", width, oldHeight, newHeight);
+    // The samples wrap to the real width either way.
+    [self.previewContentView apollo_refreshForWidth:width animated:NO];
+    if (fabs(newHeight - oldHeight) <= 0.5) return;
+    // Re-measure just the spacer row; the host follows the new rect on the next
+    // layout pass. No animation so the pinned card doesn't visibly resize.
+    [UIView performWithoutAnimation:^{
+        [self reloadRowWithID:@"preview"];
+    }];
+}
+
+// A mode changed: re-render the samples (keyed cross-fade) and spring the
+// spacer row — and with it the card and every row beneath — to the new
+// height in the same beat. Nothing reloads.
+- (void)animatePreviewStateChange {
+    CGFloat width = [self previewCardWidthForTable:self.tableView];
+    [self.previewContentView apollo_refreshForWidth:width animated:YES];
+    UITableView *table = self.tableView;
+    if (UIAccessibilityIsReduceMotionEnabled()) {
+        [table performBatchUpdates:nil completion:nil]; // re-reads the spacer's height block
+        return;
+    }
+    [UIView animateWithDuration:0.35 delay:0 usingSpringWithDamping:0.9 initialSpringVelocity:0
+                        options:UIViewAnimationOptionBeginFromCurrentState |
+                                UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
+        [table performBatchUpdates:nil completion:nil]; // re-reads the spacer's height block
+        [table layoutIfNeeded];                         // the host follows the new row rect
+    }
+                     completion:nil];
 }
 
 #pragma mark - State helpers
@@ -313,15 +851,6 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 
 - (UIColor *)currentCardColor {
     return ApolloColorFromHexString(sLinkPreviewCardColorHex);
-}
-
-- (NSString *)modeTextForMode:(NSInteger)mode {
-    switch (mode) {
-        case ApolloLinkPreviewModeOff:     return @"Off";
-        case ApolloLinkPreviewModeCompact: return @"Compact";
-        case ApolloLinkPreviewModeFull:
-        default:                           return @"Full";
-    }
 }
 
 // A rounded color swatch for the Color row's left image. Default (no color) is a
@@ -356,18 +885,22 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     if (self.settingsDidChange) self.settingsDidChange(area);
 }
 
+- (NSString *)currentCardColorHexForPreview {
+    return [sLinkPreviewCardColorHex isKindOfClass:[NSString class]] ? sLinkPreviewCardColorHex : @"";
+}
+
 // Commit a card color (or "" / nil to reset to Default) and refresh everything.
 - (void)applyCardColorHex:(NSString *)hex {
     [self storeCardColorHex:hex];
     [self broadcastChangeForArea:@"card-color"];
-    [self refreshPreview];                // persistent preview view, no reload needed
+    [self.previewContentView apollo_applyCardColorHex:[self currentCardColorHexForPreview] animated:YES];
     [self visibilityDidChange];           // reset row tracks hasCustomColor
     [self reloadRowWithID:@"color"];      // swatch chip + #hex detail
     [self reloadRowWithID:@"swatches"];   // selected-swatch border
 }
 
 - (void)setLinkPreviewMode:(NSInteger)mode body:(BOOL)body {
-    if (mode < ApolloLinkPreviewModeOff || mode > ApolloLinkPreviewModeFull) mode = ApolloLinkPreviewModeFull;
+    mode = ApolloLPNormalizedMode(mode);
     if (body) {
         sLinkPreviewBodyMode = mode;
         [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyLinkPreviewBodyMode];
@@ -377,6 +910,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     }
     [self broadcastChangeForArea:body ? @"body" : @"comments"];
     [self reloadRowWithID:body ? @"body" : @"comments"];
+    [self animatePreviewStateChange];
 }
 
 #pragma mark - Actions
@@ -412,7 +946,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     NSArray<NSNumber *> *modes = @[@(ApolloLinkPreviewModeFull), @(ApolloLinkPreviewModeCompact), @(ApolloLinkPreviewModeOff)];
     for (NSNumber *modeNumber in modes) {
         NSInteger mode = modeNumber.integerValue;
-        NSString *name = [self modeTextForMode:mode];
+        NSString *name = ApolloLPModeName(mode);
         NSString *actionTitle = (mode == currentMode) ? [NSString stringWithFormat:@"%@ (Current)", name] : name;
         [sheet addAction:[UIAlertAction actionWithTitle:actionTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
             [self setLinkPreviewMode:mode body:body];
@@ -428,11 +962,11 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 #pragma mark - UIColorPickerViewControllerDelegate
 
 - (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController *)viewController {
-    // Fires continuously while dragging. Update the live preview (visible above
-    // the picker sheet) immediately; defer the heavier feed broadcast + row
-    // refresh (Color row swatch + #hex, reset row visibility) to didFinish.
+    // Fires continuously while dragging. Recolor the pinned preview in place
+    // immediately; defer the heavier feed broadcast + row refresh (Color row
+    // swatch + #hex, reset row visibility) to didFinish.
     [self storeCardColorHex:ApolloHexStringFromColor(viewController.selectedColor)];
-    [self refreshPreview];
+    [self.previewContentView apollo_applyCardColorHex:[self currentCardColorHexForPreview] animated:NO];
 }
 
 - (void)colorPickerViewControllerDidFinish:(UIColorPickerViewController *)viewController {
@@ -493,26 +1027,6 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
         ]];
         [stack addArrangedSubview:button];
     }
-    return cell;
-}
-
-- (UITableViewCell *)previewCell {
-    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    if (!self.previewView) {
-        self.previewView = [[ApolloLPPreviewCardsView alloc] initWithFrame:CGRectZero];
-    }
-    // Re-host the persistent preview view so it survives reloadData and can be
-    // updated live (a view has one superview, so detach before re-adding).
-    [self.previewView removeFromSuperview];
-    [cell.contentView addSubview:self.previewView];
-    [NSLayoutConstraint activateConstraints:@[
-        [self.previewView.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:8.0],
-        [self.previewView.leadingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.leadingAnchor],
-        [self.previewView.trailingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.trailingAnchor],
-        [self.previewView.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-10.0],
-    ]];
-    [self.previewView applyCardColorHex:sLinkPreviewCardColorHex];
     return cell;
 }
 

--- a/src/settings/ApolloSettingsPinnedPreview.h
+++ b/src/settings/ApolloSettingsPinnedPreview.h
@@ -1,0 +1,68 @@
+#import <UIKit/UIKit.h>
+
+// Pinned "Preview" block for settings screens: a card hosted directly in the
+// table (never in a cell) that sits on a transparent spacer row and, while
+// pinned, stays locked at that resting spot — together with a copy of the
+// section title — whichever way the list scrolls or bounces, the rows sliding
+// underneath. Unpinned it scrolls like any row. Tap the card to pin/unpin. See
+// InlineMediaSettingsViewController for the reference adoption and
+// ApolloLinkPreviewSettingsViewController for the form-screen one.
+//
+// How it fits together:
+//   • The screen's "Preview" section keeps its native title and holds ONE row,
+//     an ApolloPinnedPreviewSpacerCell (run through
+//     ApolloPinnedPreviewClearSpacerCell so no theme pass paints it), whose
+//     height is the card's height for the current card width.
+//   • The host is a direct subview of the table (ApolloPinnedPreviewAttachHost)
+//     and the table is re-classed to ApolloPinnedPreviewTableView, whose layout
+//     pass places the card exactly on the spacer row and, while pinned, keeps
+//     it (plus a sampled copy of the section title) at that screen position
+//     as the list moves, drawing an opaque backdrop so the rows slide
+//     underneath. No locking in compact height or when less than
+//     kApolloPinnedPreviewMinListViewport of list would remain.
+//   • Pin toggle: a pin glyph in the card's top-right corner shows the state
+//     (pin.fill in the accent when pinned, pin in tertiaryLabelColor when
+//     not); tapping anywhere on the card flips it with a selection haptic, a
+//     glyph bounce, a brief "Pinned"/"Unpinned" caption, and the block sliding
+//     into / out of its stuck spot. The screen persists the choice (one
+//     NSUserDefaults key per screen, default pinned) in pinDidChange.
+@interface ApolloPinnedPreviewHost : UIView
+@property (nonatomic, strong, readonly) UIView *card;
+@property (nonatomic, strong) UIView *contentView;               // the screen's mock, fills the card
+@property (nonatomic, strong) UIColor *backdropColor;            // table background, shown while stuck
+@property (nonatomic, strong) UIColor *accentColor;              // filled pin glyph
+@property (nonatomic, readonly) BOOL stuck;                      // locked with rows sliding beneath
+@property (nonatomic) BOOL pinned;                               // default YES
+@property (nonatomic, copy) void (^pinDidChange)(BOOL pinned);   // persist + animate, see the recipe
+// Where the spacer row lives right now (form screens derive their indices, so
+// this is asked on every layout pass rather than fixed at attach time). nil
+// hides the host.
+@property (nonatomic, copy) NSIndexPath *(^spacerIndexPath)(void);
+// Real inset-grouped cell width as measured by the layout pass (0 = not yet
+// seen) and the callback the screen uses to re-measure the spacer row when it
+// changes (first layout, rotation). Delivered on the next runloop turn — row
+// heights can't change inside the table's own layout pass.
+@property (nonatomic, readonly) CGFloat measuredCardWidth;
+@property (nonatomic, copy) void (^cardWidthDidChange)(CGFloat width);
+@end
+
+// Transparent placeholder row that reserves the card's resting slot.
+@interface ApolloPinnedPreviewSpacerCell : UITableViewCell
+@end
+void ApolloPinnedPreviewClearSpacerCell(UITableViewCell *cell);
+
+// Table subclass carrying the layout pass. Ivar-free on purpose: screens
+// isa-swizzle their existing table with object_setClass (or subclass it when
+// they need their own touch arbitration, as Inline Media does).
+@interface ApolloPinnedPreviewTableView : UITableView
+@end
+// Adds the host to the table and registers it with the layout pass.
+void ApolloPinnedPreviewAttachHost(UITableView *table, ApolloPinnedPreviewHost *host);
+
+// Inset-grouped section geometry the card copies so it matches the real cells
+// (private UITableView getters with public fallbacks).
+UIEdgeInsets ApolloPinnedPreviewSectionContentInset(UITableView *table);
+CGFloat ApolloPinnedPreviewSectionCornerRadius(UITableView *table);
+
+// List room needed under the block at rest to bother locking it at all.
+extern const CGFloat kApolloPinnedPreviewMinListViewport;

--- a/src/settings/ApolloSettingsPinnedPreview.m
+++ b/src/settings/ApolloSettingsPinnedPreview.m
@@ -1,0 +1,427 @@
+#import "ApolloSettingsPinnedPreview.h"
+
+#import "ApolloCommon.h"
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+// Extracted from InlineMediaSettingsViewController (the reference adoption)
+// so every settings screen with a live preview behaves and looks the same:
+// same sticking rules, same pin glyph, caption and animation.
+
+static const CGFloat kApolloPinnedPreviewStuckBottomPad = 8.0;  // backdrop below the card
+const CGFloat kApolloPinnedPreviewMinListViewport = 200.0;      // list room needed to bother sticking
+static const CGFloat kApolloPinnedPreviewPinInset = 12.0;       // card right edge → pin glyph
+static const CGFloat kApolloPinnedPreviewPinTop = 7.0;          // card top → pin glyph
+static const CGFloat kApolloPinnedPreviewPinSide = 22.0;        // glyph box
+
+// MARK: - Host
+
+// The preview card. A direct subview of the table view — never a cell — sized
+// to the transparent spacer row that reserves its resting place under the
+// "Preview" header. Unpinned, the card sits exactly on that row and scrolls
+// like any other row. Pinned, the header AND the card are LOCKED at their
+// resting screen position — they never move, whichever way the list scrolls
+// or rubber-bands — and the rows slide underneath (an opaque backdrop hides
+// them), so every control further down is adjusted with the preview still in
+// view. Positioning lives in ApolloPinnedPreviewTableView's layoutSubviews,
+// which UIScrollView runs on every content-offset change.
+//
+// The pinned "Preview" title is a copy of UIKit's own section header label —
+// text, font, colour and position are sampled from the real header view while
+// it is on screen (it always is at rest), so it matches whatever header style
+// this iOS / Liquid Glass combination draws, and only becomes visible once the
+// list has left its resting offset (the native header is under the backdrop
+// by then; at rest the two are pixel-identical, so the hand-off is invisible).
+//
+// Height-constrained layouts (landscape phones, tiny screens) don't lock:
+// pinning a tall card there would leave no usable list, so the card just
+// scrolls with the content as it always did.
+@interface ApolloPinnedPreviewHost ()
+@property (nonatomic, strong, readwrite) UIView *card;
+@property (nonatomic, strong) UILabel *titleLabel;      // pinned copy of the section header
+@property (nonatomic, readwrite) BOOL stuck;
+@property (nonatomic, strong) UIButton *pinButton;
+@property (nonatomic, strong) UIImageView *pinIcon;
+@property (nonatomic, strong) UILabel *pinCaption;
+@property (nonatomic, strong) UISelectionFeedbackGenerator *pinFeedback;
+@property (nonatomic) NSUInteger pinCaptionToken;
+// Sampled from the native header: the label's origin relative to the card's
+// resting origin (y is negative — the title sits above the card) and its size.
+@property (nonatomic) BOOL hasTitleSample;
+@property (nonatomic) CGPoint titleOffset;
+@property (nonatomic) CGSize titleSize;
+@property (nonatomic, readwrite) CGFloat measuredCardWidth;
+- (void)sampleTitleFromHeaderView:(UIView *)headerView
+                          inTable:(UITableView *)table
+                       headerRect:(CGRect)headerRect
+                       cardOrigin:(CGPoint)cardOrigin;
+@end
+
+@implementation ApolloPinnedPreviewHost
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        self.backgroundColor = [UIColor clearColor];
+        _card = [[UIView alloc] init];
+        _card.clipsToBounds = YES;
+        [self addSubview:_card];
+        _titleLabel = [[UILabel alloc] init];
+        _titleLabel.hidden = YES;
+        [self addSubview:_titleLabel];
+
+        // UIControl target/action does not retain its target, so the host can
+        // be the target without a host → card → button → host cycle.
+        _pinButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        _pinButton.backgroundColor = [UIColor clearColor];
+        [_pinButton addTarget:self action:@selector(apollo_pinTapped) forControlEvents:UIControlEventTouchUpInside];
+        [_card addSubview:_pinButton];
+        _pinIcon = [[UIImageView alloc] init];
+        _pinIcon.contentMode = UIViewContentModeCenter;
+        _pinIcon.userInteractionEnabled = NO;
+        [_card addSubview:_pinIcon];
+        _pinCaption = [[UILabel alloc] init];
+        _pinCaption.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold];
+        _pinCaption.textColor = [UIColor secondaryLabelColor];
+        _pinCaption.textAlignment = NSTextAlignmentRight;
+        _pinCaption.alpha = 0.0;
+        _pinCaption.userInteractionEnabled = NO;
+        [_card addSubview:_pinCaption];
+        _pinFeedback = [[UISelectionFeedbackGenerator alloc] init];
+        _pinned = YES;
+        [self apollo_updatePinIcon];
+    }
+    return self;
+}
+
+// The screen's mock fills the card, underneath the pin controls (which stay
+// on top so the whole card remains the pin's tap target).
+- (void)setContentView:(UIView *)contentView {
+    if (_contentView == contentView) return;
+    [_contentView removeFromSuperview];
+    _contentView = contentView;
+    if (contentView) {
+        contentView.userInteractionEnabled = NO;
+        [self.card insertSubview:contentView atIndex:0];
+        [self setNeedsLayout];
+    }
+}
+
+- (void)setPinned:(BOOL)pinned {
+    _pinned = pinned;
+    [self apollo_updatePinIcon];
+}
+
+- (void)setAccentColor:(UIColor *)accentColor {
+    _accentColor = accentColor;
+    [self apollo_updatePinIcon];
+}
+
+- (void)apollo_updatePinIcon {
+    UIImageSymbolConfiguration *config =
+        [UIImageSymbolConfiguration configurationWithPointSize:13.0 weight:UIImageSymbolWeightSemibold];
+    self.pinIcon.image = [UIImage systemImageNamed:self.pinned ? @"pin.fill" : @"pin" withConfiguration:config];
+    self.pinIcon.tintColor = self.pinned
+        ? (self.accentColor ?: [UIColor systemBlueColor])
+        : [UIColor tertiaryLabelColor];
+    self.pinButton.accessibilityLabel = self.pinned ? @"Unpin preview" : @"Pin preview";
+}
+
+- (void)apollo_pinTapped {
+    self.pinned = !self.pinned;
+    [self.pinFeedback selectionChanged];
+
+    // Bounce the glyph so the tap reads as a state change.
+    self.pinIcon.transform = CGAffineTransformMakeScale(1.3, 1.3);
+    [UIView animateWithDuration:0.45 delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0
+                        options:UIViewAnimationOptionBeginFromCurrentState
+                     animations:^{ self.pinIcon.transform = CGAffineTransformIdentity; }
+                     completion:nil];
+
+    // Brief caption next to the glyph, replaced (not stacked) by a quick re-tap.
+    NSUInteger token = ++self.pinCaptionToken;
+    self.pinCaption.text = self.pinned ? @"Pinned" : @"Unpinned";
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+    [UIView animateWithDuration:0.15 animations:^{ self.pinCaption.alpha = 1.0; }];
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf.pinCaptionToken != token) return;
+        [UIView animateWithDuration:0.3 animations:^{ strongSelf.pinCaption.alpha = 0.0; }];
+    });
+
+    if (self.pinDidChange) self.pinDidChange(self.pinned);
+}
+
+// The header's text label, wherever this iOS version nests it.
+static UILabel *ApolloPinnedPreviewFindHeaderLabel(UIView *view) {
+    if ([view isKindOfClass:[UILabel class]] && ((UILabel *)view).text.length > 0) return (UILabel *)view;
+    for (UIView *sub in view.subviews) {
+        UILabel *label = ApolloPinnedPreviewFindHeaderLabel(sub);
+        if (label) return label;
+    }
+    return nil;
+}
+
+- (void)sampleTitleFromHeaderView:(UIView *)headerView
+                          inTable:(UITableView *)table
+                       headerRect:(CGRect)headerRect
+                       cardOrigin:(CGPoint)cardOrigin {
+    UILabel *label = ApolloPinnedPreviewFindHeaderLabel(headerView);
+    if (!label || !label.superview || CGRectIsEmpty(label.frame) || !headerView.superview) return;
+    CGRect frame = [label.superview convertRect:label.frame toView:table];
+    // Only trust a label that lies inside the table's own rect for that header.
+    // After a reloadData (a light/dark flip, or a hand-rolled screen's
+    // viewWillAppear) the header view UIKit hands out reports its label ~37pt
+    // ABOVE the header on iOS 26 while the title is visibly drawn in place;
+    // sampling that pushed the block off its row at rest and floated the
+    // title copy up into the gap. Skip such passes — the
+    // previous good sample stays.
+    if (!CGRectIsEmpty(headerRect) &&
+        (CGRectGetMinY(frame) < CGRectGetMinY(headerRect) - 1.0 ||
+         CGRectGetMaxY(frame) > CGRectGetMaxY(headerRect) + 1.0)) {
+        return;
+    }
+    CGPoint offset = CGPointMake(CGRectGetMinX(frame) - cardOrigin.x, CGRectGetMinY(frame) - cardOrigin.y);
+    if (offset.y >= 0) return;   // not above the card: not our header's label
+    BOOL sameText = [self.titleLabel.text isEqualToString:label.text];
+    if (self.hasTitleSample && sameText &&
+        fabs(offset.x - self.titleOffset.x) < 0.5 && fabs(offset.y - self.titleOffset.y) < 0.5 &&
+        fabs(frame.size.width - self.titleSize.width) < 0.5 && fabs(frame.size.height - self.titleSize.height) < 0.5) {
+        return;   // unchanged
+    }
+    self.titleLabel.font = label.font;
+    self.titleLabel.textColor = label.textColor;
+    self.titleLabel.textAlignment = label.textAlignment;
+    self.titleLabel.numberOfLines = label.numberOfLines;
+    self.titleLabel.text = label.text;
+    if (label.attributedText) self.titleLabel.attributedText = [label.attributedText copy];
+    self.titleOffset = offset;
+    self.titleSize = frame.size;
+    self.hasTitleSample = YES;
+}
+
+- (void)setStuck:(BOOL)stuck {
+    _stuck = stuck;
+    [self apollo_updateBackdrop];
+}
+
+- (void)setBackdropColor:(UIColor *)backdropColor {
+    _backdropColor = backdropColor;
+    [self apollo_updateBackdrop];
+}
+
+- (void)apollo_updateBackdrop {
+    self.backgroundColor = self.stuck
+        ? (self.backdropColor ?: [UIColor systemGroupedBackgroundColor])
+        : [UIColor clearColor];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect cardBounds = self.card.bounds;
+    self.contentView.frame = cardBounds;
+    self.pinButton.frame = cardBounds;
+    self.pinIcon.frame = CGRectMake(CGRectGetWidth(cardBounds) - kApolloPinnedPreviewPinInset - kApolloPinnedPreviewPinSide,
+                                    kApolloPinnedPreviewPinTop, kApolloPinnedPreviewPinSide, kApolloPinnedPreviewPinSide);
+    [self.pinCaption sizeToFit];
+    CGSize captionSize = self.pinCaption.bounds.size;
+    self.pinCaption.frame = CGRectMake(CGRectGetMinX(self.pinIcon.frame) - 6.0 - captionSize.width,
+                                       CGRectGetMidY(self.pinIcon.frame) - captionSize.height * 0.5,
+                                       captionSize.width, captionSize.height);
+}
+
+@end
+
+// MARK: - Spacer row
+
+// Transparent spacer cell: reserves the preview's resting slot in the flow (so
+// UIKit draws the native "Preview" section header above it) while the pinned
+// card does all the drawing. Kept clear by the theme override in the screen.
+@implementation ApolloPinnedPreviewSpacerCell
+@end
+
+void ApolloPinnedPreviewClearSpacerCell(UITableViewCell *cell) {
+    cell.backgroundColor = [UIColor clearColor];
+    cell.contentView.backgroundColor = [UIColor clearColor];
+    if (!cell.backgroundView) cell.backgroundView = [[UIView alloc] init];
+    cell.backgroundView.backgroundColor = [UIColor clearColor];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+}
+
+// MARK: - Section geometry
+
+// Inset-grouped section geometry the card copies so it matches the real cells.
+// Both are private UITableView getters (iOS 13+), called defensively with
+// public fallbacks: the table's layoutMargins for the inset, and the familiar
+// 10pt (26pt under Liquid Glass) for the corner radius.
+UIEdgeInsets ApolloPinnedPreviewSectionContentInset(UITableView *table) {
+    SEL sel = NSSelectorFromString(@"_sectionContentInset");
+    if ([table respondsToSelector:sel]) {
+        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
+        if (sig && strcmp(sig.methodReturnType, @encode(UIEdgeInsets)) == 0) {
+            UIEdgeInsets insets = ((UIEdgeInsets (*)(id, SEL))objc_msgSend)(table, sel);
+            if (insets.left >= 0 && insets.right >= 0) return insets;
+        }
+    }
+    return table.layoutMargins;
+}
+
+CGFloat ApolloPinnedPreviewSectionCornerRadius(UITableView *table) {
+    SEL sel = NSSelectorFromString(@"_sectionCornerRadius");
+    if ([table respondsToSelector:sel]) {
+        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
+        if (sig && strcmp(sig.methodReturnType, @encode(double)) == 0) {
+            double radius = ((double (*)(id, SEL))objc_msgSend)(table, sel);
+            if (radius > 0) return (CGFloat)radius;
+        }
+    }
+    return IsLiquidGlass() ? 26.0 : 10.0;
+}
+
+// MARK: - Table view (the layout pass)
+
+// The host is attached by the screen (associated, not an ivar — the subclass
+// must stay ivar-free for object_setClass to be safe).
+static char kApolloPinnedPreviewHostKey;
+
+void ApolloPinnedPreviewAttachHost(UITableView *table, ApolloPinnedPreviewHost *host) {
+    if (!table || !host) return;
+    [table addSubview:host];
+    objc_setAssociatedObject(table, &kApolloPinnedPreviewHostKey, host, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [table setNeedsLayout];
+}
+
+@implementation ApolloPinnedPreviewTableView
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self apollo_layoutPinnedPreview];
+}
+
+- (void)apollo_layoutPinnedPreview {
+    ApolloPinnedPreviewHost *host = objc_getAssociatedObject(self, &kApolloPinnedPreviewHostKey);
+    if (!host || host.superview != self) return;
+    NSIndexPath *previewPath = host.spacerIndexPath ? host.spacerIndexPath() : nil;
+    if (!previewPath ||
+        self.numberOfSections <= previewPath.section ||
+        [self numberOfRowsInSection:previewPath.section] <= previewPath.row) {
+        host.hidden = YES;
+        return;
+    }
+    CGRect row = [self rectForRowAtIndexPath:previewPath];   // full table width; cells are inset
+    if (CGRectIsEmpty(row)) { host.hidden = YES; return; }
+    host.hidden = NO;
+
+    // Horizontal card geometry = whatever the inset-grouped cells actually use.
+    // Any visible cell will do (they all share it), converted into the table's
+    // coordinate space: on iOS 26 cells are parented to a per-section container,
+    // so their raw frame is relative to that (x = 0), not to the table. Before
+    // the first cell exists, fall back to the row rect — already inset on iOS 26,
+    // full-width on earlier releases, where the table's section inset is applied.
+    UITableViewCell *sample = [self cellForRowAtIndexPath:previewPath] ?: self.visibleCells.firstObject;
+    CGFloat cardX, cardW;
+    if (sample && sample.superview) {
+        CGRect cellRect = [sample.superview convertRect:sample.frame toView:self];
+        cardX = CGRectGetMinX(cellRect);
+        cardW = CGRectGetWidth(cellRect);
+    } else if (CGRectGetWidth(row) < CGRectGetWidth(self.bounds) - 1.0) {
+        cardX = CGRectGetMinX(row);
+        cardW = CGRectGetWidth(row);
+    } else {
+        UIEdgeInsets inset = ApolloPinnedPreviewSectionContentInset(self);
+        cardX = CGRectGetMinX(row) + inset.left;
+        cardW = CGRectGetWidth(row) - inset.left - inset.right;
+    }
+    if (sample && fabs(cardW - host.measuredCardWidth) > 0.5) {
+        host.measuredCardWidth = cardW;
+        if (host.cardWidthDidChange) {
+            // Row-height changes can't happen inside the table's own layout pass;
+            // let the screen re-measure the spacer row on the next turn.
+            void (^cb)(CGFloat) = host.cardWidthDidChange;
+            dispatch_async(dispatch_get_main_queue(), ^{ cb(cardW); });
+        }
+    }
+
+    // The section header ("Preview") is pinned with the card. Sample its label
+    // while UIKit has it on screen; the copy is only shown once stuck.
+    UIView *headerView = [self headerViewForSection:previewPath.section];
+    if (headerView) {
+        [host sampleTitleFromHeaderView:headerView
+                                inTable:self
+                             headerRect:[self rectForHeaderInSection:previewPath.section]
+                             cardOrigin:CGPointMake(cardX, CGRectGetMinY(row))];
+    }
+    // How far the list has moved from its resting offset (negative while it
+    // rubber-bands above it). At rest this is 0 and the block is on its row.
+    CGFloat scrolled = self.contentOffset.y + self.adjustedContentInset.top;
+    CGFloat viewport = CGRectGetHeight(self.bounds) - self.adjustedContentInset.top - self.adjustedContentInset.bottom;
+    // Lock only when there's real list room left under the block at rest.
+    CGFloat listRoom = viewport - (CGRectGetMaxY(row) + kApolloPinnedPreviewStuckBottomPad);
+    BOOL compactHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
+    BOOL canLock = host.pinned && !compactHeight && listRoom >= kApolloPinnedPreviewMinListViewport;
+
+    // Pinned: the block stays exactly where it rests on screen. Its content
+    // y follows the offset one-for-one, so scrolling down slides the rows
+    // under it and a pull-down bounce leaves it put while the rows spring
+    // away and back beneath it. Unpinned (or no room): it rides its row.
+    CGFloat cardY = CGRectGetMinY(row);
+    if (canLock) cardY += scrolled;
+    BOOL stuck = canLock && fabs(scrolled) > 0.5;
+
+    // Locked: the backdrop runs from the very top of the visible bounds, so
+    // the native header and the section's own rounded background never show
+    // around the block — under a transparent nav bar (Liquid Glass), the
+    // status bar once a hide-on-scroll bar has gone, or while a bounce drags
+    // them down past the locked card. The scroll-edge effect fades the
+    // backdrop's top into the table's background, which is the same colour,
+    // so nothing reads as a seam.
+    CGFloat hostTop = stuck ? self.contentOffset.y : CGRectGetMinY(row);
+    CGFloat hostBottom = cardY + CGRectGetHeight(row) + (stuck ? kApolloPinnedPreviewStuckBottomPad : 0.0);
+    host.frame = CGRectMake(0, hostTop, CGRectGetWidth(self.bounds), hostBottom - hostTop);
+    host.card.frame = CGRectMake(cardX, cardY - hostTop, cardW, CGRectGetHeight(row));
+    // Alpha rather than hidden so a pin/unpin toggle (run inside an animation
+    // block by the screen) fades the title along with the sliding card.
+    host.titleLabel.hidden = !host.hasTitleSample;
+    host.titleLabel.alpha = (stuck && host.hasTitleSample) ? 1.0 : 0.0;
+    if (host.hasTitleSample) {
+        host.titleLabel.frame = CGRectMake(cardX + host.titleOffset.x, cardY - hostTop + host.titleOffset.y,
+                                           host.titleSize.width, host.titleSize.height);
+    }
+    if (host.stuck != stuck) host.stuck = stuck;
+
+    // Keep the host above every cell and section header/footer (UITableView
+    // appends those as they scroll in, which would otherwise put them over the
+    // stuck card and let taps reach rows hidden underneath) — but no higher, so
+    // UIKit's own overlays (scroll indicator, iOS 26 scroll-edge effect) stay on
+    // top. Cells/headers may be nested in per-section containers (iOS 26), so
+    // what matters is each one's ancestor that is a DIRECT subview of the table.
+    NSArray<UIView *> *subviews = self.subviews;
+    NSUInteger hostIndex = [subviews indexOfObjectIdenticalTo:host];
+    NSMutableArray<UIView *> *content = [NSMutableArray arrayWithArray:self.visibleCells];
+    NSInteger sections = self.numberOfSections;
+    for (NSInteger section = 0; section < sections; section++) {
+        UIView *header = [self headerViewForSection:section];
+        UIView *footer = [self footerViewForSection:section];
+        if (header) [content addObject:header];
+        if (footer) [content addObject:footer];
+    }
+    UIView *topContent = nil;
+    NSUInteger topContentIndex = 0;
+    for (UIView *view in content) {
+        UIView *direct = view;
+        while (direct.superview && direct.superview != self) direct = direct.superview;
+        if (direct.superview != self || direct == host) continue;
+        NSUInteger index = [subviews indexOfObjectIdenticalTo:direct];
+        if (index != NSNotFound && (!topContent || index > topContentIndex)) {
+            topContent = direct;
+            topContentIndex = index;
+        }
+    }
+    if (topContent && topContentIndex > hostIndex) {
+        [self insertSubview:host aboveSubview:topContent];
+    }
+}
+
+@end

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -4,6 +4,7 @@
 #import "ApolloMediaAutoplay.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
+#import "settings/ApolloSettingsPinnedPreview.h"
 #import <QuartzCore/QuartzCore.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
@@ -32,11 +33,11 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 
 // MARK: - Live preview (fake comment + message thread)
 //
-// A standalone UIView owned by the controller. Unlike ApolloLPPreviewCardsView
-// (Rich Link Preview settings) it is NOT hosted in a table cell: it lives in the
-// pinned preview card (ApolloIMPinnedPreviewHost, a direct subview of the table
-// view), so it survives every reloadData untouched and keeps updating live while
-// the list scrolls beneath it. One apply/refresh entry point the controls call
+// A standalone UIView owned by the controller. It is NOT hosted in a table
+// cell: it lives in the pinned preview card (ApolloPinnedPreviewHost, a direct
+// subview of the table view — see ApolloSettingsPinnedPreview.h), so it
+// survives every reloadData untouched and keeps updating live while the list
+// scrolls beneath it. One apply/refresh entry point the controls call
 // continuously while dragging. Frame-based layout — this is a plain settings
 // view, not a Texture hook, so laying out subviews here is fine.
 //
@@ -278,257 +279,6 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
 }
 
 @end
-
-// MARK: - Pinned preview host (sticks below the nav bar while the list scrolls)
-
-// The preview card. A direct subview of the table view — never a cell — sized
-// to the transparent spacer row that reserves its resting place under the
-// "Preview" header. While that row is on screen the card sits exactly on it and
-// scrolls like any other row; once the header would slide under the nav bar the
-// header AND the card stick just below the bar instead (an opaque backdrop
-// hides the rows passing underneath), so every control further down is adjusted
-// with the preview still in view. Positioning lives in
-// ApolloIMSettingsTableView's layoutSubviews, which UIScrollView runs on every
-// content-offset change.
-//
-// The pinned "Preview" title is a copy of UIKit's own section header label —
-// text, font, colour and position are sampled from the real header view while
-// it is on screen (it always is at rest), so it matches whatever header style
-// this iOS / Liquid Glass combination draws, and only becomes visible once the
-// block is stuck (the native header is under the backdrop by then).
-//
-// Height-constrained layouts (landscape phones, tiny screens) don't stick:
-// pinning a ~400pt card there would leave no usable list, so the card just
-// scrolls with the content as it always did.
-static const CGFloat kApolloIMStuckTopGap = 8.0;       // nav bar bottom → card top
-static const CGFloat kApolloIMStuckBottomPad = 8.0;    // backdrop below the card
-static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bother sticking
-
-@interface ApolloIMPinnedPreviewHost : UIView
-@property (nonatomic, strong) UIView *card;
-@property (nonatomic, strong) ApolloInlineMediaPreviewView *preview;
-@property (nonatomic, strong) UILabel *titleLabel;      // pinned copy of the section header
-@property (nonatomic, strong) UIColor *backdropColor;   // table background, shown while stuck
-@property (nonatomic, strong) UIColor *accentColor;     // filled pin glyph
-@property (nonatomic) BOOL stuck;
-// Pin toggle: tapping anywhere on the card flips it. Pinned (default) = the
-// block sticks below the nav bar; unpinned = it scrolls with the list like any
-// row. A small pin glyph in the card's corner shows the state at all times
-// (filled + accent when pinned, outlined + dim when not), and a short caption
-// acknowledges each tap. The controller persists the choice.
-@property (nonatomic) BOOL pinned;
-@property (nonatomic, strong) UIButton *pinButton;
-@property (nonatomic, strong) UIImageView *pinIcon;
-@property (nonatomic, strong) UILabel *pinCaption;
-@property (nonatomic, strong) UISelectionFeedbackGenerator *pinFeedback;
-@property (nonatomic) NSUInteger pinCaptionToken;
-@property (nonatomic, copy) void (^pinDidChange)(BOOL pinned);
-// Sampled from the native header: the label's origin relative to the card's
-// resting origin (y is negative — the title sits above the card) and its size.
-@property (nonatomic) BOOL hasTitleSample;
-@property (nonatomic) CGPoint titleOffset;
-@property (nonatomic) CGSize titleSize;
-- (void)sampleTitleFromHeaderView:(UIView *)headerView inTable:(UITableView *)table cardOrigin:(CGPoint)cardOrigin;
-// Real inset-grouped cell width measured by the layout pass (0 = not yet seen)
-// and the callback the controller uses to re-measure the spacer row when it
-// changes (first layout, rotation).
-@property (nonatomic) CGFloat measuredCardWidth;
-@property (nonatomic, copy) void (^cardWidthDidChange)(CGFloat width);
-@end
-
-@implementation ApolloIMPinnedPreviewHost
-
-- (instancetype)initWithFrame:(CGRect)frame {
-    if ((self = [super initWithFrame:frame])) {
-        self.backgroundColor = [UIColor clearColor];
-        _card = [[UIView alloc] init];
-        _card.clipsToBounds = YES;
-        [self addSubview:_card];
-        _preview = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
-        [_card addSubview:_preview];
-        _titleLabel = [[UILabel alloc] init];
-        _titleLabel.hidden = YES;
-        [self addSubview:_titleLabel];
-
-        // UIControl target/action does not retain its target, so the host can
-        // be the target without a host → card → button → host cycle.
-        _pinButton = [UIButton buttonWithType:UIButtonTypeCustom];
-        _pinButton.backgroundColor = [UIColor clearColor];
-        [_pinButton addTarget:self action:@selector(apollo_pinTapped) forControlEvents:UIControlEventTouchUpInside];
-        [_card addSubview:_pinButton];
-        _pinIcon = [[UIImageView alloc] init];
-        _pinIcon.contentMode = UIViewContentModeCenter;
-        _pinIcon.userInteractionEnabled = NO;
-        [_card addSubview:_pinIcon];
-        _pinCaption = [[UILabel alloc] init];
-        _pinCaption.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold];
-        _pinCaption.textColor = [UIColor secondaryLabelColor];
-        _pinCaption.textAlignment = NSTextAlignmentRight;
-        _pinCaption.alpha = 0.0;
-        _pinCaption.userInteractionEnabled = NO;
-        [_card addSubview:_pinCaption];
-        _pinFeedback = [[UISelectionFeedbackGenerator alloc] init];
-        _pinned = YES;
-        [self apollo_updatePinIcon];
-    }
-    return self;
-}
-
-- (void)setPinned:(BOOL)pinned {
-    _pinned = pinned;
-    [self apollo_updatePinIcon];
-}
-
-- (void)setAccentColor:(UIColor *)accentColor {
-    _accentColor = accentColor;
-    [self apollo_updatePinIcon];
-}
-
-- (void)apollo_updatePinIcon {
-    UIImageSymbolConfiguration *config =
-        [UIImageSymbolConfiguration configurationWithPointSize:13.0 weight:UIImageSymbolWeightSemibold];
-    self.pinIcon.image = [UIImage systemImageNamed:self.pinned ? @"pin.fill" : @"pin" withConfiguration:config];
-    self.pinIcon.tintColor = self.pinned
-        ? (self.accentColor ?: [UIColor systemBlueColor])
-        : [UIColor tertiaryLabelColor];
-    self.pinButton.accessibilityLabel = self.pinned ? @"Unpin preview" : @"Pin preview";
-}
-
-- (void)apollo_pinTapped {
-    self.pinned = !self.pinned;
-    [self.pinFeedback selectionChanged];
-
-    // Bounce the glyph so the tap reads as a state change.
-    self.pinIcon.transform = CGAffineTransformMakeScale(1.3, 1.3);
-    [UIView animateWithDuration:0.45 delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0
-                        options:UIViewAnimationOptionBeginFromCurrentState
-                     animations:^{ self.pinIcon.transform = CGAffineTransformIdentity; }
-                     completion:nil];
-
-    // Brief caption next to the glyph, replaced (not stacked) by a quick re-tap.
-    NSUInteger token = ++self.pinCaptionToken;
-    self.pinCaption.text = self.pinned ? @"Pinned" : @"Unpinned";
-    [self setNeedsLayout];
-    [self layoutIfNeeded];
-    [UIView animateWithDuration:0.15 animations:^{ self.pinCaption.alpha = 1.0; }];
-    __weak __typeof(self) weakSelf = self;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf || strongSelf.pinCaptionToken != token) return;
-        [UIView animateWithDuration:0.3 animations:^{ strongSelf.pinCaption.alpha = 0.0; }];
-    });
-
-    if (self.pinDidChange) self.pinDidChange(self.pinned);
-}
-
-// The header's text label, wherever this iOS version nests it.
-static UILabel *ApolloIMFindHeaderLabel(UIView *view) {
-    if ([view isKindOfClass:[UILabel class]] && ((UILabel *)view).text.length > 0) return (UILabel *)view;
-    for (UIView *sub in view.subviews) {
-        UILabel *label = ApolloIMFindHeaderLabel(sub);
-        if (label) return label;
-    }
-    return nil;
-}
-
-- (void)sampleTitleFromHeaderView:(UIView *)headerView inTable:(UITableView *)table cardOrigin:(CGPoint)cardOrigin {
-    UILabel *label = ApolloIMFindHeaderLabel(headerView);
-    if (!label || !label.superview || CGRectIsEmpty(label.frame)) return;
-    CGRect frame = [label.superview convertRect:label.frame toView:table];
-    CGPoint offset = CGPointMake(CGRectGetMinX(frame) - cardOrigin.x, CGRectGetMinY(frame) - cardOrigin.y);
-    if (offset.y >= 0) return;   // not above the card: not our header's label
-    BOOL sameText = [self.titleLabel.text isEqualToString:label.text];
-    if (self.hasTitleSample && sameText &&
-        fabs(offset.x - self.titleOffset.x) < 0.5 && fabs(offset.y - self.titleOffset.y) < 0.5 &&
-        fabs(frame.size.width - self.titleSize.width) < 0.5 && fabs(frame.size.height - self.titleSize.height) < 0.5) {
-        return;   // unchanged
-    }
-    self.titleLabel.font = label.font;
-    self.titleLabel.textColor = label.textColor;
-    self.titleLabel.textAlignment = label.textAlignment;
-    self.titleLabel.numberOfLines = label.numberOfLines;
-    self.titleLabel.text = label.text;
-    if (label.attributedText) self.titleLabel.attributedText = [label.attributedText copy];
-    self.titleOffset = offset;
-    self.titleSize = frame.size;
-    self.hasTitleSample = YES;
-}
-
-- (void)setStuck:(BOOL)stuck {
-    _stuck = stuck;
-    [self apollo_updateBackdrop];
-}
-
-- (void)setBackdropColor:(UIColor *)backdropColor {
-    _backdropColor = backdropColor;
-    [self apollo_updateBackdrop];
-}
-
-- (void)apollo_updateBackdrop {
-    self.backgroundColor = self.stuck
-        ? (self.backdropColor ?: [UIColor systemGroupedBackgroundColor])
-        : [UIColor clearColor];
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    CGRect cardBounds = self.card.bounds;
-    self.preview.frame = cardBounds;
-    self.pinButton.frame = cardBounds;
-    CGFloat side = 22.0;
-    self.pinIcon.frame = CGRectMake(CGRectGetWidth(cardBounds) - kApolloIMPreviewInset - side, kApolloIMPreviewPad - 1.0, side, side);
-    [self.pinCaption sizeToFit];
-    CGSize captionSize = self.pinCaption.bounds.size;
-    self.pinCaption.frame = CGRectMake(CGRectGetMinX(self.pinIcon.frame) - 6.0 - captionSize.width,
-                                       CGRectGetMidY(self.pinIcon.frame) - captionSize.height * 0.5,
-                                       captionSize.width, captionSize.height);
-}
-
-@end
-
-// Transparent spacer cell: reserves the preview's resting slot in the flow (so
-// UIKit draws the native "Preview" section header above it) while the pinned
-// card does all the drawing. Kept clear by the theme override in the controller.
-@interface ApolloIMPreviewSpacerCell : UITableViewCell
-@end
-@implementation ApolloIMPreviewSpacerCell
-@end
-
-static void ApolloIMClearSpacerCell(UITableViewCell *cell) {
-    cell.backgroundColor = [UIColor clearColor];
-    cell.contentView.backgroundColor = [UIColor clearColor];
-    if (!cell.backgroundView) cell.backgroundView = [[UIView alloc] init];
-    cell.backgroundView.backgroundColor = [UIColor clearColor];
-    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-}
-
-// Inset-grouped section geometry the card copies so it matches the real cells.
-// Both are private UITableView getters (iOS 13+), called defensively with
-// public fallbacks: the table's layoutMargins for the inset, and the familiar
-// 10pt (26pt under Liquid Glass) for the corner radius.
-static UIEdgeInsets ApolloIMSectionContentInset(UITableView *table) {
-    SEL sel = NSSelectorFromString(@"_sectionContentInset");
-    if ([table respondsToSelector:sel]) {
-        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
-        if (sig && strcmp(sig.methodReturnType, @encode(UIEdgeInsets)) == 0) {
-            UIEdgeInsets insets = ((UIEdgeInsets (*)(id, SEL))objc_msgSend)(table, sel);
-            if (insets.left >= 0 && insets.right >= 0) return insets;
-        }
-    }
-    return table.layoutMargins;
-}
-
-static CGFloat ApolloIMSectionCornerRadius(UITableView *table) {
-    SEL sel = NSSelectorFromString(@"_sectionCornerRadius");
-    if ([table respondsToSelector:sel]) {
-        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
-        if (sig && strcmp(sig.methodReturnType, @encode(double)) == 0) {
-            double radius = ((double (*)(id, SEL))objc_msgSend)(table, sel);
-            if (radius > 0) return (CGFloat)radius;
-        }
-    }
-    return IsLiquidGlass() ? 26.0 : 10.0;
-}
 
 // MARK: - Detent slider (50 / 75 / 100)
 
@@ -955,13 +705,14 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
 
 // MARK: - Table view (keeps the slider drag from scrolling the screen)
 
-// The settings table is isa-swizzled to this class in viewDidLoad. It overrides
-// two UIScrollView touch-arbitration hooks, scoped to the size slider only, so
-// the screen never scrolls out from under a slider drag — WITHOUT any per-drag
-// state to enable/restore (the earlier scrollEnabled / canCancelContentTouches
-// / pan-disabling approaches either collapsed the layout or left the table
-// stuck when UIControl end-tracking didn't fire).
-@interface ApolloIMSettingsTableView : UITableView
+// The settings table is isa-swizzled to this class in viewDidLoad. On top of
+// the shared pinned-preview layout pass (ApolloPinnedPreviewTableView) it
+// overrides two UIScrollView touch-arbitration hooks, scoped to the size slider
+// only, so the screen never scrolls out from under a slider drag — WITHOUT any
+// per-drag state to enable/restore (the earlier scrollEnabled /
+// canCancelContentTouches / pan-disabling approaches either collapsed the
+// layout or left the table stuck when UIControl end-tracking didn't fire).
+@interface ApolloIMSettingsTableView : ApolloPinnedPreviewTableView
 @end
 @implementation ApolloIMSettingsTableView
 static BOOL ApolloIMViewIsInSlider(UIView *view) {
@@ -985,131 +736,12 @@ static BOOL ApolloIMViewIsInSlider(UIView *view) {
     return [super touchesShouldCancelInContentView:view];
 }
 
-// MARK: Pinned preview layout
-
-// The host is attached by the controller (associated, not an ivar — the subclass
-// must stay ivar-free for object_setClass to be safe).
-static char kApolloIMPinnedHostKey;
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    [self apollo_layoutPinnedPreview];
-}
-
-- (void)apollo_layoutPinnedPreview {
-    ApolloIMPinnedPreviewHost *host = objc_getAssociatedObject(self, &kApolloIMPinnedHostKey);
-    if (!host || host.superview != self) return;
-    if (self.numberOfSections <= ApolloIMSectionPreview ||
-        [self numberOfRowsInSection:ApolloIMSectionPreview] < 1) {
-        host.hidden = YES;
-        return;
-    }
-    NSIndexPath *previewPath = [NSIndexPath indexPathForRow:0 inSection:ApolloIMSectionPreview];
-    CGRect row = [self rectForRowAtIndexPath:previewPath];   // full table width; cells are inset
-    if (CGRectIsEmpty(row)) { host.hidden = YES; return; }
-    host.hidden = NO;
-
-    // Horizontal card geometry = whatever the inset-grouped cells actually use.
-    // Any visible cell will do (they all share it), converted into the table's
-    // coordinate space: on iOS 26 cells are parented to a per-section container,
-    // so their raw frame is relative to that (x = 0), not to the table. Before
-    // the first cell exists, fall back to the row rect — already inset on iOS 26,
-    // full-width on earlier releases, where the table's section inset is applied.
-    UITableViewCell *sample = [self cellForRowAtIndexPath:previewPath] ?: self.visibleCells.firstObject;
-    CGFloat cardX, cardW;
-    if (sample && sample.superview) {
-        CGRect cellRect = [sample.superview convertRect:sample.frame toView:self];
-        cardX = CGRectGetMinX(cellRect);
-        cardW = CGRectGetWidth(cellRect);
-    } else if (CGRectGetWidth(row) < CGRectGetWidth(self.bounds) - 1.0) {
-        cardX = CGRectGetMinX(row);
-        cardW = CGRectGetWidth(row);
-    } else {
-        UIEdgeInsets inset = ApolloIMSectionContentInset(self);
-        cardX = CGRectGetMinX(row) + inset.left;
-        cardW = CGRectGetWidth(row) - inset.left - inset.right;
-    }
-    if (sample && fabs(cardW - host.measuredCardWidth) > 0.5) {
-        host.measuredCardWidth = cardW;
-        if (host.cardWidthDidChange) {
-            // Row-height changes can't happen inside the table's own layout pass;
-            // let the controller re-measure the spacer row on the next turn.
-            void (^cb)(CGFloat) = host.cardWidthDidChange;
-            dispatch_async(dispatch_get_main_queue(), ^{ cb(cardW); });
-        }
-    }
-
-    // The section header ("Preview") is pinned with the card. Sample its label
-    // while UIKit has it on screen; the copy is only shown once stuck.
-    UIView *headerView = [self headerViewForSection:ApolloIMSectionPreview];
-    if (headerView) {
-        [host sampleTitleFromHeaderView:headerView inTable:self cardOrigin:CGPointMake(cardX, CGRectGetMinY(row))];
-    }
-    CGFloat titleAbove = host.hasTitleSample ? -host.titleOffset.y : 0.0;   // title top → card top
-
-    // Stick only when there's real list room left under the block.
-    CGFloat visibleTop = self.contentOffset.y + self.adjustedContentInset.top;
-    CGFloat visibleBottom = self.contentOffset.y + CGRectGetHeight(self.bounds) - self.adjustedContentInset.bottom;
-    CGFloat listRoom = (visibleBottom - visibleTop) - titleAbove - CGRectGetHeight(row) - kApolloIMStuckTopGap - kApolloIMStuckBottomPad;
-    BOOL compactHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
-    BOOL canStick = host.pinned && !compactHeight && listRoom >= kApolloIMMinListViewport;
-
-    CGFloat cardY = CGRectGetMinY(row);
-    if (canStick) cardY = MAX(cardY, visibleTop + kApolloIMStuckTopGap + titleAbove);
-    BOOL stuck = cardY > CGRectGetMinY(row) + 0.5;
-
-    CGFloat hostTop = stuck ? visibleTop : CGRectGetMinY(row);
-    CGFloat hostBottom = cardY + CGRectGetHeight(row) + (stuck ? kApolloIMStuckBottomPad : 0.0);
-    host.frame = CGRectMake(0, hostTop, CGRectGetWidth(self.bounds), hostBottom - hostTop);
-    host.card.frame = CGRectMake(cardX, cardY - hostTop, cardW, CGRectGetHeight(row));
-    // Alpha rather than hidden so a pin/unpin toggle (run inside an animation
-    // block by the controller) fades the title along with the sliding card.
-    host.titleLabel.hidden = !host.hasTitleSample;
-    host.titleLabel.alpha = (stuck && host.hasTitleSample) ? 1.0 : 0.0;
-    if (host.hasTitleSample) {
-        host.titleLabel.frame = CGRectMake(cardX + host.titleOffset.x, cardY - hostTop + host.titleOffset.y,
-                                           host.titleSize.width, host.titleSize.height);
-    }
-    if (host.stuck != stuck) host.stuck = stuck;
-
-    // Keep the host above every cell and section header/footer (UITableView
-    // appends those as they scroll in, which would otherwise put them over the
-    // stuck card and let taps reach rows hidden underneath) — but no higher, so
-    // UIKit's own overlays (scroll indicator, iOS 26 scroll-edge effect) stay on
-    // top. Cells/headers may be nested in per-section containers (iOS 26), so
-    // what matters is each one's ancestor that is a DIRECT subview of the table.
-    NSArray<UIView *> *subviews = self.subviews;
-    NSUInteger hostIndex = [subviews indexOfObjectIdenticalTo:host];
-    NSMutableArray<UIView *> *content = [NSMutableArray arrayWithArray:self.visibleCells];
-    NSInteger sections = self.numberOfSections;
-    for (NSInteger section = 0; section < sections; section++) {
-        UIView *header = [self headerViewForSection:section];
-        UIView *footer = [self footerViewForSection:section];
-        if (header) [content addObject:header];
-        if (footer) [content addObject:footer];
-    }
-    UIView *topContent = nil;
-    NSUInteger topContentIndex = 0;
-    for (UIView *view in content) {
-        UIView *direct = view;
-        while (direct.superview && direct.superview != self) direct = direct.superview;
-        if (direct.superview != self || direct == host) continue;
-        NSUInteger index = [subviews indexOfObjectIdenticalTo:direct];
-        if (index != NSNotFound && (!topContent || index > topContentIndex)) {
-            topContent = direct;
-            topContentIndex = index;
-        }
-    }
-    if (topContent && topContentIndex > hostIndex) {
-        [self insertSubview:host aboveSubview:topContent];
-    }
-}
 @end
 
 // MARK: - Controller
 
 @interface InlineMediaSettingsViewController ()
-@property (nonatomic, strong) ApolloIMPinnedPreviewHost *previewHost;
+@property (nonatomic, strong) ApolloPinnedPreviewHost *previewHost;
 @property (nonatomic, strong) UILabel *mediaSizeValueLabel;
 // Card width the spacer row was last measured for (0 = only the table's own
 // section inset was available). Updated from the real cell frame by the pinned
@@ -1135,7 +767,11 @@ static char kApolloIMPinnedHostKey;
 
     // The pinned preview card: a subview of the table (positioned by the
     // subclass's layout pass), not a cell, so it never gets rebuilt by reloads.
-    ApolloIMPinnedPreviewHost *host = [[ApolloIMPinnedPreviewHost alloc] initWithFrame:CGRectZero];
+    ApolloPinnedPreviewHost *host = [[ApolloPinnedPreviewHost alloc] initWithFrame:CGRectZero];
+    host.contentView = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
+    host.spacerIndexPath = ^NSIndexPath * {
+        return [NSIndexPath indexPathForRow:0 inSection:ApolloIMSectionPreview];
+    };
     __weak __typeof(self) weakSelf = self;
     host.cardWidthDidChange = ^(CGFloat width) {
         [weakSelf previewCardWidthDidChange:width];
@@ -1153,8 +789,7 @@ static char kApolloIMPinnedHostKey;
                          completion:nil];
     };
     self.previewHost = host;
-    [self.tableView addSubview:host];
-    objc_setAssociatedObject(self.tableView, &kApolloIMPinnedHostKey, host, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloPinnedPreviewAttachHost(self.tableView, host);
     [self applyThemeToPreviewHost];
     [self syncPreviewState];
 }
@@ -1168,7 +803,7 @@ static char kApolloIMPinnedHostKey;
 // MARK: Preview plumbing
 
 - (ApolloInlineMediaPreviewView *)previewView {
-    return self.previewHost.preview;
+    return (ApolloInlineMediaPreviewView *)self.previewHost.contentView;
 }
 
 // Push every setting this screen owns into the mock. Called from each control's
@@ -1189,10 +824,10 @@ static char kApolloIMPinnedHostKey;
 // section corner radius, table background for the stuck backdrop, accent for
 // the plain-link stand-ins).
 - (void)applyThemeToPreviewHost {
-    ApolloIMPinnedPreviewHost *host = self.previewHost;
+    ApolloPinnedPreviewHost *host = self.previewHost;
     if (!host) return;
     host.card.backgroundColor = [self apollo_themeCellBackgroundColor];
-    host.card.layer.cornerRadius = ApolloIMSectionCornerRadius(self.tableView);
+    host.card.layer.cornerRadius = ApolloPinnedPreviewSectionCornerRadius(self.tableView);
     UIColor *tableBackground = self.tableView.backgroundColor;
     UIColor *resolved = [tableBackground resolvedColorWithTraitCollection:self.tableView.traitCollection];
     if (!resolved || CGColorGetAlpha(resolved.CGColor) < 0.99) {
@@ -1200,8 +835,8 @@ static char kApolloIMPinnedHostKey;
     }
     host.backdropColor = tableBackground;
     host.accentColor = [self apollo_themeAccentColor];
-    host.preview.accentColor = host.accentColor;
-    [host.preview refresh];
+    self.previewView.accentColor = host.accentColor;
+    [self.previewView refresh];
 }
 
 - (void)apollo_applyTheme {
@@ -1211,8 +846,8 @@ static char kApolloIMPinnedHostKey;
 
 // The spacer row must stay invisible whatever the theme pass does to cells.
 - (void)apollo_applyThemeToCell:(UITableViewCell *)cell {
-    if ([cell isKindOfClass:[ApolloIMPreviewSpacerCell class]]) {
-        ApolloIMClearSpacerCell(cell);
+    if ([cell isKindOfClass:[ApolloPinnedPreviewSpacerCell class]]) {
+        ApolloPinnedPreviewClearSpacerCell(cell);
         return;
     }
     [super apollo_applyThemeToCell:cell];
@@ -1222,7 +857,7 @@ static char kApolloIMPinnedHostKey;
 // the layout pass has seen a real cell, else the table's reported section inset.
 - (CGFloat)previewCardWidthForTable:(UITableView *)tableView {
     if (self.previewCardWidth > 0) return self.previewCardWidth;
-    UIEdgeInsets inset = ApolloIMSectionContentInset(tableView);
+    UIEdgeInsets inset = ApolloPinnedPreviewSectionContentInset(tableView);
     return CGRectGetWidth(tableView.bounds) - inset.left - inset.right;
 }
 
@@ -1433,8 +1068,8 @@ static NSString *ApolloIMMessageMediaFooter(void) {
         case ApolloIMSectionPreview: {
             // Transparent placeholder — the pinned host draws the card on top of
             // (or, once scrolled, instead of) this slot.
-            ApolloIMPreviewSpacerCell *cell = [[ApolloIMPreviewSpacerCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-            ApolloIMClearSpacerCell(cell);
+            ApolloPinnedPreviewSpacerCell *cell = [[ApolloPinnedPreviewSpacerCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            ApolloPinnedPreviewClearSpacerCell(cell);
             cell.isAccessibilityElement = NO;
             return cell;
         }

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -5,20 +5,57 @@
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import <QuartzCore/QuartzCore.h>
+#import <objc/message.h>
 #import <objc/runtime.h>
 
-// MARK: - Live preview (fake comments)
+// MARK: - Sections
+
+typedef NS_ENUM(NSInteger, ApolloIMSection) {
+    ApolloIMSectionPreview = 0,   // one transparent spacer row; the pinned card sits on it
+    ApolloIMSectionMaster,
+    ApolloIMSectionOptions,
+    ApolloIMSectionCount,
+};
+
+typedef NS_ENUM(NSInteger, ApolloIMMasterRow) {
+    ApolloIMMasterRowPreviews = 0,   // inline media in posts + comments
+    ApolloIMMasterRowChat,           // inline media in Apollo's native message threads
+    ApolloIMMasterRowCount,
+};
+
+typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
+    ApolloIMOptionsRowAlignment = 0,
+    ApolloIMOptionsRowAutoplay,
+    ApolloIMOptionsRowMediaSize,
+    ApolloIMOptionsRowCount,
+};
+
+// MARK: - Live preview (fake comment + message thread)
 //
-// Same pattern as ApolloLPPreviewCardsView (Rich Link Preview settings): a
-// standalone UIView owned by the controller, re-hosted into its cell on every
-// cellForRow so it survives reloadData, with one apply/refresh entry point the
-// controls call continuously while dragging. Frame-based layout — this is a
-// plain settings view, not a Texture hook, so laying out subviews here is fine.
+// A standalone UIView owned by the controller. Unlike ApolloLPPreviewCardsView
+// (Rich Link Preview settings) it is NOT hosted in a table cell: it lives in the
+// pinned preview card (ApolloIMPinnedPreviewHost, a direct subview of the table
+// view), so it survives every reloadData untouched and keeps updating live while
+// the list scrolls beneath it. One apply/refresh entry point the controls call
+// continuously while dragging. Frame-based layout — this is a plain settings
+// view, not a Texture hook, so laying out subviews here is fine.
+//
+// Two mocks, one per master switch on this screen:
+//   • a comment (avatar, name, text, then the GIF block that follows the
+//     size / alignment / autoplay controls — or a plain link when Inline Media
+//     Previews is off);
+//   • a received message bubble with a small inline image (or a plain link when
+//     Inline Media in Messages is off). Size/alignment don't apply to message
+//     threads (ApolloWrapImageNodeForLayout is comments/posts only), so the
+//     bubble's image is deliberately fixed-size.
 
 @interface ApolloInlineMediaPreviewView : UIView
-@property (nonatomic) CGFloat mediaFraction;   // 0.5 / 0.75 / 1.0
-@property (nonatomic) NSInteger alignment;     // ApolloInlineImageAlignment
-@property (nonatomic) BOOL showsPlayOverlay;   // paused modes that tap-to-play
+@property (nonatomic) BOOL commentMediaEnabled;   // Inline Media Previews (master)
+@property (nonatomic) BOOL messageMediaEnabled;   // Inline Media in Messages
+@property (nonatomic) CGFloat mediaFraction;      // 0.5 / 0.75 / 1.0
+@property (nonatomic) NSInteger alignment;        // ApolloInlineImageAlignment
+@property (nonatomic) BOOL showsPlayOverlay;      // paused modes that tap-to-play
+@property (nonatomic, strong) UIColor *accentColor;   // plain-link text colour
 
 @property (nonatomic, strong) UIView *avatarOne;
 @property (nonatomic, strong) UILabel *nameOne;
@@ -26,19 +63,46 @@
 @property (nonatomic, strong) UIView *mediaBlock;
 @property (nonatomic, strong) UILabel *gifBadge;
 @property (nonatomic, strong) UIImageView *playIcon;
-@property (nonatomic, strong) UIView *avatarTwo;
+@property (nonatomic, strong) UILabel *commentLink;
 @property (nonatomic, strong) UILabel *nameTwo;
-@property (nonatomic, strong) UIView *textBarTwo;
-@property (nonatomic, strong) UIView *cardBlock;
-@property (nonatomic, strong) UIView *cardThumb;
-@property (nonatomic, strong) UIView *cardLineOne;
-@property (nonatomic, strong) UIView *cardLineTwo;
+@property (nonatomic, strong) UIView *bubble;
+@property (nonatomic, strong) UIView *bubbleText;
+@property (nonatomic, strong) UIView *bubbleImage;
+@property (nonatomic, strong) UILabel *bubbleLink;
 @end
+
+// Card edge → mock content. The content column is capped so an iPad-width card
+// shows a phone-width comment centered in it instead of a banner-sized block.
+static const CGFloat kApolloIMPreviewInset = 12.0;
+static const CGFloat kApolloIMPreviewMaxContent = 440.0;
+static const CGFloat kApolloIMLinkHeight = 18.0;
+static const CGFloat kApolloIMBubbleImageWidth = 120.0;
+
+static CGFloat ApolloIMContentWidth(CGFloat cardWidth) {
+    return MAX(60.0, MIN(cardWidth - kApolloIMPreviewInset * 2.0, kApolloIMPreviewMaxContent));
+}
+
+static CGFloat ApolloIMMediaHeight(CGFloat rowWidth, CGFloat fraction) {
+    return MAX(60.0, rowWidth * fraction) * 9.0 / 16.0;   // 16:9, like the real GIF block
+}
+
+static CGFloat ApolloIMBubbleWidth(CGFloat rowWidth) {
+    return MAX(120.0, rowWidth * 0.72);
+}
+
+// Bubble = 10 pad + 10 text bar + 8 gap + (image | link line) + 10 pad.
+static CGFloat ApolloIMBubbleHeight(CGFloat rowWidth, BOOL mediaOn) {
+    CGFloat inner = ApolloIMBubbleWidth(rowWidth) - 20.0;
+    CGFloat body = mediaOn ? MIN(inner, kApolloIMBubbleImageWidth) * 9.0 / 16.0 : kApolloIMLinkHeight;
+    return 10.0 + 10.0 + 8.0 + body + 10.0;
+}
 
 @implementation ApolloInlineMediaPreviewView
 
 - (instancetype)initWithFrame:(CGRect)frame {
     if ((self = [super initWithFrame:frame])) {
+        _commentMediaEnabled = YES;
+        _messageMediaEnabled = YES;
         _mediaFraction = 1.0;
         _alignment = ApolloInlineImageAlignmentCenter;
         [self build];
@@ -71,6 +135,17 @@ static UILabel *ApolloIMName(UIView *parent, NSString *text) {
     return label;
 }
 
+// The "plain link" stand-in shown wherever inline media is switched off — the
+// row then renders the URL as accent-coloured text, exactly like Apollo does.
+static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = [UIFont systemFontOfSize:13.0];
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    [parent addSubview:label];
+    return label;
+}
+
 - (void)build {
     self.avatarOne = ApolloIMAvatar(self);
     self.nameOne = ApolloIMName(self, @"u/GifEnjoyer · 2h");
@@ -97,39 +172,46 @@ static UILabel *ApolloIMName(UIView *parent, NSString *text) {
     self.playIcon.contentMode = UIViewContentModeScaleAspectFit;
     [self.mediaBlock addSubview:self.playIcon];
 
-    self.avatarTwo = ApolloIMAvatar(self);
+    self.commentLink = ApolloIMLink(self, @"i.redd.it/happy-cat.gif");
+
     self.nameTwo = ApolloIMName(self, @"u/LinkLover · 1h");
-    self.textBarTwo = ApolloIMBar(self, 0.35);
 
-    self.cardBlock = [[UIView alloc] init];
-    self.cardBlock.backgroundColor = [UIColor secondarySystemFillColor];
-    self.cardBlock.layer.cornerRadius = 10.0;
-    self.cardBlock.clipsToBounds = YES;
-    [self addSubview:self.cardBlock];
+    self.bubble = [[UIView alloc] init];
+    self.bubble.backgroundColor = [UIColor secondarySystemFillColor];
+    self.bubble.layer.cornerRadius = 16.0;
+    self.bubble.clipsToBounds = YES;
+    [self addSubview:self.bubble];
 
-    self.cardThumb = [[UIView alloc] init];
-    self.cardThumb.backgroundColor = [UIColor systemFillColor];
-    self.cardThumb.layer.cornerRadius = 6.0;
-    [self.cardBlock addSubview:self.cardThumb];
-    self.cardLineOne = ApolloIMBar(self.cardBlock, 0.5);
-    self.cardLineTwo = ApolloIMBar(self.cardBlock, 0.3);
+    self.bubbleText = ApolloIMBar(self.bubble, 0.5);
+
+    self.bubbleImage = [[UIView alloc] init];
+    self.bubbleImage.backgroundColor = [UIColor systemFillColor];
+    self.bubbleImage.layer.cornerRadius = 8.0;
+    self.bubbleImage.clipsToBounds = YES;
+    [self.bubble addSubview:self.bubbleImage];
+
+    self.bubbleLink = ApolloIMLink(self.bubble, @"i.redd.it/vacation.jpg");
 }
 
-+ (CGFloat)preferredHeight {
-    // Sized for the 100% media block on typical widths; smaller fractions
-    // simply leave breathing room. Row height stays fixed so live slider
-    // drags never force table reloads.
-    return 384.0;
+// Natural card height for a card width, laid out for the TALLEST state (both
+// switches on, media at 100%). The row height therefore never changes while the
+// controls are adjusted — smaller fractions and switched-off media simply leave
+// breathing room — so live slider drags never force table reloads.
++ (CGFloat)heightForCardWidth:(CGFloat)cardWidth {
+    CGFloat rowWidth = ApolloIMContentWidth(cardWidth);
+    return 10.0 + 32.0 + 20.0 + ApolloIMMediaHeight(rowWidth, 1.0) + 18.0
+         + 18.0 + ApolloIMBubbleHeight(rowWidth, YES) + 14.0;
 }
 
 - (void)layoutSubviews {
     [super layoutSubviews];
     CGFloat W = self.bounds.size.width;
     if (W <= 0) return;
-    CGFloat margin = 12.0;
-    CGFloat rowWidth = W - margin * 2.0;
+    CGFloat rowWidth = ApolloIMContentWidth(W);
+    CGFloat margin = (W - rowWidth) * 0.5;
     CGFloat y = 10.0;
 
+    // Comment header + a line of text.
     self.avatarOne.frame = CGRectMake(margin, y, 24, 24);
     self.nameOne.frame = CGRectMake(margin + 32, y + 4, rowWidth - 32, 16);
     y += 32;
@@ -138,43 +220,175 @@ static UILabel *ApolloIMName(UIView *parent, NSString *text) {
 
     // Media block — width follows the media slider, aspect fixed at 16:9,
     // horizontal position follows the alignment setting (same slack rule as
-    // ApolloWrapImageNodeForLayout).
-    CGFloat mediaWidth = MAX(60.0, rowWidth * self.mediaFraction);
-    CGFloat mediaHeight = mediaWidth * 9.0 / 16.0;
-    CGFloat slack = rowWidth - mediaWidth;
-    CGFloat mediaX = margin + (self.alignment == ApolloInlineImageAlignmentLeft ? 0.0 :
-                     self.alignment == ApolloInlineImageAlignmentRight ? slack : slack * 0.5);
-    self.mediaBlock.frame = CGRectMake(mediaX, y, mediaWidth, mediaHeight);
-    self.gifBadge.frame = CGRectMake(8, mediaHeight - 26, 40, 18);
-    // Matches the real overlay: a small play badge pinned bottom-right.
-    CGFloat playSide = 26.0;
-    self.playIcon.frame = CGRectMake(mediaWidth - 6.0 - playSide, mediaHeight - 6.0 - playSide, playSide, playSide);
-    self.playIcon.hidden = !self.showsPlayOverlay;
-    y += mediaHeight + 18;
+    // ApolloWrapImageNodeForLayout). With Inline Media Previews off the row
+    // shows the link as plain text instead.
+    BOOL commentMedia = self.commentMediaEnabled;
+    self.mediaBlock.hidden = !commentMedia;
+    self.commentLink.hidden = commentMedia;
+    if (commentMedia) {
+        CGFloat mediaWidth = MAX(60.0, rowWidth * self.mediaFraction);
+        CGFloat mediaHeight = ApolloIMMediaHeight(rowWidth, self.mediaFraction);
+        CGFloat slack = rowWidth - mediaWidth;
+        CGFloat mediaX = margin + (self.alignment == ApolloInlineImageAlignmentLeft ? 0.0 :
+                         self.alignment == ApolloInlineImageAlignmentRight ? slack : slack * 0.5);
+        self.mediaBlock.frame = CGRectMake(mediaX, y, mediaWidth, mediaHeight);
+        self.gifBadge.frame = CGRectMake(8, mediaHeight - 26, 40, 18);
+        // Matches the real overlay: a small play badge pinned bottom-right.
+        CGFloat playSide = 26.0;
+        self.playIcon.frame = CGRectMake(mediaWidth - 6.0 - playSide, mediaHeight - 6.0 - playSide, playSide, playSide);
+        self.playIcon.hidden = !self.showsPlayOverlay;
+        y += mediaHeight;
+    } else {
+        self.commentLink.frame = CGRectMake(margin, y, rowWidth, kApolloIMLinkHeight);
+        y += kApolloIMLinkHeight;
+    }
+    y += 18;
 
-    self.avatarTwo.frame = CGRectMake(margin, y, 24, 24);
-    self.nameTwo.frame = CGRectMake(margin + 32, y + 4, rowWidth - 32, 16);
-    y += 32;
-    self.textBarTwo.frame = CGRectMake(margin, y, rowWidth * 0.62, 10);
-    y += 20;
-
-    // Link preview card mock — fixed full width (card sizing is handled by the
-    // Compact/Full modes in Rich Link Preview Settings, not by this screen).
-    CGFloat cardWidth = rowWidth;
-    CGFloat cardHeight = 72.0;
-    self.cardBlock.frame = CGRectMake(margin + (rowWidth - cardWidth) * 0.5, y, cardWidth, cardHeight);
-    self.cardThumb.frame = CGRectMake(8, 8, 56, 56);
-    CGFloat lineX = 72.0;
-    self.cardLineOne.frame = CGRectMake(lineX, 14, MAX(40.0, cardWidth - lineX - 12), 12);
-    self.cardLineTwo.frame = CGRectMake(lineX, 36, MAX(30.0, (cardWidth - lineX - 12) * 0.7), 10);
+    // Message thread: sender name, then a received bubble with a line of text
+    // and either a small inline image or the same plain-link stand-in.
+    self.nameTwo.frame = CGRectMake(margin, y, rowWidth, 14);
+    y += 18;
+    BOOL messageMedia = self.messageMediaEnabled;
+    CGFloat bubbleWidth = ApolloIMBubbleWidth(rowWidth);
+    CGFloat inner = bubbleWidth - 20.0;
+    CGFloat by = 10.0;
+    self.bubbleText.frame = CGRectMake(10, by, inner * 0.8, 10);
+    by += 18;
+    self.bubbleImage.hidden = !messageMedia;
+    self.bubbleLink.hidden = messageMedia;
+    if (messageMedia) {
+        CGFloat imageWidth = MIN(inner, kApolloIMBubbleImageWidth);
+        CGFloat imageHeight = imageWidth * 9.0 / 16.0;
+        self.bubbleImage.frame = CGRectMake(10, by, imageWidth, imageHeight);
+        by += imageHeight;
+    } else {
+        self.bubbleLink.frame = CGRectMake(10, by, inner, kApolloIMLinkHeight);
+        by += kApolloIMLinkHeight;
+    }
+    by += 10;
+    self.bubble.frame = CGRectMake(margin, y, bubbleWidth, by);
 }
 
 - (void)refresh {
+    UIColor *accent = self.accentColor ?: [UIColor systemBlueColor];
+    self.commentLink.textColor = accent;
+    self.bubbleLink.textColor = accent;
     [self setNeedsLayout];
     [self layoutIfNeeded];
 }
 
 @end
+
+// MARK: - Pinned preview host (sticks below the nav bar while the list scrolls)
+
+// The preview card. A direct subview of the table view — never a cell — sized
+// to the transparent spacer row that reserves its resting place under the
+// "Preview" header. While that row is on screen the card sits exactly on it and
+// scrolls like any other row; once the row would slide under the nav bar the
+// card sticks just below the bar instead (an opaque backdrop hides the rows
+// passing underneath), so every control further down is adjusted with the
+// preview still in view. Positioning lives in ApolloIMSettingsTableView's
+// layoutSubviews, which UIScrollView runs on every content-offset change.
+//
+// Height-constrained layouts (landscape phones, tiny screens) don't stick:
+// pinning a ~400pt card there would leave no usable list, so the card just
+// scrolls with the content as it always did.
+static const CGFloat kApolloIMStuckTopGap = 8.0;       // nav bar bottom → card top
+static const CGFloat kApolloIMStuckBottomPad = 8.0;    // backdrop below the card
+static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bother sticking
+
+@interface ApolloIMPinnedPreviewHost : UIView
+@property (nonatomic, strong) UIView *card;
+@property (nonatomic, strong) ApolloInlineMediaPreviewView *preview;
+@property (nonatomic, strong) UIColor *backdropColor;   // table background, shown while stuck
+@property (nonatomic) BOOL stuck;
+// Real inset-grouped cell width measured by the layout pass (0 = not yet seen)
+// and the callback the controller uses to re-measure the spacer row when it
+// changes (first layout, rotation).
+@property (nonatomic) CGFloat measuredCardWidth;
+@property (nonatomic, copy) void (^cardWidthDidChange)(CGFloat width);
+@end
+
+@implementation ApolloIMPinnedPreviewHost
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        self.backgroundColor = [UIColor clearColor];
+        _card = [[UIView alloc] init];
+        _card.clipsToBounds = YES;
+        [self addSubview:_card];
+        _preview = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
+        [_card addSubview:_preview];
+    }
+    return self;
+}
+
+- (void)setStuck:(BOOL)stuck {
+    _stuck = stuck;
+    [self apollo_updateBackdrop];
+}
+
+- (void)setBackdropColor:(UIColor *)backdropColor {
+    _backdropColor = backdropColor;
+    [self apollo_updateBackdrop];
+}
+
+- (void)apollo_updateBackdrop {
+    self.backgroundColor = self.stuck
+        ? (self.backdropColor ?: [UIColor systemGroupedBackgroundColor])
+        : [UIColor clearColor];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.preview.frame = self.card.bounds;
+}
+
+@end
+
+// Transparent spacer cell: reserves the preview's resting slot in the flow (so
+// UIKit draws the native "Preview" section header above it) while the pinned
+// card does all the drawing. Kept clear by the theme override in the controller.
+@interface ApolloIMPreviewSpacerCell : UITableViewCell
+@end
+@implementation ApolloIMPreviewSpacerCell
+@end
+
+static void ApolloIMClearSpacerCell(UITableViewCell *cell) {
+    cell.backgroundColor = [UIColor clearColor];
+    cell.contentView.backgroundColor = [UIColor clearColor];
+    if (!cell.backgroundView) cell.backgroundView = [[UIView alloc] init];
+    cell.backgroundView.backgroundColor = [UIColor clearColor];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+}
+
+// Inset-grouped section geometry the card copies so it matches the real cells.
+// Both are private UITableView getters (iOS 13+), called defensively with
+// public fallbacks: the table's layoutMargins for the inset, and the familiar
+// 10pt (26pt under Liquid Glass) for the corner radius.
+static UIEdgeInsets ApolloIMSectionContentInset(UITableView *table) {
+    SEL sel = NSSelectorFromString(@"_sectionContentInset");
+    if ([table respondsToSelector:sel]) {
+        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
+        if (sig && strcmp(sig.methodReturnType, @encode(UIEdgeInsets)) == 0) {
+            UIEdgeInsets insets = ((UIEdgeInsets (*)(id, SEL))objc_msgSend)(table, sel);
+            if (insets.left >= 0 && insets.right >= 0) return insets;
+        }
+    }
+    return table.layoutMargins;
+}
+
+static CGFloat ApolloIMSectionCornerRadius(UITableView *table) {
+    SEL sel = NSSelectorFromString(@"_sectionCornerRadius");
+    if ([table respondsToSelector:sel]) {
+        NSMethodSignature *sig = [table methodSignatureForSelector:sel];
+        if (sig && strcmp(sig.methodReturnType, @encode(double)) == 0) {
+            double radius = ((double (*)(id, SEL))objc_msgSend)(table, sel);
+            if (radius > 0) return (CGFloat)radius;
+        }
+    }
+    return IsLiquidGlass() ? 26.0 : 10.0;
+}
 
 // MARK: - Detent slider (50 / 75 / 100)
 
@@ -309,10 +523,11 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
 @end
 
 // UISlider with exactly three stops. Unlike a stock slider, tracking begins
-// from a touch anywhere on the bar (not just on the thumb), and the thumb
-// snaps between the detents while dragging — with a selection tick on each
-// snap. Tick marks at both ends and the middle show the three positions so
-// it doesn't read as a free-flowing slider.
+// from a touch anywhere on the bar (not just on the thumb), the thumb snaps
+// between the detents while dragging — with a selection tick on each snap —
+// and lifting the finger (a plain tap included) lands on the detent nearest the
+// release point. Tick marks at both ends and the middle show the three
+// positions so it doesn't read as a free-flowing slider.
 @interface ApolloIMDetentSlider : UISlider
 @property (nonatomic, strong) NSArray<UIView *> *tickViews;
 @property (nonatomic, strong) UISelectionFeedbackGenerator *feedback;
@@ -338,6 +553,8 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
 // re-wiring is idempotent.
 @property (nonatomic, strong) ApolloIMSliderClaimGesture *claimGesture;
 @property (nonatomic, strong) NSHashTable<UIGestureRecognizer *> *wiredBackGestures;
+// Our own tracking flag — see -isTracking.
+@property (nonatomic) BOOL apolloTracking;
 @end
 
 @implementation ApolloIMDetentSlider
@@ -458,12 +675,48 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
     }
 }
 
-- (void)apollo_applyTouch:(UITouch *)touch {
+// The un-snapped value at an x position along the track.
+- (float)apollo_rawValueForX:(CGFloat)x {
     CGRect track = [self trackRectForBounds:self.bounds];
     CGFloat width = MAX(1.0, CGRectGetWidth(track));
-    CGFloat fraction = ([touch locationInView:self].x - CGRectGetMinX(track)) / width;
+    CGFloat fraction = (x - CGRectGetMinX(track)) / width;
     fraction = MIN(1.0, MAX(0.0, fraction));
-    float raw = self.minimumValue + fraction * (self.maximumValue - self.minimumValue);
+    return self.minimumValue + fraction * (self.maximumValue - self.minimumValue);
+}
+
+- (float)apollo_rawValueForTouch:(UITouch *)touch {
+    return [self apollo_rawValueForX:[touch locationInView:self].x];
+}
+
+// Touch-up: land on the detent nearest x — tap or drag alike. Plain nearest-stop
+// snap on purpose: the hysteresis band and the 2-frame confirmation exist to
+// debounce a HELD finger, and neither applies once it has lifted. For a tap they
+// would leave the thumb where it was (a tap is a single frame, so the streak can
+// never confirm — issue #1006); for a drag they could park the thumb a detent
+// short of where the finger was released.
+- (void)apollo_selectDetentAtX:(CGFloat)x source:(NSString *)source {
+    float raw = [self apollo_rawValueForX:x];
+    NSInteger target = ApolloIMSnapPercent(raw);
+    if (target != self.lastSnappedPercent) {
+        ApolloLog(@"[IMSlider] %@ → %ld%% (was %ld%%)", source, (long)target, (long)self.lastSnappedPercent);
+        [self apollo_commitPercent:target];
+    } else if ((NSInteger)lroundf(self.value) != target) {
+        [self setValue:(float)target animated:YES];   // re-seat a thumb left off-grid
+    }
+}
+
+// Commit a detent: one animated thumb move, one selection tick, one action.
+- (void)apollo_commitPercent:(NSInteger)percent {
+    self.lastSnappedPercent = percent;
+    self.pendingStreak = 0;
+    self.lastFireTime = CACurrentMediaTime();
+    [self setValue:(float)percent animated:YES];
+    [self.feedback selectionChanged];
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
+}
+
+- (void)apollo_applyTouch:(UITouch *)touch {
+    float raw = [self apollo_rawValueForTouch:touch];
     // Hysteretic snap keyed off the current detent — a held finger's jitter
     // can't flip it across a boundary, so the haptic fires once per crossing.
     NSInteger snapped = ApolloIMSnapPercentHysteretic(raw, self.lastSnappedPercent);
@@ -483,21 +736,52 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
     BOOL confirmed = (snapped != self.lastSnappedPercent) && (self.pendingStreak >= 2) && !lockedOut;
 
     if (confirmed) {
-        self.lastSnappedPercent = snapped;      // one haptic per confirmed crossing
-        self.pendingStreak = 0;
-        self.lastFireTime = now;
-        [self setValue:(float)snapped animated:YES];
-        [self.feedback selectionChanged];
-        [self sendActionsForControlEvents:UIControlEventValueChanged];
+        [self apollo_commitPercent:snapped];   // one haptic per confirmed crossing
     }
+}
+
+// MARK: iOS 26 — make UIControl finish the touch sequence
+//
+// On iOS 26 UISlider installs a "fluid" visual element (_UISliderFluidVisualElement)
+// that changes how the CLASSIC UIControl tracking sequence completes, in two ways
+// (both read from the decompiled UIKitCore):
+//
+//  1. -[UISlider isTracking] defers to the visual element's own "interactively
+//     changing" flag, which only turns on for a thumb drag the element drives
+//     itself. UIControl's touchesMoved:/touchesEnded: consult -isTracking before
+//     calling continueTracking/endTracking, so a touch we started from the bare
+//     track (beginTracking returned YES, but the element never saw a thumb drag)
+//     reported NOT tracking and was dropped after beginTracking.
+//  2. -[UISlider _deferFinalActions] returns YES whenever the fluid element is
+//     installed. With that, UIControl's touchesEnded: does NOT call
+//     endTrackingWithTouch: — it flags the touch-up as deferred and expects the
+//     fluid interaction to finish the sequence later. We refuse that interaction
+//     (see addInteraction:), so the deferral never completed: endTracking /
+//     cancelTracking never fired for any touch, and the control stayed "tracking"
+//     forever. (This, not synthetic input, is why end-tracking-based designs kept
+//     failing here, and why a tap never landed — issue #1006.)
+//
+// Both overrides simply restore the classic sequence: report our own tracking
+// state, and never defer the final actions.
+- (BOOL)isTracking {
+    return self.apolloTracking;
+}
+
+- (BOOL)_deferFinalActions {
+    return NO;
 }
 
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     // Catch any pop pan installed after we entered the window (e.g. re-added when
     // the push transition settled); wiring is idempotent.
     [self apollo_wireSwipeBackFailureRequirements];
-    // Sync to the settled value before the drag; self.value isn't animating yet.
-    self.lastSnappedPercent = (NSInteger)lroundf(self.value);
+    self.apolloTracking = YES;
+    // Sync to the settled value before the drag — but only when it IS settled: a
+    // quick second touch while the previous commit's thumb animation is still in
+    // flight would otherwise read a mid-animation, off-grid value and lose the
+    // committed detent the hysteresis keys off.
+    NSInteger settled = (NSInteger)lroundf(self.value);
+    if (settled == 50 || settled == 75 || settled == 100) self.lastSnappedPercent = settled;
     self.pendingPercent = self.lastSnappedPercent;
     self.pendingStreak = 0;
     [self.feedback prepare];
@@ -508,6 +792,23 @@ static UIViewController *ApolloIMVCForView(UIView *view) {
 - (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     [self apollo_applyTouch:touch];
     return YES;
+}
+
+// Touch-up (tap or drag): land on the detent nearest the release point. This is
+// the path that makes a plain tap select a stop (issue #1006) — beginTracking
+// alone never commits, by design of the anti-jitter guards above.
+- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [super endTrackingWithTouch:touch withEvent:event];
+    self.apolloTracking = NO;
+    if (!touch) return;
+    [self apollo_selectDetentAtX:[touch locationInView:self].x source:@"released"];
+}
+
+// A cancelled touch commits nothing — the thumb stays on the last detent the
+// drag logic confirmed.
+- (void)cancelTrackingWithEvent:(UIEvent *)event {
+    [super cancelTrackingWithEvent:event];
+    self.apolloTracking = NO;
 }
 
 @end
@@ -543,33 +844,121 @@ static BOOL ApolloIMViewIsInSlider(UIView *view) {
     if (ApolloIMViewIsInSlider(view)) return NO;
     return [super touchesShouldCancelInContentView:view];
 }
+
+// MARK: Pinned preview layout
+
+// The host is attached by the controller (associated, not an ivar — the subclass
+// must stay ivar-free for object_setClass to be safe).
+static char kApolloIMPinnedHostKey;
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self apollo_layoutPinnedPreview];
+}
+
+- (void)apollo_layoutPinnedPreview {
+    ApolloIMPinnedPreviewHost *host = objc_getAssociatedObject(self, &kApolloIMPinnedHostKey);
+    if (!host || host.superview != self) return;
+    if (self.numberOfSections <= ApolloIMSectionPreview ||
+        [self numberOfRowsInSection:ApolloIMSectionPreview] < 1) {
+        host.hidden = YES;
+        return;
+    }
+    NSIndexPath *previewPath = [NSIndexPath indexPathForRow:0 inSection:ApolloIMSectionPreview];
+    CGRect row = [self rectForRowAtIndexPath:previewPath];   // full table width; cells are inset
+    if (CGRectIsEmpty(row)) { host.hidden = YES; return; }
+    host.hidden = NO;
+
+    // Horizontal card geometry = whatever the inset-grouped cells actually use.
+    // Any visible cell will do (they all share it), converted into the table's
+    // coordinate space: on iOS 26 cells are parented to a per-section container,
+    // so their raw frame is relative to that (x = 0), not to the table. Before
+    // the first cell exists, fall back to the row rect — already inset on iOS 26,
+    // full-width on earlier releases, where the table's section inset is applied.
+    UITableViewCell *sample = [self cellForRowAtIndexPath:previewPath] ?: self.visibleCells.firstObject;
+    CGFloat cardX, cardW;
+    if (sample && sample.superview) {
+        CGRect cellRect = [sample.superview convertRect:sample.frame toView:self];
+        cardX = CGRectGetMinX(cellRect);
+        cardW = CGRectGetWidth(cellRect);
+    } else if (CGRectGetWidth(row) < CGRectGetWidth(self.bounds) - 1.0) {
+        cardX = CGRectGetMinX(row);
+        cardW = CGRectGetWidth(row);
+    } else {
+        UIEdgeInsets inset = ApolloIMSectionContentInset(self);
+        cardX = CGRectGetMinX(row) + inset.left;
+        cardW = CGRectGetWidth(row) - inset.left - inset.right;
+    }
+    if (sample && fabs(cardW - host.measuredCardWidth) > 0.5) {
+        host.measuredCardWidth = cardW;
+        if (host.cardWidthDidChange) {
+            // Row-height changes can't happen inside the table's own layout pass;
+            // let the controller re-measure the spacer row on the next turn.
+            void (^cb)(CGFloat) = host.cardWidthDidChange;
+            dispatch_async(dispatch_get_main_queue(), ^{ cb(cardW); });
+        }
+    }
+
+    // Stick only when there's real list room left under the card.
+    CGFloat visibleTop = self.contentOffset.y + self.adjustedContentInset.top;
+    CGFloat visibleBottom = self.contentOffset.y + CGRectGetHeight(self.bounds) - self.adjustedContentInset.bottom;
+    CGFloat listRoom = (visibleBottom - visibleTop) - CGRectGetHeight(row) - kApolloIMStuckTopGap - kApolloIMStuckBottomPad;
+    BOOL compactHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
+    BOOL canStick = !compactHeight && listRoom >= kApolloIMMinListViewport;
+
+    CGFloat cardY = CGRectGetMinY(row);
+    if (canStick) cardY = MAX(cardY, visibleTop + kApolloIMStuckTopGap);
+    BOOL stuck = cardY > CGRectGetMinY(row) + 0.5;
+
+    CGFloat hostTop = stuck ? visibleTop : CGRectGetMinY(row);
+    CGFloat hostBottom = cardY + CGRectGetHeight(row) + (stuck ? kApolloIMStuckBottomPad : 0.0);
+    host.frame = CGRectMake(0, hostTop, CGRectGetWidth(self.bounds), hostBottom - hostTop);
+    host.card.frame = CGRectMake(cardX, cardY - hostTop, cardW, CGRectGetHeight(row));
+    if (host.stuck != stuck) host.stuck = stuck;
+
+    // Keep the host above every cell and section header/footer (UITableView
+    // appends those as they scroll in, which would otherwise put them over the
+    // stuck card and let taps reach rows hidden underneath) — but no higher, so
+    // UIKit's own overlays (scroll indicator, iOS 26 scroll-edge effect) stay on
+    // top. Cells/headers may be nested in per-section containers (iOS 26), so
+    // what matters is each one's ancestor that is a DIRECT subview of the table.
+    NSArray<UIView *> *subviews = self.subviews;
+    NSUInteger hostIndex = [subviews indexOfObjectIdenticalTo:host];
+    NSMutableArray<UIView *> *content = [NSMutableArray arrayWithArray:self.visibleCells];
+    NSInteger sections = self.numberOfSections;
+    for (NSInteger section = 0; section < sections; section++) {
+        UIView *header = [self headerViewForSection:section];
+        UIView *footer = [self footerViewForSection:section];
+        if (header) [content addObject:header];
+        if (footer) [content addObject:footer];
+    }
+    UIView *topContent = nil;
+    NSUInteger topContentIndex = 0;
+    for (UIView *view in content) {
+        UIView *direct = view;
+        while (direct.superview && direct.superview != self) direct = direct.superview;
+        if (direct.superview != self || direct == host) continue;
+        NSUInteger index = [subviews indexOfObjectIdenticalTo:direct];
+        if (index != NSNotFound && (!topContent || index > topContentIndex)) {
+            topContent = direct;
+            topContentIndex = index;
+        }
+    }
+    if (topContent && topContentIndex > hostIndex) {
+        [self insertSubview:host aboveSubview:topContent];
+    }
+}
 @end
 
 // MARK: - Controller
 
-typedef NS_ENUM(NSInteger, ApolloIMSection) {
-    ApolloIMSectionPreview = 0,
-    ApolloIMSectionMaster,
-    ApolloIMSectionOptions,
-    ApolloIMSectionCount,
-};
-
-typedef NS_ENUM(NSInteger, ApolloIMMasterRow) {
-    ApolloIMMasterRowPreviews = 0,   // inline media in posts + comments
-    ApolloIMMasterRowChat,           // inline media in Apollo's native message threads
-    ApolloIMMasterRowCount,
-};
-
-typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
-    ApolloIMOptionsRowAlignment = 0,
-    ApolloIMOptionsRowAutoplay,
-    ApolloIMOptionsRowMediaSize,
-    ApolloIMOptionsRowCount,
-};
-
 @interface InlineMediaSettingsViewController ()
-@property (nonatomic, strong) ApolloInlineMediaPreviewView *previewView;
+@property (nonatomic, strong) ApolloIMPinnedPreviewHost *previewHost;
 @property (nonatomic, strong) UILabel *mediaSizeValueLabel;
+// Card width the spacer row was last measured for (0 = only the table's own
+// section inset was available). Updated from the real cell frame by the pinned
+// layout pass, which then asks for a one-row re-measure.
+@property (nonatomic) CGFloat previewCardWidth;
 @end
 
 @implementation InlineMediaSettingsViewController
@@ -587,29 +976,101 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     // applies while content touches are delayed; NO makes tracking begin at once
     // for a vertical drag too).
     self.tableView.delaysContentTouches = NO;
+
+    // The pinned preview card: a subview of the table (positioned by the
+    // subclass's layout pass), not a cell, so it never gets rebuilt by reloads.
+    ApolloIMPinnedPreviewHost *host = [[ApolloIMPinnedPreviewHost alloc] initWithFrame:CGRectZero];
+    __weak __typeof(self) weakSelf = self;
+    host.cardWidthDidChange = ^(CGFloat width) {
+        [weakSelf previewCardWidthDidChange:width];
+    };
+    self.previewHost = host;
+    [self.tableView addSubview:host];
+    objc_setAssociatedObject(self.tableView, &kApolloIMPinnedHostKey, host, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self applyThemeToPreviewHost];
+    [self syncPreviewState];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self.tableView reloadData];
+    [self syncPreviewState];
 }
 
 // MARK: Preview plumbing
 
-- (ApolloInlineMediaPreviewView *)ensurePreviewView {
-    if (!self.previewView) {
-        self.previewView = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
-    }
-    [self syncPreviewState];
-    return self.previewView;
+- (ApolloInlineMediaPreviewView *)previewView {
+    return self.previewHost.preview;
 }
 
+// Push every setting this screen owns into the mock. Called from each control's
+// action (continuously while the slider drags) — the card is pinned, so the
+// change is visible without scrolling back up.
 - (void)syncPreviewState {
-    self.previewView.mediaFraction = sInlineMediaSizePercent / 100.0;
-    self.previewView.alignment = sInlineImageAlignment;
+    ApolloInlineMediaPreviewView *preview = self.previewView;
+    preview.commentMediaEnabled = sEnableInlineImages;
+    preview.messageMediaEnabled = sEnableChatMedia;
+    preview.mediaFraction = sInlineMediaSizePercent / 100.0;
+    preview.alignment = sInlineImageAlignment;
     NSString *mode = ApolloAutoplayGIFModeString();
-    self.previewView.showsPlayOverlay = [mode isEqualToString:@"tap-to-play"];
-    [self.previewView refresh];
+    preview.showsPlayOverlay = [mode isEqualToString:@"tap-to-play"];
+    [preview refresh];
+}
+
+// Card chrome follows the same theme walk as the real cells (cell colour,
+// section corner radius, table background for the stuck backdrop, accent for
+// the plain-link stand-ins).
+- (void)applyThemeToPreviewHost {
+    ApolloIMPinnedPreviewHost *host = self.previewHost;
+    if (!host) return;
+    host.card.backgroundColor = [self apollo_themeCellBackgroundColor];
+    host.card.layer.cornerRadius = ApolloIMSectionCornerRadius(self.tableView);
+    UIColor *tableBackground = self.tableView.backgroundColor;
+    UIColor *resolved = [tableBackground resolvedColorWithTraitCollection:self.tableView.traitCollection];
+    if (!resolved || CGColorGetAlpha(resolved.CGColor) < 0.99) {
+        tableBackground = [UIColor systemGroupedBackgroundColor];
+    }
+    host.backdropColor = tableBackground;
+    host.preview.accentColor = [self apollo_themeAccentColor];
+    [host.preview refresh];
+}
+
+- (void)apollo_applyTheme {
+    [super apollo_applyTheme];
+    [self applyThemeToPreviewHost];
+}
+
+// The spacer row must stay invisible whatever the theme pass does to cells.
+- (void)apollo_applyThemeToCell:(UITableViewCell *)cell {
+    if ([cell isKindOfClass:[ApolloIMPreviewSpacerCell class]]) {
+        ApolloIMClearSpacerCell(cell);
+        return;
+    }
+    [super apollo_applyThemeToCell:cell];
+}
+
+// Width the spacer row's height is derived from: the measured cell width once
+// the layout pass has seen a real cell, else the table's reported section inset.
+- (CGFloat)previewCardWidthForTable:(UITableView *)tableView {
+    if (self.previewCardWidth > 0) return self.previewCardWidth;
+    UIEdgeInsets inset = ApolloIMSectionContentInset(tableView);
+    return CGRectGetWidth(tableView.bounds) - inset.left - inset.right;
+}
+
+- (void)previewCardWidthDidChange:(CGFloat)width {
+    if (width <= 0 || fabs(width - self.previewCardWidth) <= 0.5) return;
+    CGFloat oldHeight = [ApolloInlineMediaPreviewView heightForCardWidth:[self previewCardWidthForTable:self.tableView]];
+    self.previewCardWidth = width;
+    CGFloat newHeight = [ApolloInlineMediaPreviewView heightForCardWidth:width];
+    ApolloLog(@"[IMPreview] card width %.1f → spacer row %.1f → %.1f", width, oldHeight, newHeight);
+    if (fabs(newHeight - oldHeight) <= 0.5) return;
+    if (self.tableView.numberOfSections <= ApolloIMSectionPreview) return;
+    // Re-measure just the spacer row; the host follows the new rect on the next
+    // layout pass. No animation so the pinned card doesn't visibly resize.
+    [UIView performWithoutAnimation:^{
+        [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:ApolloIMSectionPreview]]
+                              withRowAnimation:UITableViewRowAnimationNone];
+    }];
 }
 
 // MARK: Cell helpers (repo-wide patterns — see PictureInPictureViewController)
@@ -801,13 +1262,11 @@ static NSString *ApolloIMMessageMediaFooter(void) {
     BOOL inlineOn = sEnableInlineImages;
     switch (indexPath.section) {
         case ApolloIMSectionPreview: {
-            UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-            cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            ApolloInlineMediaPreviewView *preview = [self ensurePreviewView];
-            [preview removeFromSuperview];
-            preview.frame = cell.contentView.bounds;
-            preview.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-            [cell.contentView addSubview:preview];
+            // Transparent placeholder — the pinned host draws the card on top of
+            // (or, once scrolled, instead of) this slot.
+            ApolloIMPreviewSpacerCell *cell = [[ApolloIMPreviewSpacerCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            ApolloIMClearSpacerCell(cell);
+            cell.isAccessibilityElement = NO;
             return cell;
         }
         case ApolloIMSectionMaster:
@@ -847,7 +1306,9 @@ static NSString *ApolloIMMessageMediaFooter(void) {
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == ApolloIMSectionPreview) return [ApolloInlineMediaPreviewView preferredHeight];
+    if (indexPath.section == ApolloIMSectionPreview) {
+        return [ApolloInlineMediaPreviewView heightForCardWidth:[self previewCardWidthForTable:tableView]];
+    }
     if (indexPath.section == ApolloIMSectionOptions && indexPath.row == ApolloIMOptionsRowMediaSize) {
         return 88.0;
     }
@@ -878,6 +1339,7 @@ static NSString *ApolloIMMessageMediaFooter(void) {
     [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloIMSectionOptions]
                   withRowAnimation:UITableViewRowAnimationNone];
+    [self syncPreviewState];   // comment mock flips between GIF block and plain link
 }
 
 // Master toggle for message-thread media (inline images/GIFs/emoji/snoomoji +
@@ -888,11 +1350,17 @@ static NSString *ApolloIMMessageMediaFooter(void) {
 - (void)chatMediaSwitchToggled:(UISwitch *)sw {
     sEnableChatMedia = sw.on;
     [[NSUserDefaults standardUserDefaults] setBool:sEnableChatMedia forKey:UDKeyEnableChatMedia];
+    [self syncPreviewState];   // message bubble flips between inline image and plain link
 }
 
 - (void)mediaSizeSliderChanged:(UISlider *)slider {
-    NSInteger percent = ApolloIMSnapPercent(slider.value);
-    if ((NSInteger)lroundf(slider.value) != percent) [slider setValue:(float)percent animated:NO];
+    // The detent slider only ever sends an action for a committed detent (drag
+    // crossing or tap), so read that rather than re-deriving it from `value`,
+    // which may still be animating toward it.
+    NSInteger percent = [slider isKindOfClass:[ApolloIMDetentSlider class]]
+        ? ((ApolloIMDetentSlider *)slider).lastSnappedPercent
+        : ApolloIMSnapPercent(slider.value);
+    if (percent != 50 && percent != 75 && percent != 100) percent = ApolloIMSnapPercent(slider.value);
     self.mediaSizeValueLabel.text = [NSString stringWithFormat:@"%ld%%", (long)percent];
     if (percent != sInlineMediaSizePercent) {
         sInlineMediaSizePercent = percent;

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -215,7 +215,7 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
 
     // Comment header + a line of text.
     self.avatarOne.frame = CGRectMake(margin, y, 22, 22);
-    self.nameOne.frame = CGRectMake(margin + 30, y + 3, rowWidth - 30, 16);
+    self.nameOne.frame = CGRectMake(margin + 30, y + 3, rowWidth - 30 - 40, 16);   // room for the pin glyph
     y += 22 + 6;
     self.textBarOne.frame = CGRectMake(margin, y, rowWidth * 0.86, 8);
     y += 8 + 8;
@@ -309,7 +309,20 @@ static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bo
 @property (nonatomic, strong) ApolloInlineMediaPreviewView *preview;
 @property (nonatomic, strong) UILabel *titleLabel;      // pinned copy of the section header
 @property (nonatomic, strong) UIColor *backdropColor;   // table background, shown while stuck
+@property (nonatomic, strong) UIColor *accentColor;     // filled pin glyph
 @property (nonatomic) BOOL stuck;
+// Pin toggle: tapping anywhere on the card flips it. Pinned (default) = the
+// block sticks below the nav bar; unpinned = it scrolls with the list like any
+// row. A small pin glyph in the card's corner shows the state at all times
+// (filled + accent when pinned, outlined + dim when not), and a short caption
+// acknowledges each tap. The controller persists the choice.
+@property (nonatomic) BOOL pinned;
+@property (nonatomic, strong) UIButton *pinButton;
+@property (nonatomic, strong) UIImageView *pinIcon;
+@property (nonatomic, strong) UILabel *pinCaption;
+@property (nonatomic, strong) UISelectionFeedbackGenerator *pinFeedback;
+@property (nonatomic) NSUInteger pinCaptionToken;
+@property (nonatomic, copy) void (^pinDidChange)(BOOL pinned);
 // Sampled from the native header: the label's origin relative to the card's
 // resting origin (y is negative — the title sits above the card) and its size.
 @property (nonatomic) BOOL hasTitleSample;
@@ -336,8 +349,76 @@ static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bo
         _titleLabel = [[UILabel alloc] init];
         _titleLabel.hidden = YES;
         [self addSubview:_titleLabel];
+
+        // UIControl target/action does not retain its target, so the host can
+        // be the target without a host → card → button → host cycle.
+        _pinButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        _pinButton.backgroundColor = [UIColor clearColor];
+        [_pinButton addTarget:self action:@selector(apollo_pinTapped) forControlEvents:UIControlEventTouchUpInside];
+        [_card addSubview:_pinButton];
+        _pinIcon = [[UIImageView alloc] init];
+        _pinIcon.contentMode = UIViewContentModeCenter;
+        _pinIcon.userInteractionEnabled = NO;
+        [_card addSubview:_pinIcon];
+        _pinCaption = [[UILabel alloc] init];
+        _pinCaption.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold];
+        _pinCaption.textColor = [UIColor secondaryLabelColor];
+        _pinCaption.textAlignment = NSTextAlignmentRight;
+        _pinCaption.alpha = 0.0;
+        _pinCaption.userInteractionEnabled = NO;
+        [_card addSubview:_pinCaption];
+        _pinFeedback = [[UISelectionFeedbackGenerator alloc] init];
+        _pinned = YES;
+        [self apollo_updatePinIcon];
     }
     return self;
+}
+
+- (void)setPinned:(BOOL)pinned {
+    _pinned = pinned;
+    [self apollo_updatePinIcon];
+}
+
+- (void)setAccentColor:(UIColor *)accentColor {
+    _accentColor = accentColor;
+    [self apollo_updatePinIcon];
+}
+
+- (void)apollo_updatePinIcon {
+    UIImageSymbolConfiguration *config =
+        [UIImageSymbolConfiguration configurationWithPointSize:13.0 weight:UIImageSymbolWeightSemibold];
+    self.pinIcon.image = [UIImage systemImageNamed:self.pinned ? @"pin.fill" : @"pin" withConfiguration:config];
+    self.pinIcon.tintColor = self.pinned
+        ? (self.accentColor ?: [UIColor systemBlueColor])
+        : [UIColor tertiaryLabelColor];
+    self.pinButton.accessibilityLabel = self.pinned ? @"Unpin preview" : @"Pin preview";
+}
+
+- (void)apollo_pinTapped {
+    self.pinned = !self.pinned;
+    [self.pinFeedback selectionChanged];
+
+    // Bounce the glyph so the tap reads as a state change.
+    self.pinIcon.transform = CGAffineTransformMakeScale(1.3, 1.3);
+    [UIView animateWithDuration:0.45 delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0
+                        options:UIViewAnimationOptionBeginFromCurrentState
+                     animations:^{ self.pinIcon.transform = CGAffineTransformIdentity; }
+                     completion:nil];
+
+    // Brief caption next to the glyph, replaced (not stacked) by a quick re-tap.
+    NSUInteger token = ++self.pinCaptionToken;
+    self.pinCaption.text = self.pinned ? @"Pinned" : @"Unpinned";
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+    [UIView animateWithDuration:0.15 animations:^{ self.pinCaption.alpha = 1.0; }];
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf.pinCaptionToken != token) return;
+        [UIView animateWithDuration:0.3 animations:^{ strongSelf.pinCaption.alpha = 0.0; }];
+    });
+
+    if (self.pinDidChange) self.pinDidChange(self.pinned);
 }
 
 // The header's text label, wherever this iOS version nests it.
@@ -391,7 +472,16 @@ static UILabel *ApolloIMFindHeaderLabel(UIView *view) {
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    self.preview.frame = self.card.bounds;
+    CGRect cardBounds = self.card.bounds;
+    self.preview.frame = cardBounds;
+    self.pinButton.frame = cardBounds;
+    CGFloat side = 22.0;
+    self.pinIcon.frame = CGRectMake(CGRectGetWidth(cardBounds) - kApolloIMPreviewInset - side, kApolloIMPreviewPad - 1.0, side, side);
+    [self.pinCaption sizeToFit];
+    CGSize captionSize = self.pinCaption.bounds.size;
+    self.pinCaption.frame = CGRectMake(CGRectGetMinX(self.pinIcon.frame) - 6.0 - captionSize.width,
+                                       CGRectGetMidY(self.pinIcon.frame) - captionSize.height * 0.5,
+                                       captionSize.width, captionSize.height);
 }
 
 @end
@@ -962,7 +1052,7 @@ static char kApolloIMPinnedHostKey;
     CGFloat visibleBottom = self.contentOffset.y + CGRectGetHeight(self.bounds) - self.adjustedContentInset.bottom;
     CGFloat listRoom = (visibleBottom - visibleTop) - titleAbove - CGRectGetHeight(row) - kApolloIMStuckTopGap - kApolloIMStuckBottomPad;
     BOOL compactHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
-    BOOL canStick = !compactHeight && listRoom >= kApolloIMMinListViewport;
+    BOOL canStick = host.pinned && !compactHeight && listRoom >= kApolloIMMinListViewport;
 
     CGFloat cardY = CGRectGetMinY(row);
     if (canStick) cardY = MAX(cardY, visibleTop + kApolloIMStuckTopGap + titleAbove);
@@ -972,7 +1062,10 @@ static char kApolloIMPinnedHostKey;
     CGFloat hostBottom = cardY + CGRectGetHeight(row) + (stuck ? kApolloIMStuckBottomPad : 0.0);
     host.frame = CGRectMake(0, hostTop, CGRectGetWidth(self.bounds), hostBottom - hostTop);
     host.card.frame = CGRectMake(cardX, cardY - hostTop, cardW, CGRectGetHeight(row));
-    host.titleLabel.hidden = !(stuck && host.hasTitleSample);
+    // Alpha rather than hidden so a pin/unpin toggle (run inside an animation
+    // block by the controller) fades the title along with the sliding card.
+    host.titleLabel.hidden = !host.hasTitleSample;
+    host.titleLabel.alpha = (stuck && host.hasTitleSample) ? 1.0 : 0.0;
     if (host.hasTitleSample) {
         host.titleLabel.frame = CGRectMake(cardX + host.titleOffset.x, cardY - hostTop + host.titleOffset.y,
                                            host.titleSize.width, host.titleSize.height);
@@ -1047,6 +1140,18 @@ static char kApolloIMPinnedHostKey;
     host.cardWidthDidChange = ^(CGFloat width) {
         [weakSelf previewCardWidthDidChange:width];
     };
+    host.pinned = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyInlineMediaPreviewPinned];
+    host.pinDidChange = ^(BOOL pinned) {
+        [[NSUserDefaults standardUserDefaults] setBool:pinned forKey:UDKeyInlineMediaPreviewPinned];
+        // Slide the block into (or out of) its pinned spot instead of snapping:
+        // the table's layout pass computes the new frames inside the animation.
+        UITableView *table = weakSelf.tableView;
+        [table setNeedsLayout];
+        [UIView animateWithDuration:0.35 delay:0 usingSpringWithDamping:0.9 initialSpringVelocity:0
+                            options:UIViewAnimationOptionBeginFromCurrentState
+                         animations:^{ [table layoutIfNeeded]; }
+                         completion:nil];
+    };
     self.previewHost = host;
     [self.tableView addSubview:host];
     objc_setAssociatedObject(self.tableView, &kApolloIMPinnedHostKey, host, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1094,7 +1199,8 @@ static char kApolloIMPinnedHostKey;
         tableBackground = [UIColor systemGroupedBackgroundColor];
     }
     host.backdropColor = tableBackground;
-    host.preview.accentColor = [self apollo_themeAccentColor];
+    host.accentColor = [self apollo_themeAccentColor];
+    host.preview.accentColor = host.accentColor;
     [host.preview refresh];
 }
 

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -73,28 +73,30 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 
 // Card edge → mock content. The content column is capped so an iPad-width card
 // shows a phone-width comment centered in it instead of a banner-sized block.
-static const CGFloat kApolloIMPreviewInset = 12.0;
+// The card is pinned while the list scrolls, so every point of height here is a
+// point the list can't use — the layout is deliberately compact: the media block
+// keeps a CONSTANT height and only its width follows the slider (width and
+// alignment are what the settings control; a 16:9 block at 100% cost ~190pt and
+// left a hole at 50%), and the message bubble holds a small inline image.
+static const CGFloat kApolloIMPreviewInset = 12.0;      // horizontal
+static const CGFloat kApolloIMPreviewPad = 8.0;         // vertical
 static const CGFloat kApolloIMPreviewMaxContent = 440.0;
+static const CGFloat kApolloIMMediaHeight = 110.0;      // comment media block
 static const CGFloat kApolloIMLinkHeight = 18.0;
-static const CGFloat kApolloIMBubbleImageWidth = 120.0;
+static const CGSize  kApolloIMBubbleImageSize = {88.0, 44.0};
 
 static CGFloat ApolloIMContentWidth(CGFloat cardWidth) {
     return MAX(60.0, MIN(cardWidth - kApolloIMPreviewInset * 2.0, kApolloIMPreviewMaxContent));
-}
-
-static CGFloat ApolloIMMediaHeight(CGFloat rowWidth, CGFloat fraction) {
-    return MAX(60.0, rowWidth * fraction) * 9.0 / 16.0;   // 16:9, like the real GIF block
 }
 
 static CGFloat ApolloIMBubbleWidth(CGFloat rowWidth) {
     return MAX(120.0, rowWidth * 0.72);
 }
 
-// Bubble = 10 pad + 10 text bar + 8 gap + (image | link line) + 10 pad.
-static CGFloat ApolloIMBubbleHeight(CGFloat rowWidth, BOOL mediaOn) {
-    CGFloat inner = ApolloIMBubbleWidth(rowWidth) - 20.0;
-    CGFloat body = mediaOn ? MIN(inner, kApolloIMBubbleImageWidth) * 9.0 / 16.0 : kApolloIMLinkHeight;
-    return 10.0 + 10.0 + 8.0 + body + 10.0;
+// Bubble = 8 pad + 8 text bar + 6 gap + (image | link line) + 8 pad.
+static CGFloat ApolloIMBubbleHeight(BOOL mediaOn) {
+    CGFloat body = mediaOn ? kApolloIMBubbleImageSize.height : kApolloIMLinkHeight;
+    return 8.0 + 8.0 + 6.0 + body + 8.0;
 }
 
 @implementation ApolloInlineMediaPreviewView
@@ -121,7 +123,7 @@ static UIView *ApolloIMBar(UIView *parent, CGFloat alpha) {
 static UIView *ApolloIMAvatar(UIView *parent) {
     UIView *avatar = [[UIView alloc] init];
     avatar.backgroundColor = [UIColor systemFillColor];
-    avatar.layer.cornerRadius = 12.0;
+    avatar.layer.cornerRadius = 11.0;
     [parent addSubview:avatar];
     return avatar;
 }
@@ -193,14 +195,14 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
     self.bubbleLink = ApolloIMLink(self.bubble, @"i.redd.it/vacation.jpg");
 }
 
-// Natural card height for a card width, laid out for the TALLEST state (both
-// switches on, media at 100%). The row height therefore never changes while the
-// controls are adjusted — smaller fractions and switched-off media simply leave
-// breathing room — so live slider drags never force table reloads.
+// Natural card height, laid out for the TALLEST state (both switches on). The
+// row height therefore never changes while the controls are adjusted — the
+// media block's height is constant and switched-off media simply leaves a
+// little room — so live slider drags never force table reloads.
 + (CGFloat)heightForCardWidth:(CGFloat)cardWidth {
-    CGFloat rowWidth = ApolloIMContentWidth(cardWidth);
-    return 10.0 + 32.0 + 20.0 + ApolloIMMediaHeight(rowWidth, 1.0) + 18.0
-         + 18.0 + ApolloIMBubbleHeight(rowWidth, YES) + 14.0;
+    (void)cardWidth;   // width no longer affects the height; kept for the call sites
+    return kApolloIMPreviewPad + 22.0 + 6.0 + 8.0 + 8.0 + kApolloIMMediaHeight + 12.0
+         + 14.0 + 4.0 + ApolloIMBubbleHeight(YES) + kApolloIMPreviewPad;
 }
 
 - (void)layoutSubviews {
@@ -209,17 +211,17 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
     if (W <= 0) return;
     CGFloat rowWidth = ApolloIMContentWidth(W);
     CGFloat margin = (W - rowWidth) * 0.5;
-    CGFloat y = 10.0;
+    CGFloat y = kApolloIMPreviewPad;
 
     // Comment header + a line of text.
-    self.avatarOne.frame = CGRectMake(margin, y, 24, 24);
-    self.nameOne.frame = CGRectMake(margin + 32, y + 4, rowWidth - 32, 16);
-    y += 32;
-    self.textBarOne.frame = CGRectMake(margin, y, rowWidth * 0.86, 10);
-    y += 20;
+    self.avatarOne.frame = CGRectMake(margin, y, 22, 22);
+    self.nameOne.frame = CGRectMake(margin + 30, y + 3, rowWidth - 30, 16);
+    y += 22 + 6;
+    self.textBarOne.frame = CGRectMake(margin, y, rowWidth * 0.86, 8);
+    y += 8 + 8;
 
-    // Media block — width follows the media slider, aspect fixed at 16:9,
-    // horizontal position follows the alignment setting (same slack rule as
+    // Media block — width follows the media slider, height constant, horizontal
+    // position follows the alignment setting (same slack rule as
     // ApolloWrapImageNodeForLayout). With Inline Media Previews off the row
     // shows the link as plain text instead.
     BOOL commentMedia = self.commentMediaEnabled;
@@ -227,7 +229,7 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
     self.commentLink.hidden = commentMedia;
     if (commentMedia) {
         CGFloat mediaWidth = MAX(60.0, rowWidth * self.mediaFraction);
-        CGFloat mediaHeight = ApolloIMMediaHeight(rowWidth, self.mediaFraction);
+        CGFloat mediaHeight = kApolloIMMediaHeight;
         CGFloat slack = rowWidth - mediaWidth;
         CGFloat mediaX = margin + (self.alignment == ApolloInlineImageAlignmentLeft ? 0.0 :
                          self.alignment == ApolloInlineImageAlignmentRight ? slack : slack * 0.5);
@@ -242,30 +244,28 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
         self.commentLink.frame = CGRectMake(margin, y, rowWidth, kApolloIMLinkHeight);
         y += kApolloIMLinkHeight;
     }
-    y += 18;
+    y += 12;
 
     // Message thread: sender name, then a received bubble with a line of text
     // and either a small inline image or the same plain-link stand-in.
     self.nameTwo.frame = CGRectMake(margin, y, rowWidth, 14);
-    y += 18;
+    y += 14 + 4;
     BOOL messageMedia = self.messageMediaEnabled;
     CGFloat bubbleWidth = ApolloIMBubbleWidth(rowWidth);
     CGFloat inner = bubbleWidth - 20.0;
-    CGFloat by = 10.0;
-    self.bubbleText.frame = CGRectMake(10, by, inner * 0.8, 10);
-    by += 18;
+    CGFloat by = 8.0;
+    self.bubbleText.frame = CGRectMake(10, by, inner * 0.8, 8);
+    by += 8 + 6;
     self.bubbleImage.hidden = !messageMedia;
     self.bubbleLink.hidden = messageMedia;
     if (messageMedia) {
-        CGFloat imageWidth = MIN(inner, kApolloIMBubbleImageWidth);
-        CGFloat imageHeight = imageWidth * 9.0 / 16.0;
-        self.bubbleImage.frame = CGRectMake(10, by, imageWidth, imageHeight);
-        by += imageHeight;
+        self.bubbleImage.frame = CGRectMake(10, by, MIN(inner, kApolloIMBubbleImageSize.width), kApolloIMBubbleImageSize.height);
+        by += kApolloIMBubbleImageSize.height;
     } else {
         self.bubbleLink.frame = CGRectMake(10, by, inner, kApolloIMLinkHeight);
         by += kApolloIMLinkHeight;
     }
-    by += 10;
+    by += 8;
     self.bubble.frame = CGRectMake(margin, y, bubbleWidth, by);
 }
 
@@ -284,11 +284,18 @@ static UILabel *ApolloIMLink(UIView *parent, NSString *text) {
 // The preview card. A direct subview of the table view — never a cell — sized
 // to the transparent spacer row that reserves its resting place under the
 // "Preview" header. While that row is on screen the card sits exactly on it and
-// scrolls like any other row; once the row would slide under the nav bar the
-// card sticks just below the bar instead (an opaque backdrop hides the rows
-// passing underneath), so every control further down is adjusted with the
-// preview still in view. Positioning lives in ApolloIMSettingsTableView's
-// layoutSubviews, which UIScrollView runs on every content-offset change.
+// scrolls like any other row; once the header would slide under the nav bar the
+// header AND the card stick just below the bar instead (an opaque backdrop
+// hides the rows passing underneath), so every control further down is adjusted
+// with the preview still in view. Positioning lives in
+// ApolloIMSettingsTableView's layoutSubviews, which UIScrollView runs on every
+// content-offset change.
+//
+// The pinned "Preview" title is a copy of UIKit's own section header label —
+// text, font, colour and position are sampled from the real header view while
+// it is on screen (it always is at rest), so it matches whatever header style
+// this iOS / Liquid Glass combination draws, and only becomes visible once the
+// block is stuck (the native header is under the backdrop by then).
 //
 // Height-constrained layouts (landscape phones, tiny screens) don't stick:
 // pinning a ~400pt card there would leave no usable list, so the card just
@@ -300,8 +307,15 @@ static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bo
 @interface ApolloIMPinnedPreviewHost : UIView
 @property (nonatomic, strong) UIView *card;
 @property (nonatomic, strong) ApolloInlineMediaPreviewView *preview;
+@property (nonatomic, strong) UILabel *titleLabel;      // pinned copy of the section header
 @property (nonatomic, strong) UIColor *backdropColor;   // table background, shown while stuck
 @property (nonatomic) BOOL stuck;
+// Sampled from the native header: the label's origin relative to the card's
+// resting origin (y is negative — the title sits above the card) and its size.
+@property (nonatomic) BOOL hasTitleSample;
+@property (nonatomic) CGPoint titleOffset;
+@property (nonatomic) CGSize titleSize;
+- (void)sampleTitleFromHeaderView:(UIView *)headerView inTable:(UITableView *)table cardOrigin:(CGPoint)cardOrigin;
 // Real inset-grouped cell width measured by the layout pass (0 = not yet seen)
 // and the callback the controller uses to re-measure the spacer row when it
 // changes (first layout, rotation).
@@ -319,8 +333,44 @@ static const CGFloat kApolloIMMinListViewport = 200.0; // list room needed to bo
         [self addSubview:_card];
         _preview = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
         [_card addSubview:_preview];
+        _titleLabel = [[UILabel alloc] init];
+        _titleLabel.hidden = YES;
+        [self addSubview:_titleLabel];
     }
     return self;
+}
+
+// The header's text label, wherever this iOS version nests it.
+static UILabel *ApolloIMFindHeaderLabel(UIView *view) {
+    if ([view isKindOfClass:[UILabel class]] && ((UILabel *)view).text.length > 0) return (UILabel *)view;
+    for (UIView *sub in view.subviews) {
+        UILabel *label = ApolloIMFindHeaderLabel(sub);
+        if (label) return label;
+    }
+    return nil;
+}
+
+- (void)sampleTitleFromHeaderView:(UIView *)headerView inTable:(UITableView *)table cardOrigin:(CGPoint)cardOrigin {
+    UILabel *label = ApolloIMFindHeaderLabel(headerView);
+    if (!label || !label.superview || CGRectIsEmpty(label.frame)) return;
+    CGRect frame = [label.superview convertRect:label.frame toView:table];
+    CGPoint offset = CGPointMake(CGRectGetMinX(frame) - cardOrigin.x, CGRectGetMinY(frame) - cardOrigin.y);
+    if (offset.y >= 0) return;   // not above the card: not our header's label
+    BOOL sameText = [self.titleLabel.text isEqualToString:label.text];
+    if (self.hasTitleSample && sameText &&
+        fabs(offset.x - self.titleOffset.x) < 0.5 && fabs(offset.y - self.titleOffset.y) < 0.5 &&
+        fabs(frame.size.width - self.titleSize.width) < 0.5 && fabs(frame.size.height - self.titleSize.height) < 0.5) {
+        return;   // unchanged
+    }
+    self.titleLabel.font = label.font;
+    self.titleLabel.textColor = label.textColor;
+    self.titleLabel.textAlignment = label.textAlignment;
+    self.titleLabel.numberOfLines = label.numberOfLines;
+    self.titleLabel.text = label.text;
+    if (label.attributedText) self.titleLabel.attributedText = [label.attributedText copy];
+    self.titleOffset = offset;
+    self.titleSize = frame.size;
+    self.hasTitleSample = YES;
 }
 
 - (void)setStuck:(BOOL)stuck {
@@ -899,21 +949,34 @@ static char kApolloIMPinnedHostKey;
         }
     }
 
-    // Stick only when there's real list room left under the card.
+    // The section header ("Preview") is pinned with the card. Sample its label
+    // while UIKit has it on screen; the copy is only shown once stuck.
+    UIView *headerView = [self headerViewForSection:ApolloIMSectionPreview];
+    if (headerView) {
+        [host sampleTitleFromHeaderView:headerView inTable:self cardOrigin:CGPointMake(cardX, CGRectGetMinY(row))];
+    }
+    CGFloat titleAbove = host.hasTitleSample ? -host.titleOffset.y : 0.0;   // title top → card top
+
+    // Stick only when there's real list room left under the block.
     CGFloat visibleTop = self.contentOffset.y + self.adjustedContentInset.top;
     CGFloat visibleBottom = self.contentOffset.y + CGRectGetHeight(self.bounds) - self.adjustedContentInset.bottom;
-    CGFloat listRoom = (visibleBottom - visibleTop) - CGRectGetHeight(row) - kApolloIMStuckTopGap - kApolloIMStuckBottomPad;
+    CGFloat listRoom = (visibleBottom - visibleTop) - titleAbove - CGRectGetHeight(row) - kApolloIMStuckTopGap - kApolloIMStuckBottomPad;
     BOOL compactHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact;
     BOOL canStick = !compactHeight && listRoom >= kApolloIMMinListViewport;
 
     CGFloat cardY = CGRectGetMinY(row);
-    if (canStick) cardY = MAX(cardY, visibleTop + kApolloIMStuckTopGap);
+    if (canStick) cardY = MAX(cardY, visibleTop + kApolloIMStuckTopGap + titleAbove);
     BOOL stuck = cardY > CGRectGetMinY(row) + 0.5;
 
     CGFloat hostTop = stuck ? visibleTop : CGRectGetMinY(row);
     CGFloat hostBottom = cardY + CGRectGetHeight(row) + (stuck ? kApolloIMStuckBottomPad : 0.0);
     host.frame = CGRectMake(0, hostTop, CGRectGetWidth(self.bounds), hostBottom - hostTop);
     host.card.frame = CGRectMake(cardX, cardY - hostTop, cardW, CGRectGetHeight(row));
+    host.titleLabel.hidden = !(stuck && host.hasTitleSample);
+    if (host.hasTitleSample) {
+        host.titleLabel.frame = CGRectMake(cardX + host.titleOffset.x, cardY - hostTop + host.titleOffset.y,
+                                           host.titleSize.width, host.titleSize.height);
+    }
     if (host.stuck != stuck) host.stuck = stuck;
 
     // Keep the host above every cell and section header/footer (UITableView


### PR DESCRIPTION
**Stacked on #1022** — this branch is based on its tip so the pinned-preview host could be pulled out of `InlineMediaSettingsViewController` into a shared file and reused here. Until #1022 merges the diff below includes its three commits too; once it lands this is just the extraction + the Rich Link Previews screen.

## Rich Link Previews screen
<img width="331" height="720" alt="richlinkpreview00 24 11" src="https://github.com/user-attachments/assets/79561365-83f9-471d-8b4b-f59328184eac" />


The old "Card Preview" always showed a full card and a compact card no matter what was set. Now the preview shows what the settings actually do: one sample for **BODY** and one for **COMMENTS**, each drawn the way that setting renders a link.

- **Full** → the hero image card
- **Compact** → the thumbnail row
- **Off** → Apollo's classic link button (thumbnail, title, URL, chevron)

Change a mode and only that sample changes — it cross-fades into its new look while the card springs to the new height and the rows below follow. The card colour recolours both rich samples in place (quick swatches and continuous drags in the system picker); the Off sample never takes the colour, same as the real renderer. The footer now also explains that comments with more than one link always get compact cards even on Full.

The preview is pinned the same way as Inline Media (#1022): while pinned the native "Preview" title + card stay locked exactly where they rest on screen while the mode rows and colour controls slide beneath them, pin glyph in the card's corner, tap the card to pin/unpin, remembered per screen (`UDKeyLinkPreviewPreviewPinned`, default pinned).

## Shared pinned preview (`src/settings/ApolloSettingsPinnedPreview.{h,m}`)

The host, spacer cell, section-geometry helpers and the table layout pass from #1022, made generic: the screen hands the host a `contentView` and a `spacerIndexPath` block instead of a section constant, so form screens (which derive their indices) can adopt it. Inline Media now uses it; its table subclass keeps only the slider touch arbitration.

Three changes to the layout pass on the way (all apply to Inline Media as well):

- **Pinned = locked.** The block used to ride its row until the header would go under the bar, then stick 8pt below it, and it bounced along with a pull-down. Now a pinned block stays exactly at its resting screen position — its content y follows the offset one-for-one — so scrolling slides the rows under it and a rubber-band bounce leaves it put. At rest nothing changes (card on its row, native header), so the hand-off to the title copy + backdrop is invisible.
- While locked, the backdrop starts at the top of the visible bounds instead of just under the bar. Otherwise the native header and the section's own rounded background (iOS 26 draws that in the section container, not in the spacer cell) peeked out around the block once a hide-on-scroll nav bar had gone (non-glass), faintly through the glass bar, or during a bounce.
- The sampled title is validated against the table's own header rect. After a `reloadData` (a light/dark flip on form screens, `viewWillAppear` on the hand-rolled ones) the header view UIKit hands out reported its label ~37pt above the header on iOS 26 while the title was visibly drawn in place; that sample pushed the block off its row at rest with the title copy floating up into a gap above the card.

One deliberate difference from the Inline Media recipe: this card's height follows the current modes rather than being fixed at the tallest state — Off/Off would otherwise leave ~130pt of empty card. Mode changes are taps, not drags, so the spacer row is animated with `performBatchUpdates` inside the same spring as the samples.

## Tested

Simulator, Liquid Glass and non-glass shells, both this screen and Inline Media: card lines up with the cells at rest, sticks with the sampled title and backdrop, pin/unpin slide + caption, mode changes (grow and shrink), swatch + picker colour, light/dark, custom theme on the non-glass shell. Device build compiles clean. Not device-tested yet.

Follow-ups once this lands: Subreddit Sections (#1020) and Feed Shortcuts onto the shared host.
