### PR TITLE
Fix freezes caused by stale search observers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloThemeQRScanViewController.m \
     $(SRC_DIR)/ApolloSearchInPlace.xm \
     $(SRC_DIR)/ApolloSearchNativeBar.xm \
+    $(SRC_DIR)/ApolloSearchObserverCleanup.xm \
     $(SRC_DIR)/ApolloJumpBarSuggestionTint.xm \
     $(SRC_DIR)/ApolloSearchHeaderOverlapFix.xm \
     $(SRC_DIR)/ApolloSearchTabFixes.xm \

--- a/src/ApolloSearchObserverCleanup.xm
+++ b/src/ApolloSearchObserverCleanup.xm
@@ -1,0 +1,43 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+
+@interface _UISearchBarTextFieldTokenCounter : NSObject
+@end
+
+static Ivar sTextStorageObservationIvar;
+
+%group ApolloSearchObserverCleanup
+%hook _UISearchBarTextFieldTokenCounter
+
+- (void)dealloc {
+    // UIKit leaves this main-queue observer registered after its text storage
+    // is freed. ASDK can reuse that address and deadlock posting a text edit
+    // while main waits for layout. Remove the exact token before UIKit frees
+    // the storage; live search notifications keep their normal delivery.
+    id observer = object_getIvar(self, sTextStorageObservationIvar);
+    if (observer) {
+        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    }
+    %orig;
+}
+
+%end
+%end
+
+%ctor {
+    if (@available(iOS 26.0, *)) {
+        Class counterClass = objc_getClass("_UISearchBarTextFieldTokenCounter");
+        Ivar observationIvar = class_getInstanceVariable(counterClass, "_textStorageObservation");
+        const char *type = observationIvar ? ivar_getTypeEncoding(observationIvar) : NULL;
+        if (!counterClass || !type || type[0] != '@') {
+            ApolloLog(@"[SearchObserverCleanup] unsupported token-counter layout; skipping");
+            return;
+        }
+
+        sTextStorageObservationIvar = observationIvar;
+        %init(ApolloSearchObserverCleanup, _UISearchBarTextFieldTokenCounter = counterClass);
+        ApolloLog(@"[SearchObserverCleanup] installed token-counter observer cleanup");
+    }
+}


### PR DESCRIPTION
## Summary

Changes included in a recent update exposed a UIKit cleanup issue that could freeze Apollo when navigating between subreddits or opening posts. This PR fixes that deadlock, which could leave the app completely unresponsive on a loading spinner or an already loaded comments screen.

## Cause

UIKit’s search-field helper leaves a text-storage notification observer registered after the helper is destroyed. When AsyncDisplayKit reuses the freed text-storage address, background text edits can trigger that leftover observer.

This creates a deadlock: the background worker waits for notification delivery on the main queue, while the main thread waits for background text layout to finish.

## Changes

- Remove the exact observer owned by `_UISearchBarTextFieldTokenCounter` before its original deallocation runs.
- Apply the cleanup on iOS 26+, with runtime checks for the expected class and object ivar.
- Preserve normal notification delivery for active search fields and the existing native search behavior.

## Validation

- Reproduced the observer-lifetime issue in the simulator and verified the compiled fix resolves it while preserving live search callbacks.
- Tested repeated subreddit navigation on an iPhone 17 Pro Max running iOS 27; the reported freeze stopped occurring.
- Confirmed all 16 captured background text-edit notifications completed after the fix.
- Verified a live device thread capture no longer showed the previous text-layout deadlock.
- Compiled the device hook without warnings.