### PR TITLE
Appearance: keep the Theme Manager label through the Post Size action sheet, drop its bold weight

### DIFF
--- a/src/ApolloThemeManagerIntegration.xm
+++ b/src/ApolloThemeManagerIntegration.xm
@@ -268,28 +268,69 @@ static NSInteger Rows(id self, SEL _cmd, UITableView *tv, NSInteger section) {
     return n;
 }
 
-// Apollo's Appearance screen builds this row with a UIListContentConfiguration
-// (iOS 14+ cell content API) — the cell renders from that, not from
-// .textLabel, so setting .textLabel.text alone silently no-ops on it and
-// only the legacy label (invisible) changes. Rewrite the content
-// configuration's text when present, and set .textLabel too for the
-// legacy-cell fallback case.
+// The Themes row is a Eureka LabelRow: its cell (Eureka.LabelCellOf<String>)
+// renders through the legacy .textLabel, and Eureka re-renders it FROM THE ROW
+// MODEL (textLabel.text = row.title, i.e. "Themes", then Apollo's cellUpdate
+// re-applies its medium-weight font) on every Cell.update(). Our rewrite runs
+// from cellForRow and willDisplay, which covers dequeues, reloads and the
+// scroll-back-into-view case — but Eureka also calls row.updateCell() from
+// Cell.tintColorDidChange(), and that path never touches the table view's
+// delegate. UIKit dims the presenting view's tint while a UIAlertController is
+// up, so presenting the Post Size action sheet reverted the label to "Themes"
+// and dismissing it (another tint change → another re-render) left it there;
+// only picking an option reloaded the table and healed it (#993). So the cell
+// is marked and its own runtime class gets a tintColorDidChange override that
+// re-asserts our label after Eureka's re-render. The class is taken from the
+// live cell rather than a hardcoded mangled generic name, so it follows
+// whatever Eureka hands us.
 //
-// Cell-time isn't the only place this needs to run: UIKit's cell state
-// machine (automaticallyUpdatesContentConfiguration, on by default) can
-// reapply the cell's ORIGINAL base configuration — Apollo's, not ours —
-// whenever the cell's configuration state changes, which fires again on
-// scroll, selection, or simply the row scrolling back into view after a
-// push/pop. Observed as the label reverting once you leave and return to
-// this screen. Re-assert from willDisplay too, which fires on every one of
-// those passes, not just the initial dequeue.
+// The content-configuration branch stays for the case where a future Apollo
+// build moves this row onto UIListContentConfiguration: there .textLabel is the
+// invisible legacy label and only the configuration's text renders.
+static const void *kThemesRowCellKey = &kThemesRowCellKey;
+
+// The cell class carrying our tintColorDidChange override, and the IMP it
+// displaced (Eureka.Cell's). Resolved from the first Themes cell we see.
+static Class sThemesCellClass = Nil;
+static void (*sThemesCellTintOrig)(id, SEL) = NULL;
+
+static void RewriteThemesRowLabel(UITableViewCell *cell);
+
+static void ThemesCellTintColorDidChange(UITableViewCell *self, SEL _cmd) {
+    if (sThemesCellTintOrig) sThemesCellTintOrig(self, _cmd);   // Eureka: row.updateCell() → "Themes" + medium font
+    if (objc_getAssociatedObject(self, kThemesRowCellKey)) RewriteThemesRowLabel(self);
+}
+
+static void InstallThemesCellTintHook(Class cls) {
+    if (!cls || sThemesCellClass) return;
+    // A KVO/isa-swizzled cell reports a dynamic subclass; hook the class that
+    // actually owns the Eureka override chain, not the ephemeral subclass.
+    while (cls && strncmp(class_getName(cls), "NSKVONotifying_", 15) == 0) cls = class_getSuperclass(cls);
+    SEL sel = @selector(tintColorDidChange);
+    Method m = class_getInstanceMethod(cls, sel);              // inherited Eureka.Cell override (or UIView's)
+    if (!m) return;
+    sThemesCellClass = cls;
+    sThemesCellTintOrig = (void (*)(id, SEL))method_getImplementation(m);
+    class_replaceMethod(cls, sel, (IMP)ThemesCellTintColorDidChange, "v@:");
+    ApolloLog(@"ThemeManager: Themes row tint hook installed on %@", NSStringFromClass(cls));
+}
+
 static void RewriteThemesRowLabel(UITableViewCell *cell) {
+    if (!objc_getAssociatedObject(cell, kThemesRowCellKey)) {
+        objc_setAssociatedObject(cell, kThemesRowCellKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        InstallThemesCellTintHook(object_getClass(cell));
+    }
     if ([cell.contentConfiguration isKindOfClass:[UIListContentConfiguration class]]) {
         UIListContentConfiguration *config = [(UIListContentConfiguration *)cell.contentConfiguration copy];
         config.text = @"Theme Manager";
         cell.contentConfiguration = config;
     }
     cell.textLabel.text = @"Theme Manager";
+    // Apollo gives its Themes row a medium-weight face; every other row on this
+    // screen is regular. The row is ours now, so match its neighbours — same
+    // size (tracks Apollo's own text-size slider), regular weight (#993).
+    UIFont *font = cell.textLabel.font;
+    if (font.pointSize > 0) cell.textLabel.font = [UIFont systemFontOfSize:font.pointSize weight:UIFontWeightRegular];
 }
 
 static UITableViewCell *Cell(id self, SEL _cmd, UITableView *tv, NSIndexPath *ip) {

--- a/src/ApolloThemeManagerIntegration.xm
+++ b/src/ApolloThemeManagerIntegration.xm
@@ -38,6 +38,8 @@ static NSInteger (*sEditingStyleOrig)(id, SEL, UITableView *, NSIndexPath *);
 static NSInteger (*sIndentOrig)(id, SEL, UITableView *, NSIndexPath *);
 static UISwipeActionsConfiguration *(*sLeadingSwipeOrig)(id, SEL, UITableView *, NSIndexPath *);
 static UISwipeActionsConfiguration *(*sTrailingSwipeOrig)(id, SEL, UITableView *, NSIndexPath *);
+static CGFloat (*sHeightForHeaderOrig)(id, SEL, UITableView *, NSInteger);
+static void (*sWillDisplayHeaderOrig)(id, SEL, UITableView *, UIView *, NSInteger);
 
 static inline BOOL IsThemesRow(NSIndexPath *ip) { return ip.section == 0 && ip.row == 0; }
 
@@ -431,6 +433,54 @@ static UISwipeActionsConfiguration *TrailingSwipe(id self, SEL _cmd, UITableView
     return sTrailingSwipeOrig ? sTrailingSwipeOrig(self, _cmd, tv, ip) : nil;
 }
 
+// ---------------------------------------------------------------------------
+// Keep the first section header ("Themes") the height it first displayed at.
+//
+// Eureka answers heightForHeaderInSection: with UITableViewAutomaticDimension,
+// so UIKit self-sizes the header view — and for the FIRST section that
+// measurement includes an extra ~17pt of top padding whenever UIKit considers
+// the header the table's "top header". That decision isn't stable: UIKit ties
+// it to the navigation controller's scroll-view observation state
+// (UIScrollView._shouldAdjustLayoutToCollapseTopSpacing — the iOS 26 name; the
+// same flip reproduces on iOS 17), which is on while the bar is observing this
+// table (first display → unpadded, 38pt at default size) and off after any
+// UIAlertController has been presented over it. The next reload then measures
+// the reused header WITH the padding (55.33pt) and the whole table jumps down
+// by 17pt: change Post Size, toggle Use System Text Size. Stock Apollo does
+// this too (verified against main), it just went unnoticed until the label fix
+// had people watching this exact row.
+//
+// Rather than chase UIKit's private flag, pin the section 0 header to the
+// height UIKit gave it the first time it was displayed, per screen instance and
+// per content size category (the only input that legitimately changes it —
+// Apollo restyles the header font in willDisplayHeaderView, AFTER UIKit has
+// measured, so Apollo's own text-size slider never affected the height). The
+// label sits identically inside the pinned frame whether or not UIKit later
+// flags the header as "top", so nothing visible moves.
+// ---------------------------------------------------------------------------
+static const void *kThemesHeaderPinKey = &kThemesHeaderPinKey;   // @{@"category": NSString, @"height": NSNumber}
+
+static CGFloat HeightForHeader(id self, SEL _cmd, UITableView *tv, NSInteger section) {
+    if (section == 0) {
+        NSDictionary *pin = objc_getAssociatedObject(self, kThemesHeaderPinKey);
+        NSString *category = tv.traitCollection.preferredContentSizeCategory ?: @"";
+        if (pin && [pin[@"category"] isEqualToString:category]) return [pin[@"height"] doubleValue];
+    }
+    return sHeightForHeaderOrig ? sHeightForHeaderOrig(self, _cmd, tv, section) : UITableViewAutomaticDimension;
+}
+
+static void WillDisplayHeader(id self, SEL _cmd, UITableView *tv, UIView *view, NSInteger section) {
+    if (sWillDisplayHeaderOrig) sWillDisplayHeaderOrig(self, _cmd, tv, view, section);
+    if (section != 0 || view.bounds.size.height <= 0) return;
+    NSString *category = tv.traitCollection.preferredContentSizeCategory ?: @"";
+    NSDictionary *pin = objc_getAssociatedObject(self, kThemesHeaderPinKey);
+    if (!pin || ![pin[@"category"] isEqualToString:category]) {
+        objc_setAssociatedObject(self, kThemesHeaderPinKey,
+                                 @{@"category": category, @"height": @(view.bounds.size.height)},
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
 #define SAVE_AND_REPLACE(sel, var, fn, sig) do { \
     Method m = class_getInstanceMethod(cls, sel); \
     var = m ? (typeof(var))class_getMethodImplementation(cls, sel) : NULL; \
@@ -443,6 +493,8 @@ static void InstallAppearanceHooks(void) {
     Class cls = objc_getClass("_TtC6Apollo32SettingsAppearanceViewController");
     if (!cls) { ApolloLog(@"ThemeManager: SettingsAppearanceViewController missing"); return; }
 
+    SAVE_AND_REPLACE(@selector(tableView:heightForHeaderInSection:), sHeightForHeaderOrig, HeightForHeader, "d@:@q");
+    SAVE_AND_REPLACE(@selector(tableView:willDisplayHeaderView:forSection:), sWillDisplayHeaderOrig, WillDisplayHeader, "v@:@@q");
     SAVE_AND_REPLACE(@selector(tableView:numberOfRowsInSection:), sRowsOrig, Rows, "q@:@q");
     SAVE_AND_REPLACE(@selector(tableView:cellForRowAtIndexPath:), sCellOrig, Cell, "@@:@@");
     SAVE_AND_REPLACE(@selector(tableView:heightForRowAtIndexPath:), sHeightOrig, Height, "d@:@@");


### PR DESCRIPTION
Fixes #993

In Settings → Appearance the top row is our repointed **Theme Manager** row, but opening the Post Size action sheet flipped its label back to Apollo's original **Themes**, and cancelling the sheet left it that way. Only actually picking Compact/Large brought Theme Manager back. Also drops the bold-ish weight on that row so it matches the rest of the screen (both asked for in the issue).

<img width="1200" height="1304" alt="before-after" src="https://github.com/user-attachments/assets/4b70ed30-d849-4df5-9c9b-20dd0f8cfc31" />

### What was going on

The row is a Eureka `LabelRow` and its cell (`Eureka.LabelCellOf<String>`) renders through the legacy `textLabel`. We rewrite the label from `cellForRow` and `willDisplay`, which covers dequeues, reloads and scrolling back into view. But Eureka also re-renders every cell straight from its row model in `Cell.tintColorDidChange()` → `row.updateCell()` → `Cell.update()` (`textLabel.text = row.title`, then Apollo's `cellUpdate` re-applies its medium font). UIKit dims the presenting view's tint while a `UIAlertController` is up, so:

- present the Post Size sheet → tint dims → Eureka re-renders → "Themes"
- cancel → tint restores → re-renders again → still "Themes"
- pick an option → Apollo reloads the table → our `cellForRow` hook runs → "Theme Manager" again

None of that goes through the table view delegate, so the existing hooks never saw it. Confirmed with a backtrace in the sim: `-[UITableViewLabel setText:]` ← `Eureka.Cell.update()` ← `Eureka.Row.updateCell()` ← `Eureka.Cell.tintColorDidChange()` ← `-[UIView _tintColorDidChange]`.

### Fix

- The Themes cell gets marked, and its own runtime class (taken from the live cell, not a hardcoded mangled generic name) gets a `tintColorDidChange` override that calls Eureka's original and then re-asserts our label. Hooking `UITableViewCell`'s would run before Eureka's re-render (Eureka calls super first), so it has to sit on the cell's class.
- The label is set to the same regular weight/size as the neighbouring rows (they're `.SFUI-Regular` 17pt, Apollo's Themes row was `.SFUI-Medium`). Size is derived from the label's current font so it keeps tracking Apollo's own text size slider.

### Tested

Sim, iOS 26.5, both shells:
- **Non-glass** (real `UIAlertController` action sheet, same as the reporter's iOS 17): open Post Size → label stays Theme Manager → Cancel → stays → open again and pick an option → stays. Log confirms every Eureka `"Themes"` write is followed by our re-assert.
- **Liquid Glass**: the Post Size picker is a UIMenu there so the tint path never fired to begin with; verified no regression and the regular weight.
- Text size slider and leaving/returning to the screen still show Theme Manager (those paths reload the table).


### Round 2 — header height after a reload (AcornElf's follow-up)

The Themes section header growing by ~17pt after changing Post Size or toggling Use System Text Size turned out to be pre-existing: untouched `main` does exactly the same in the sim (header 38 → 55.33 on iOS 26, glass and non-glass; AcornElf measured 44 → 61.33 on iOS 17). Nothing in the label fix touches headers or reloads, it just made people watch that row.

Mechanism (UIKitCore + a diag build): the first section header of a grouped table is measured ~17pt taller when UIKit considers it the table's "top header". That decision follows the nav controller's scroll-view observation flag (`_shouldAdjustLayoutToCollapseTopSpacing`): on while the bar is observing the table (first display → unpadded), off once a `UIAlertController` has been presented over it, and it never flips back. The next reload re-measures the reused header with the padding and the table jumps.

Fix: this module already owns the Appearance table's delegate surface, so it now also replaces `heightForHeaderInSection:` / `willDisplayHeaderView:` and pins section 0's header to the height UIKit gave it on first display, per screen instance and per content-size category. Public API only. The label sits identically inside the pinned frame in both flag states, so nothing visible moves. (Apollo restyles the header font after UIKit has measured, so its own text-size slider never affected the height.)

Verified on iOS 26.5 sims: non-glass and Liquid Glass (iPhone 16 Pro) and non-glass on an iPhone 13 mini — header stays at 38pt through open/cancel/pick on Post Size and through the Use System Text Size toggle; accessibility frames and screenshots identical before/after.
