### PR TITLE
Rework Liquid Glass navigation with collapsible actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloSettingsNativeInjections.xm \
     $(SRC_DIR)/ApolloPerPostCommentSort.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
+    $(SRC_DIR)/ApolloNavigationActions.xm \
+    $(SRC_DIR)/ApolloNavigationTitlePresentation.xm \
     $(SRC_DIR)/ApolloTabBarTitles.xm \
     $(SRC_DIR)/ApolloScrollEdgePopFix.xm \
     $(SRC_DIR)/ApolloInterruptibleNavTransition.xm \

--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -1028,17 +1028,10 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
         objc_setAssociatedObject(host, &kInboxAllOriginalRightItemsKey,
                                  [savedRightItems copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    // Stripping the right buttons must not let the Liquid Glass recenter
-    // re-balance the "Inbox" title against an empty trailing side — the title
-    // visibly slid toward screen center on every Notifications -> Chat switch
-    // and back again on the return. Hold the trailing reservation BEFORE the
-    // strip (so a recenter pass mid-removal already holds the old edge) and
-    // release it only AFTER the restore (so no pass between the two sees a
-    // bare bar). No-op off-glass and under the pre-26 nav bar.
-    if (visible) ApolloNavItemSetTrailingReservationHold(host.navigationItem, YES);
+    // Titles are anchored to screen center independently of these actions;
+    // the shared collapsed-pill presenter follows the original item array.
     [host.navigationItem setRightBarButtonItems:visible ? nil : (savedRightItems.count ? savedRightItems : nil)
                                        animated:animated];
-    if (!visible) ApolloNavItemSetTrailingReservationHold(host.navigationItem, NO);
 
     if (visible) {
         // The install-time wiring runs before the host view joins the
@@ -1138,10 +1131,6 @@ static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason
     // The restored right bar items are live on the navigation item again;
     // clear the stash so a later re-enable captures a fresh copy.
     objc_setAssociatedObject(host, &kInboxAllOriginalRightItemsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    // The hide above already released the trailing reservation hold, but keep
-    // dismantle self-sufficient: the hold must never outlive the hub on this
-    // navigation item, whatever path led here.
-    ApolloNavItemSetTrailingReservationHold(host.navigationItem, NO);
     ChatsFilterLog(@"dismantled Inbox chat hub (%@)", reason ?: @"unknown");
 }
 

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -3,6 +3,8 @@
 #import <os/log.h>
 #import <Security/SecBase.h>
 
+@class CASpringAnimation;
+
 // On iOS 26, NSLog redacts strings, so use os_log: https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#NSLog
 // Uses a dedicated subsystem so OSLogStore can efficiently filter our entries.
 #define ApolloLogWithType(type, fmt, ...) do { \
@@ -64,25 +66,6 @@ NSURLSessionDataTask *ApolloStartBoundedDataRequest(
 
 BOOL IsLiquidGlass(void);
 
-// --- Liquid Glass trailing-cluster reservation ---
-// Some screens temporarily strip their right bar buttons while staying on the
-// SAME navigation item (the Inbox strips them whenever its in-place Chat hub
-// covers Notifications). The Liquid Glass title recenter in
-// ApolloLiquidGlass.xm would then re-balance the title against an empty
-// trailing side, visibly sliding it — in gap-centering mode because the gap
-// midpoint moves, and in screen-centering mode because the overlap clamp
-// relaxes. While a "hold" is set on the navigation item, the recenter keeps
-// using the trailing content edge it last measured for that item (stored as an
-// inset from the bar's trailing edge, so rotation keeps working), making the
-// title position identical whether the buttons are up or stripped. The
-// recenter itself records the live inset via
-// ApolloNavItemNoteTrailingContentInset on every pass that sees real trailing
-// content; holders only toggle the hold. All four are no-ops off-glass (the
-// recenter never runs there and nothing else reads the values).
-void ApolloNavItemSetTrailingReservationHold(UINavigationItem *item, BOOL hold);
-BOOL ApolloNavItemTrailingReservationHold(UINavigationItem *item);
-void ApolloNavItemNoteTrailingContentInset(UINavigationItem *item, CGFloat inset);
-CGFloat ApolloNavItemTrailingContentInset(UINavigationItem *item);   // 0 = never captured
 NSURL *ApolloURLByConvertingResolvedURLToApolloScheme(NSURL *url);
 BOOL ApolloRouteResolvedURLViaApolloScheme(NSURL *resolvedURL);
 void ApolloFlushReadPostIDsToDefaults(void);
@@ -152,9 +135,20 @@ BOOL ApolloRouteURLThroughApp(NSURL *url);
 // Returns all UIWindows across every connected UIWindowScene.
 // Use instead of the deprecated UIApplication.windows property.
 NSArray<UIWindow *> *ApolloAllWindows(void);
-// Re-centers every live nav bar title after the LG title-centering mode toggle
-// changes (defined in ApolloLiquidGlass.xm; no-op off Liquid Glass).
-void ApolloLGTitleCenteringModeChanged(void);
+// Refresh title geometry/capsules on one known bar after a local content or
+// action change. Never walks the window/page hierarchy (no-op off Liquid Glass).
+void ApolloNavigationTitlesRefreshBar(UINavigationBar *bar);
+// Global appearance changes (e.g. Header Style) must refresh every live bar.
+// Local title owners should use the bar-scoped entry point above instead.
+void ApolloNavigationTitlesRefresh(void);
+// Settle new content before display, preserving the control, width constraint
+// and same-host glass. sameItem also preserves the active action-avoidance spring.
+void ApolloNavigationTitleGlassRefreshContent(UIView *titleControl, BOOL sameItem);
+// Capture the currently displayed title before publishing action widths, then
+// settle collision geometry with the pill's spring. Nil spring means immediate
+// placement (Reduce Motion, page teardown or nonanimated updates).
+void ApolloNavigationTitleActionsWillChange(UINavigationBar *bar);
+void ApolloNavigationTitleActionsDidChange(UINavigationBar *bar, CASpringAnimation *spring);
 // Keeps the Liquid Glass title capsule in sync with a custom title view's
 // independently-faded content (defined in ApolloLiquidGlass.xm; no-op off LG).
 void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alpha);

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -590,32 +590,6 @@ BOOL IsLiquidGlass(void) {
     return available;
 }
 
-// --- Liquid Glass trailing-cluster reservation (see ApolloCommon.h) ---
-// Plain associated storage on the navigation item; the recenter in
-// ApolloLiquidGlass.xm is the only reader and sole inset writer.
-static char kApolloNavItemTrailingHoldKey;
-static char kApolloNavItemTrailingInsetKey;
-
-void ApolloNavItemSetTrailingReservationHold(UINavigationItem *item, BOOL hold) {
-    if (!item) return;
-    objc_setAssociatedObject(item, &kApolloNavItemTrailingHoldKey,
-                             hold ? @YES : nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-BOOL ApolloNavItemTrailingReservationHold(UINavigationItem *item) {
-    return [objc_getAssociatedObject(item, &kApolloNavItemTrailingHoldKey) boolValue];
-}
-
-void ApolloNavItemNoteTrailingContentInset(UINavigationItem *item, CGFloat inset) {
-    if (!item || inset <= 0) return;
-    objc_setAssociatedObject(item, &kApolloNavItemTrailingInsetKey,
-                             @(inset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-CGFloat ApolloNavItemTrailingContentInset(UINavigationItem *item) {
-    return [objc_getAssociatedObject(item, &kApolloNavItemTrailingInsetKey) doubleValue];
-}
-
 // Route a URL through Apollo's own URL handler, bypassing iOS URL dispatch.
 //
 // On iOS 13+ with scenes, the SceneDelegate owns the tabBarController while

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -1183,7 +1183,16 @@ static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *con
         // UINavigationBar title controls are often only as wide as their label.
         // Permit overhang so the capsule retains real padding instead of
         // collapsing to a plain title label's intrinsic width and height.
-        frame = CGRectInset(contentFrame, -kApolloTitleCapsuleHorizontalPadding, -kVerticalPadding);
+        // Two title lines already fill most of the 44pt navigation row. Keep
+        // their glass padding inside it, including Apollo's push/pop clip.
+        CGFloat verticalPadding = MIN(kVerticalPadding,
+            MAX(0.0, (44.0 - CGRectGetHeight(contentFrame)) / 2.0));
+        frame = CGRectInset(contentFrame, -kApolloTitleCapsuleHorizontalPadding, -verticalPadding);
+        if (ApolloNavigationTitlePresentationOwnsControl(hostView)) {
+            // Fractional label baselines must not move a full-height capsule
+            // above the navigation row while UIKit clips the incoming title.
+            frame.origin.y = CGRectGetMidY(hostView.bounds) - CGRectGetHeight(frame) / 2.0;
+        }
     }
 
     CGFloat scale = hostView.window.screen.scale ?: UIScreen.mainScreen.scale;
@@ -2142,8 +2151,36 @@ void ApolloNavigationTitlesRefresh(void) {
 
 %end
 
+static CGSize ApolloDualTitleNavigationSize(UIButton *button, CGSize size) {
+    if (!isfinite(size.height) || size.height <= 44.0 || !isfinite(size.width) || size.width <= 0) return size;
+    // UIKit may not have populated its label yet. Measure the current native
+    // attributed title without forcing lazy layout from an intrinsic-size read.
+    NSAttributedString *title = button.currentAttributedTitle;
+    if (!title.length) return size;
+    CGFloat textHeight = ceil([title boundingRectWithSize:CGSizeMake(size.width, CGFLOAT_MAX)
+        options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size.height);
+    if (isfinite(textHeight) && textHeight > 0 && textHeight <= 44.0) size.height = 44.0;
+    return size;
+}
+
+%group ApolloLGDualTitleSizing
+%hook ApolloDualLabelNavigationTitleButton
+- (CGSize)intrinsicContentSize {
+    return ApolloDualTitleNavigationSize((UIButton *)self, %orig);
+}
+- (CGSize)sizeThatFits:(CGSize)size {
+    return ApolloDualTitleNavigationSize((UIButton *)self, %orig(size));
+}
+%end
+%end
+
 %ctor {
     %init;
+    Class dualTitleButton = NSClassFromString(@"Apollo.DualLabelTitleButton");
+    if (IsLiquidGlass() && NSClassFromString(@"UIGlassEffect") && dualTitleButton) {
+        // Set the native allocation before push animation or title adoption.
+        %init(ApolloLGDualTitleSizing, ApolloDualLabelNavigationTitleButton = dualTitleButton);
+    }
     // Also cover programmatic JumpBar entry, which doesn't pass through touch
     // tracking. The native opening helper has set the field frame by this point.
     [[NSNotificationCenter defaultCenter] addObserverForName:UITextFieldTextDidBeginEditingNotification

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -5,6 +5,9 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloNavigationTitleGeometry.h"
+#import "ApolloNavigationActions.h"
+#import "ApolloNavigationTitlePresentation.h"
 
 /// Helpers for restoring long-press to activate account switcher w/ Liquid Glass
 static char kApolloTabButtonSetupKey;
@@ -767,21 +770,13 @@ static void HideApolloStatusBarBackgroundView(UINavigationController *navControl
 // titles (#178) and was therefore disabled entirely while bulk translation was
 // on (#200) — bringing the inconsistency right back.
 //
-// Fix: hook _UINavigationBarTitleControl (the universal container for plain
-// titles, DualLabelTitleButton, and JumpBar) and translate it to the midpoint
-// of the visual gap between the leading (back) pill and the trailing pill —
-// their actual _UINavigationBarPlatterView edges, measured at layout time. One
-// rule for every screen and every trailing-pill width, equal breathing room on
-// both sides by construction, so it can never overlap either pill and no
-// longer needs the bulk-translation opt-out.
-//
-// Subreddit headers (ApolloSubredditHeaders.xm) additionally get their
-// JumpBar's width sized to its actual content before this centering math runs
-// — Apollo's own layout snaps that width to one of two fixed constants (156pt
-// moderated / 204pt not) instead of hugging its own text, so without the
-// re-size the gap math is centering a box that has nothing to do with what is
-// actually drawn in it. That sizing pass is unchanged here; only the rule that
-// picks the final center changed.
+// Center the drawn content, including glass padding, rather than its wrapper.
+// Fit against the collapsed pill; expansion keeps that width and shifts only
+// overlapping titles left with the pill's spring. Measure visible siblings in
+// the title's vertical band, then remeasure after navigation transitions.
+
+static const CGFloat kApolloTitleCapsuleHorizontalPadding = 14.0;
+static const CGFloat kApolloTitleButtonSpacing = 8.0;
 
 @interface _UINavigationBarTitleControl : UIControl
 @end
@@ -820,37 +815,16 @@ static UIView *ApolloFindJumpBar(UIView *root) {
     return nil;
 }
 
-// JumpBar is a Swift class (_TtC6Apollo7JumpBar), so its ivars are NOT all plain
-// strong ObjC object pointers: a `weak var` stores a side-table pointer and a
-// non-class-typed property stores inline value bits. `object_getIvar` is declared
-// to return `id`, so ARC retains whatever it finds — retaining those bits is an
-// immediate EXC_BAD_ACCESS at a nonsense address (issue #893: iPad launch,
-// fault address 0x103ba258720, straight out of objc_retain).
-//
-// Read the slot as raw memory instead, and only hand it back as an object once
-// it looks like one: strong-object type encoding, pointer-aligned, and a class
-// pointer the runtime actually recognizes. Anything else reads as "absent",
-// which is exactly how the callers already treat a nil ivar.
-static id ApolloJumpBarObjectIvar(UIView *jumpBar, const char *name) {
-    if (!jumpBar || !name) return nil;
-    Ivar ivar = class_getInstanceVariable(jumpBar.class, name);
-    if (!ivar) return nil;
-
-    // Swift weak/unowned and value-typed ivars do not carry a plain '@' encoding.
-    const char *encoding = ivar_getTypeEncoding(ivar);
-    if (!encoding || encoding[0] != '@' || encoding[1] == '?') return nil;
-
-    ptrdiff_t offset = ivar_getOffset(ivar);
-    if (offset <= 0) return nil;
-    void *slot = (__bridge void *)jumpBar;
-    uintptr_t raw = *(uintptr_t *)((uint8_t *)slot + offset);
-    if (raw == 0 || (raw & (sizeof(void *) - 1)) != 0) return nil;
-
-    // Past the encoding gate the slot is a plain strong object pointer, so it is
-    // either nil (handled above) or a live object — no further probing needed.
-    // Deliberately no isa validation here: dereferencing a candidate to check it
-    // is the very thing that would fault if we were wrong.
-    return (__bridge __unsafe_unretained id)(void *)raw;
+// Use the view tree: Swift Optional/weak ivar storage is unsafe to read as an
+// object and caused the iPad crash in #893.
+static UITextField *ApolloVisibleTitleSearchField(UIView *root) {
+    if (!root || root.hidden || root.alpha < 0.01) return nil;
+    if ([root isKindOfClass:UITextField.class]) return (UITextField *)root;
+    for (UIView *child in root.subviews) {
+        UITextField *field = ApolloVisibleTitleSearchField(child);
+        if (field) return field;
+    }
+    return nil;
 }
 
 // Whether the JumpBar is in "type a subreddit name" mode. Apollo swaps the name
@@ -858,10 +832,53 @@ static id ApolloJumpBarObjectIvar(UIView *jumpBar, const char *name) {
 // label's text — it only hides it — so anything measuring that label has to
 // check this first or it sizes the bar to invisible content.
 static BOOL ApolloJumpBarIsSearching(UIView *jumpBar) {
-    id searchField = ApolloJumpBarObjectIvar(jumpBar, "searchTextField");
-    if (![searchField isKindOfClass:UIView.class]) return NO;
-    UIView *field = (UIView *)searchField;
-    return !field.hidden && field.alpha > 0.01;
+    return ApolloVisibleTitleSearchField(jumpBar) != nil;
+}
+
+// Apollo sizes this non-autoresizing editor from the old title width. Refit
+// the native field and suffix to the final capsule without calling
+// searchTextFieldChanged:, which would also query the search delegate.
+static void ApolloLayoutJumpBarSearchContent(UIView *jumpBar) {
+    UITextField *field = ApolloVisibleTitleSearchField(jumpBar);
+    if (!field || field.superview != jumpBar) return;
+    CGRect bounds = jumpBar.bounds;
+    // The glass has an 8pt outer inset; give text another 12pt of breathing room.
+    CGFloat inset = MIN(20.0, CGRectGetWidth(bounds) / 2.0);
+    CGRect content = CGRectInset(bounds, inset, 0);
+    CGFloat available = MAX(0.0, CGRectGetWidth(content));
+    UIFont *font = field.font ?: [UIFont systemFontOfSize:17.0];
+    NSDictionary *attributes = @{NSFontAttributeName:font};
+    UILabel *suffix = nil;
+    for (UIView *child in jumpBar.subviews) {
+        if ([child isKindOfClass:UILabel.class] && !child.hidden && child.alpha > 0.01 &&
+            ((UILabel *)child).text.length > 0) {
+            suffix = (UILabel *)child;
+            break;
+        }
+    }
+
+    CGRect frame = content;
+    if (field.text.length == 0) {
+        CGFloat width = [(field.placeholder ?: @"") sizeWithAttributes:attributes].width + 1.0;
+        frame.size.width = MIN(available, ceil(width));
+        frame.origin.x = CGRectGetMidX(content) - frame.size.width / 2.0;
+    } else if (suffix && field.textAlignment == NSTextAlignmentRight) {
+        // Center the right-aligned prefix and separate suffix label as a pair.
+        CGFloat typedWidth = MIN(available, ceil([field.text sizeWithAttributes:attributes].width));
+        CGFloat gap = MIN(1.0, MAX(0.0, available - typedWidth));
+        CGFloat suffixWidth = MIN(MAX(0.0, suffix.intrinsicContentSize.width),
+                                  MAX(0.0, available - typedWidth - gap));
+        CGFloat total = typedWidth + gap + suffixWidth;
+        frame.origin.x = CGRectGetMidX(content) - total / 2.0;
+        frame.size.width = typedWidth;
+        CGRect suffixFrame = suffix.frame;
+        suffixFrame.origin.x = CGRectGetMaxX(frame) + gap;
+        suffixFrame.size.width = suffixWidth;
+        if (!CGRectEqualToRect(suffix.frame, suffixFrame)) suffix.frame = suffixFrame;
+    }
+    // With no suggestion Apollo already centers the text in a full-width
+    // field. Preserve that alignment, but keep its editing/caret area padded.
+    if (!CGRectEqualToRect(field.frame, frame)) field.frame = frame;
 }
 
 static BOOL ApolloViewIsProfileNavTitleView(UIView *view) {
@@ -900,7 +917,8 @@ static UILabel *ApolloProfileNavigationTitleLabel(UIView *root) {
     return nil;
 }
 
-static BOOL ApolloRecenterTitleControl(UIView *titleControl);
+@class ApolloNavigationTitleGlassController;
+static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *controller);
 
 @interface ApolloNavigationTitleGlassController : NSObject
 @property (nonatomic, weak) UIView *titleControl;
@@ -908,6 +926,16 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
 @property (nonatomic, strong) UIVisualEffectView *glassView;
 @property (nonatomic) BOOL refreshScheduled;
 @property (nonatomic) BOOL observationValid;
+@property (nonatomic) BOOL preservesNativeSearchLayout;
+@property (nonatomic, strong) NSLayoutConstraint *fittedWidthConstraint;
+@property (nonatomic) CGFloat appliedTranslationX;
+@property (nonatomic) CGFloat appliedTranslationY;
+@property (nonatomic) CGAffineTransform lastAppliedTransform;
+@property (nonatomic, strong) CALayer *overflowMask;
+@property (nonatomic, strong) CALayer *previousMask;
+@property (nonatomic) CGRect overflowClipRect;
+@property (nonatomic, weak) id<UIViewControllerTransitionCoordinator> pendingTransition;
+@property (nonatomic, weak) id<UIViewControllerTransitionCoordinator> completedTransition;
 // Set by ApolloNavigationTitleGlassRefreshNavigationBar: the next capsule install fades in
 // instead of appearing, because it lands right as an interactive transition settles.
 @property (nonatomic) BOOL fadeNextInstall;
@@ -918,6 +946,10 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
 @property (nonatomic) CGRect observedJumpBarBounds;
 @property (nonatomic) NSUInteger observedJumpBarSubviewCount;
 @property (nonatomic) BOOL observedSearching;
+@property (nonatomic) CFTimeInterval searchMorphDeadline;
+@property (nonatomic, weak) UITextField *revealingSearchField;
+@property (nonatomic) BOOL actionsMotionCaptured;
+@property (nonatomic) CGPoint actionsMotionStart;
 // Read-only frame fold over the whole bar subtree: the recenter's output
 // depends on SIBLING bar-item geometry (left/right content limits), so a
 // trailing pill appearing/disappearing must break the "unchanged" gate even
@@ -929,6 +961,11 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
 - (void)scheduleTargetRefresh;
 - (void)scheduleTargetRefreshIfNeeded;
 - (void)invalidate;
+- (void)resetContentPlacementPreservingActionsMotion:(BOOL)preserve;
+- (NSArray<UIView *> *)titleContentViews;
+- (CGRect)contentFrameInView:(UIView *)view;
+- (CGFloat)naturalContentWidth;
+- (void)applyOverflowClip:(CGRect)rect;
 @end
 
 @implementation ApolloNavigationTitleGlassController
@@ -946,10 +983,137 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
 }
 
 - (void)invalidate {
+    [self resetContentPlacementPreservingActionsMotion:NO];
+    self.fittedWidthConstraint.active = NO;
+    self.fittedWidthConstraint = nil;
     [self.glassView removeFromSuperview];
     self.glassView = nil;
     self.glassHostView = nil;
+    self.searchMorphDeadline = 0;
+    [self.revealingSearchField.layer removeAnimationForKey:@"ApolloJumpBarSearchReveal"];
+    self.revealingSearchField = nil;
+}
+
+- (void)resetContentPlacementPreservingActionsMotion:(BOOL)preserve {
+    [self applyOverflowClip:CGRectNull];
+    if (!preserve) {
+        [self.titleControl.layer removeAnimationForKey:@"ApolloNavigationTitleActionsShiftX"];
+        [self.titleControl.layer removeAnimationForKey:@"ApolloNavigationTitleActionsShiftY"];
+        self.actionsMotionCaptured = NO;
+    }
+    // Remove only our correction when reusing a title control; preserve any
+    // transform UIKit replaced during the navigation transition.
+    UIView *titleControl = self.titleControl;
+    CGAffineTransform transform = titleControl.transform;
+    if (CGAffineTransformEqualToTransform(transform, self.lastAppliedTransform)) {
+        transform.tx -= self.appliedTranslationX;
+        transform.ty -= self.appliedTranslationY;
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        titleControl.transform = transform;
+        [CATransaction commit];
+    }
+    self.appliedTranslationX = 0;
+    self.appliedTranslationY = 0;
+    self.lastAppliedTransform = titleControl.transform;
     self.observationValid = NO;
+}
+
+- (void)applyOverflowClip:(CGRect)rect {
+    UIView *title = self.titleControl;
+    if (CGRectIsNull(rect)) {
+        if (self.overflowMask && title.layer.mask == self.overflowMask) {
+            title.layer.mask = self.previousMask;
+        }
+        self.overflowMask = nil;
+        self.previousMask = nil;
+        self.overflowClipRect = CGRectNull;
+        return;
+    }
+    // Clip custom content that ignores the fitted width. An exhausted gap gets
+    // an empty mask so neither the content nor its capsule can overhang.
+    if (!self.overflowMask) {
+        self.previousMask = title.layer.mask;
+        self.overflowMask = [CALayer layer];
+        self.overflowMask.backgroundColor = UIColor.whiteColor.CGColor;
+    }
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    self.overflowMask.frame = rect;
+    title.layer.mask = self.overflowMask;
+    [CATransaction commit];
+    self.overflowClipRect = rect;
+}
+
+- (NSArray<UIView *> *)titleContentViews {
+    NSMutableArray<UIView *> *views = [NSMutableArray array];
+    ApolloCollectNavigationTitleContent(self.titleControl, self.glassView, views, NO);
+    return views;
+}
+
+- (CGRect)contentFrameInView:(UIView *)coordinateView {
+    UIView *jumpBar = ApolloFindJumpBar(self.titleControl);
+    if (jumpBar && ApolloJumpBarIsSearching(jumpBar)) {
+        // Center the search FIELD, not just the characters currently typed.
+        return [jumpBar convertRect:CGRectInset(jumpBar.bounds, 8.0, 0) toView:coordinateView];
+    }
+    CGRect result = CGRectNull;
+    UILabel *profileLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
+    for (UIView *view in [self titleContentViews]) {
+        if (view.hidden || (view != profileLabel && view.alpha < 0.01) ||
+            CGRectIsEmpty(view.bounds)) continue;
+        CGRect rect = [view convertRect:view.bounds toView:coordinateView];
+        result = CGRectIsNull(result) ? rect : CGRectUnion(result, rect);
+    }
+    return result;
+}
+
+- (CGFloat)naturalContentWidth {
+    // Alpha-only fades do not change natural size; hidden children are absent.
+    NSMutableArray<UIView *> *views = [NSMutableArray array];
+    ApolloCollectNavigationTitleContent(self.titleControl, self.glassView, views, YES);
+    CGFloat textWidth = 0;
+    CGFloat decorationWidth = 0;
+    NSUInteger decorationCount = 0;
+    for (UIView *view in views) {
+        if ([view isKindOfClass:UILabel.class]) {
+            // Stacked title lines use the widest intrinsic line, not their sum.
+            CGFloat width = ((UILabel *)view).intrinsicContentSize.width;
+            if (isfinite(width) && width > 0) textWidth = MAX(textWidth, width);
+        } else if ([view isKindOfClass:UITextField.class]) {
+            CGFloat width = view.intrinsicContentSize.width;
+            if (isfinite(width) && width > 0) textWidth = MAX(textWidth, width);
+        } else if ([view isKindOfClass:UIImageView.class]) {
+            UIImageView *imageView = (UIImageView *)view;
+            // Ignore empty placeholders; intrinsic size survives squeezed frames.
+            if (!imageView.image && !imageView.highlightedImage) continue;
+            CGFloat width = imageView.intrinsicContentSize.width;
+            if (!isfinite(width) || width <= 0) {
+                width = (imageView.image ?: imageView.highlightedImage).size.width;
+            }
+            if (isfinite(width) && width > 0) {
+                decorationWidth += width;
+                decorationCount++;
+            }
+        }
+    }
+    // Use the native 6pt chevron gap. Post-truncation frames would feed the
+    // previous fitting result back into the next natural-width calculation.
+    NSUInteger spacingCount = decorationCount > 0
+        ? decorationCount - (textWidth > 0 ? 0 : 1) : 0;
+    CGFloat width = textWidth + decorationWidth + 6.0 * spacingCount;
+
+    // Measure this control's custom view, not the possibly incoming screen's.
+    // Composite controls supply their own intrinsic width; the caller caps it.
+    SEL titleViewSelector = NSSelectorFromString(@"titleView");
+    UIView *custom = [self.titleControl respondsToSelector:titleViewSelector]
+        ? ((id (*)(id, SEL))objc_msgSend)(self.titleControl, titleViewSelector) : nil;
+    if ([custom isKindOfClass:UIView.class] && !custom.hidden &&
+        [custom isDescendantOfView:self.titleControl]) {
+        CGFloat customWidth = custom.intrinsicContentSize.width;
+        if (isfinite(customWidth) && customWidth > 0) width = MAX(width, customWidth);
+    }
+    return isfinite(width) && width > 0 ? width : 0;
 }
 
 - (UIVisualEffectView *)newRegularGlassView {
@@ -988,7 +1152,7 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         // field spanning the gap between the leading and trailing bar buttons.
         CGRect bounds = hostView.bounds;
         if (CGRectGetWidth(bounds) <= 0 || CGRectGetHeight(bounds) <= 0) return CGRectNull;
-        id field = ApolloJumpBarObjectIvar(hostView, "searchTextField");
+        UITextField *field = ApolloVisibleTitleSearchField(hostView);
         CGFloat lineHeight = 0;
         if ([field isKindOfClass:UITextField.class]) {
             lineHeight = ceil(((UITextField *)field).font.lineHeight);
@@ -1019,7 +1183,7 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         // UINavigationBar title controls are often only as wide as their label.
         // Permit overhang so the capsule retains real padding instead of
         // collapsing to a plain title label's intrinsic width and height.
-        frame = CGRectInset(contentFrame, -14.0, -kVerticalPadding);
+        frame = CGRectInset(contentFrame, -kApolloTitleCapsuleHorizontalPadding, -kVerticalPadding);
     }
 
     CGFloat scale = hostView.window.screen.scale ?: UIScreen.mainScreen.scale;
@@ -1061,7 +1225,9 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         // at partial alpha and not yet at its settled position. A capsule installed now reads
         // as a translucent bubble floating beside the current title (cancelled swipe on the
         // feed). Skip it; the transition's completion refreshes the bar and installs it then.
-        if (ApolloNavTransitionInFlight()) return;
+        // Our owned title is not a cross-fade copy; install its capsule immediately.
+        BOOL ownsTitle = ApolloNavigationTitlePresentationOwnsControl(self.titleControl);
+        if (!ownsTitle && ApolloNavTransitionInFlight()) return;
         self.glassView = [self newRegularGlassView];
         if (!self.glassView) return;
         self.glassView.frame = targetFrame;
@@ -1069,8 +1235,9 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         CGFloat targetAlpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
         self.glassView.alpha = targetAlpha;
         [hostView insertSubview:self.glassView atIndex:0];
-        if (self.fadeNextInstall) {
-            self.fadeNextInstall = NO;
+        BOOL fadeInstall = self.fadeNextInstall && !ownsTitle;
+        self.fadeNextInstall = NO;
+        if (fadeInstall) {
             UIVisualEffectView *installed = self.glassView;
             installed.alpha = 0.0;
             [UIView animateWithDuration:0.2 delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState
@@ -1081,26 +1248,28 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         return;
     }
 
-    if (hostView.subviews.firstObject != self.glassView) {
+    // UIKit can rebuild the children without replacing this controller.
+    // Reattach the capsule before treating its unchanged frame as settled.
+    if (self.glassView.superview != hostView) {
+        [hostView insertSubview:self.glassView atIndex:0];
+    } else if (hostView.subviews.firstObject != self.glassView) {
         [hostView sendSubviewToBack:self.glassView];
     }
     UILabel *profileTitleLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
     self.glassView.alpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
     if (CGRectEqualToRect(self.glassView.frame, targetFrame)) return;
-    // UIKit already animates the containing navigation transition. A second,
-    // independently timed frame animation made the capsule visibly trail the
-    // title and continuously retarget during interactive pushes.
+    // UIKit animates the parent; a separate capsule animation would lag behind.
     self.glassView.frame = targetFrame;
 }
 
-// Read-only, depth/count-capped fold of every visible descendant frame under
-// the enclosing navigation bar (pills sit ~5-6 levels deep on Liquid Glass).
-// Frame reads only — a few microseconds — versus the frame conversions, bar
-// scan, transform writes and sizeThatFits passes this gate exists to avoid.
-static void ApolloFoldBarContentFingerprint(UIView *view, NSUInteger depth,
+// Bound the frame scan and reuse one ownership snapshot to avoid rediscovery
+// for every descendant when deciding whether fitting needs to run.
+static void ApolloFoldBarContentFingerprint(UIView *view, NSArray<UIView *> *managedRoots, NSUInteger depth,
                                             NSUInteger *count, NSUInteger *hash) {
     if (depth > 8 || *count > 120) return;
     for (UIView *child in view.subviews) {
+        if (ApolloNavigationActionsViewIsInManagedRoots(child, managedRoots) ||
+            [child isKindOfClass:UIVisualEffectView.class]) continue;
         if (child.hidden || child.alpha < 0.01) continue;
         (*count)++;
         CGRect f = child.frame;
@@ -1109,7 +1278,7 @@ static void ApolloFoldBarContentFingerprint(UIView *view, NSUInteger depth,
                      | (((NSUInteger)lround(f.size.width * 2.0) & 0xFFF) << 24)
                      | (((NSUInteger)lround(f.size.height * 2.0) & 0xFFF) << 36);
         *hash = (*hash * 1099511628211ULL) ^ h;
-        ApolloFoldBarContentFingerprint(child, depth + 1, count, hash);
+        ApolloFoldBarContentFingerprint(child, managedRoots, depth + 1, count, hash);
     }
 }
 
@@ -1121,57 +1290,155 @@ static NSUInteger ApolloNavigationBarContentFingerprint(UIView *titleControl) {
     if (!bar) return 0;
     NSUInteger hash = 1469598103934665603ULL;
     NSUInteger count = 0;
-    ApolloFoldBarContentFingerprint(bar, 0, &count, &hash);
+    NSArray<UIView *> *managedRoots = ApolloNavigationActionsManagedRoots(bar);
+    ApolloFoldBarContentFingerprint(bar, managedRoots, 0, &count, &hash);
+    // Exclude action contents but track their final edge for collision updates.
+    CGRect expanded = ApolloNavigationActionsExpandedFrame(bar);
+    if (!CGRectIsNull(expanded) && !CGRectIsEmpty(expanded)) {
+        hash = (hash * 1099511628211ULL) ^ (NSUInteger)lround(CGRectGetMinX(expanded) * 2.0);
+    }
     return hash ^ (count << 1);
 }
 
-// Text/font identity of the JumpBar's name label: the capsule and the
-// content-sized width are measured from it, and a text or Dynamic Type font
-// change can re-lay the label inside an unchanged JumpBar frame.
-static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
-    if (!jumpBar) return 0;
-    id nameLabel = ApolloJumpBarObjectIvar(jumpBar, "nameLabel");
-    if (![nameLabel isKindOfClass:UILabel.class]) return 0;
-    UILabel *label = (UILabel *)nameLabel;
-    return label.text.hash ^ (NSUInteger)lround(label.font.pointSize * 4.0);
+// Detect content changes inside unchanged wrappers without logging title text.
+// Like natural fitting, ignore alpha fades but track hidden/unhidden changes.
+static NSUInteger ApolloNavigationTitleContentMetricExcludingView(UIView *view, UIView *excluded) {
+    if (!view || view == excluded) return 0;
+    if (view.hidden) return 0x9E3779B9;
+    CGSize intrinsic = view.intrinsicContentSize;
+    NSUInteger metric = [@(isfinite(intrinsic.width) ? intrinsic.width : 0) hash];
+    metric = metric * 31 + [@(isfinite(intrinsic.height) ? intrinsic.height : 0) hash];
+    if ([view isKindOfClass:UILabel.class]) {
+        UILabel *label = (UILabel *)view;
+        metric = metric * 31 + label.text.hash;
+        metric = metric * 31 + label.font.hash;
+        metric = metric * 31 + label.attributedText.hash;
+    } else if ([view isKindOfClass:UITextField.class]) {
+        UITextField *field = (UITextField *)view;
+        metric = metric * 31 + field.text.hash;
+        metric = metric * 31 + field.font.hash;
+        metric = metric * 31 + field.attributedText.hash;
+        metric = metric * 31 + field.placeholder.hash;
+    } else if ([view isKindOfClass:UIImageView.class]) {
+        UIImageView *imageView = (UIImageView *)view;
+        metric = metric * 31 + imageView.image.hash;
+        metric = metric * 31 + imageView.highlightedImage.hash;
+    }
+    for (UIView *child in view.subviews) {
+        if (child == excluded) continue;
+        metric = metric * 31 + ApolloNavigationTitleContentMetricExcludingView(child, excluded);
+    }
+    return metric;
+}
+
+static NSUInteger ApolloNavigationTitleContentMetric(UIView *view) {
+    ApolloNavigationTitleGlassController *controller =
+        objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
+    return ApolloNavigationTitleContentMetricExcludingView(view, controller.glassView);
+}
+
+// Preserve native UISearchBar sizing. JumpBar's inline editor still uses our
+// centered capsule, unlike the Search tab's full-width input.
+BOOL ApolloNavigationTitleContainsNativeSearchSurface(UIView *view) {
+    // A native input temporarily hidden during a transition is still an input;
+    // never install a title-width constraint merely because UIKit faded it out.
+    if (!view) return NO;
+    if ([NSStringFromClass(view.class) isEqualToString:@"Apollo.JumpBar"]) return NO;
+    if ([view isKindOfClass:UISearchBar.class]) return YES;
+    for (UIView *child in view.subviews) {
+        if (ApolloNavigationTitleContainsNativeSearchSurface(child)) return YES;
+    }
+    return NO;
 }
 
 - (void)refreshTargets {
+    // Fitting a suppressed native source would create a preferred-size loop
+    // with the owned title that replaced it.
+    if (ApolloNavigationTitlePresentationSuppressesControl(self.titleControl)) {
+        [self invalidate];
+        if (objc_getAssociatedObject(self.titleControl, &kApolloNavigationTitleGlassControllerKey) == self) {
+            objc_setAssociatedObject(self.titleControl, &kApolloNavigationTitleGlassControllerKey,
+                                     nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        return;
+    }
     UIView *jumpBar = ApolloFindJumpBar(self.titleControl);
     UIView *hostView = jumpBar ?: self.titleControl;
-    NSMutableArray<UIView *> *glassCandidates = [NSMutableArray array];
 
-    // Recenter outside layoutSubviews. It can resize JumpBar and transform the
-    // title control, both of which are layout-driving writes that must not feed
-    // back into UIKit's active navigation-bar pass. When it BAILS (mid push/pop
-    // animation, bar not resolvable yet) the observations below must not latch:
-    // the old code recovered from a skipped recenter by re-running every layout
-    // pass, and latching "unchanged" against geometry the recenter never
-    // processed would leave the title off-center until the next real change.
-    //
-    // Runs unconditionally now: gap-centering re-measures the trailing pill
-    // every pass, so the translation globe appearing/disappearing is simply a
-    // new gap. The old `!sEnableBulkTranslation` bail existed because absolute
-    // bar-centering overlapped the widened pill (#178) — and it is exactly what
-    // left titles off-center whenever bulk translation was on (#200).
-    BOOL recenterSettled = ApolloRecenterTitleControl(self.titleControl);
-
-    if (jumpBar) {
-        const char *ivarNames[] = {
-            "nameLabel", "secondaryLabel", "suggestionLabel", "arrowImageView", "searchTextField"
-        };
-        for (NSUInteger i = 0; i < sizeof(ivarNames) / sizeof(ivarNames[0]); i++) {
-            id candidate = ApolloJumpBarObjectIvar(jumpBar, ivarNames[i]);
-            if ([candidate isKindOfClass:UIView.class]) [glassCandidates addObject:candidate];
+    if (ApolloNavigationTitleContainsNativeSearchSurface(self.titleControl)) {
+        if (!self.preservesNativeSearchLayout) {
+            // Clear the preceding title's layout once, without a cleanup loop.
+            self.preservesNativeSearchLayout = YES;
+            [self invalidate];
         }
-    } else {
-        // Plain titles, profile titles, and Apollo's dual-label title buttons
-        // all ultimately expose their visible label/image content here.
-        ApolloCollectNavigationTitleContent(self.titleControl, self.glassView,
-                                            glassCandidates, NO);
+        // Cache observations so unchanged search layouts do not queue cleanup.
+        self.observedTitleFrame = self.titleControl.frame;
+        self.observedTitleBounds = self.titleControl.bounds;
+        self.observedTitleSubviewCount = self.titleControl.subviews.count;
+        self.observedJumpBar = jumpBar;
+        self.observedJumpBarBounds = jumpBar.bounds;
+        self.observedJumpBarSubviewCount = jumpBar.subviews.count;
+        self.observedSearching = ApolloJumpBarIsSearching(jumpBar);
+        self.observedBarFingerprint = ApolloNavigationBarContentFingerprint(self.titleControl);
+        self.observedContentMetric = ApolloNavigationTitleContentMetric(self.titleControl);
+        self.observationValid = YES;
+        return;
+    }
+    self.preservesNativeSearchLayout = NO;
+
+    // Search's Cancel/globe allocation settles over several frames on iOS 27.
+    // Morph from the displayed bar-space frame to avoid width jumps; exclude
+    // push/pop transitions and Reduce Motion.
+    BOOL searching = ApolloJumpBarIsSearching(jumpBar);
+    BOOL navigating = ApolloOwningTopViewController(self.titleControl).transitionCoordinator.isAnimated;
+    if (navigating || UIAccessibilityIsReduceMotionEnabled()) self.searchMorphDeadline = 0;
+    if (self.observationValid && jumpBar && jumpBar == self.observedJumpBar &&
+        searching != self.observedSearching && !navigating && !UIAccessibilityIsReduceMotionEnabled()) {
+        self.searchMorphDeadline = CACurrentMediaTime() + 0.3;
+        [self.revealingSearchField.layer removeAnimationForKey:@"ApolloJumpBarSearchReveal"];
+        self.revealingSearchField = searching ? ApolloVisibleTitleSearchField(jumpBar) : nil;
+        if (self.revealingSearchField && self.glassView) {
+            // Reveal text as the narrow capsule opens, preserving model alpha.
+            CAKeyframeAnimation *reveal = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
+            reveal.values = @[@(-1.0), @(-1.0), @0.0];
+            reveal.keyTimes = @[@0.0, @0.5, @1.0];
+            reveal.duration = 0.3;
+            reveal.additive = YES;
+            [self.revealingSearchField.layer addAnimation:reveal forKey:@"ApolloJumpBarSearchReveal"];
+        }
+    }
+    UIView *bar = self.titleControl.superview;
+    while (bar && ![bar isKindOfClass:UINavigationBar.class]) bar = bar.superview;
+    UIVisualEffectView *oldGlass = self.glassView;
+    CGRect oldGlassFrame = CGRectNull;
+    if (bar && oldGlass.window && CACurrentMediaTime() < self.searchMorphDeadline) {
+        CALayer *presentation = oldGlass.layer.presentationLayer;
+        CALayer *barPresentation = bar.layer.presentationLayer;
+        oldGlassFrame = presentation && barPresentation
+            ? [presentation convertRect:presentation.bounds toLayer:barPresentation]
+            : [oldGlass convertRect:oldGlass.bounds toView:bar];
     }
 
-    [self updateGlassForHostView:hostView candidateViews:glassCandidates];
+    // Constrain/transform outside layoutSubviews to avoid a layout loop. Cache
+    // observations only after recentering succeeds, so skipped work retries.
+    BOOL recenterSettled = ApolloRecenterTitleControl(self);
+    if (recenterSettled && jumpBar) ApolloLayoutJumpBarSearchContent(jumpBar);
+    [self updateGlassForHostView:hostView candidateViews:[self titleContentViews]];
+    if (!CGRectIsNull(oldGlassFrame) && self.glassView == oldGlass && oldGlass.superview == hostView) {
+        CGRect target = oldGlass.frame;
+        CGRect start = [bar convertRect:oldGlassFrame toView:hostView];
+        if (!CGRectEqualToRect(start, target)) {
+            // The host itself just changed width/origin. Rebase before
+            // animating so that transform is not counted a second time.
+            [oldGlass.layer removeAnimationForKey:@"position"];
+            [oldGlass.layer removeAnimationForKey:@"bounds"];
+            [UIView performWithoutAnimation:^{ oldGlass.frame = start; }];
+            [UIView animateWithDuration:MAX(0.08, self.searchMorphDeadline - CACurrentMediaTime())
+                                  delay:0 options:UIViewAnimationOptionBeginFromCurrentState |
+                                      UIViewAnimationOptionAllowUserInteraction | UIViewAnimationOptionCurveEaseOut
+                             animations:^{ oldGlass.frame = target; } completion:nil];
+        }
+    }
 
     self.observedTitleFrame = self.titleControl.frame;
     self.observedTitleBounds = self.titleControl.bounds;
@@ -1181,7 +1448,7 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
     self.observedJumpBarSubviewCount = jumpBar.subviews.count;
     self.observedSearching = ApolloJumpBarIsSearching(jumpBar);
     self.observedBarFingerprint = ApolloNavigationBarContentFingerprint(self.titleControl);
-    self.observedContentMetric = ApolloJumpBarContentMetric(jumpBar);
+    self.observedContentMetric = ApolloNavigationTitleContentMetric(self.titleControl);
     // A bailed recenter leaves the gate open so the next layout pass retries.
     self.observationValid = recenterSettled;
 }
@@ -1201,8 +1468,14 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
 - (void)scheduleTargetRefreshIfNeeded {
     UIView *titleControl = self.titleControl;
     if (!titleControl) return;
+    if (ApolloNavigationTitlePresentationSuppressesControl(titleControl)) {
+        if (self.fittedWidthConstraint || self.glassView) [self scheduleTargetRefresh];
+        return;
+    }
     UIView *jumpBar = ApolloFindJumpBar(titleControl);
     BOOL unchanged = self.observationValid &&
+        (!self.glassView || (self.glassHostView && self.glassView.superview == self.glassHostView)) &&
+        self.preservesNativeSearchLayout == ApolloNavigationTitleContainsNativeSearchSurface(titleControl) &&
         CGRectEqualToRect(self.observedTitleFrame, titleControl.frame) &&
         CGRectEqualToRect(self.observedTitleBounds, titleControl.bounds) &&
         self.observedTitleSubviewCount == titleControl.subviews.count &&
@@ -1211,14 +1484,119 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
         self.observedJumpBarSubviewCount == jumpBar.subviews.count &&
         self.observedSearching == ApolloJumpBarIsSearching(jumpBar) &&
         self.observedBarFingerprint == ApolloNavigationBarContentFingerprint(titleControl) &&
-        self.observedContentMetric == ApolloJumpBarContentMetric(jumpBar);
+        self.observedContentMetric == ApolloNavigationTitleContentMetric(titleControl);
     if (!unchanged) [self scheduleTargetRefresh];
 }
 
 @end
 
+static void ApolloAnimateTitleActionsTranslation(UIView *titleControl, CGPoint start,
+                                                CASpringAnimation *spring) {
+    CALayer *layer = titleControl.layer;
+    [layer removeAnimationForKey:@"ApolloNavigationTitleActionsShiftX"];
+    [layer removeAnimationForKey:@"ApolloNavigationTitleActionsShiftY"];
+    if (!spring || UIAccessibilityIsReduceMotionEnabled()) return;
+    CGPoint end = CGPointMake(layer.transform.m41, layer.transform.m42);
+    CGFloat distances[] = {start.x - end.x, start.y - end.y};
+    NSArray *paths = @[@"transform.translation.x", @"transform.translation.y"];
+    NSArray *keys = @[@"ApolloNavigationTitleActionsShiftX", @"ApolloNavigationTitleActionsShiftY"];
+    for (NSUInteger axis = 0; axis < 2; axis++) {
+        if (!isfinite(distances[axis]) || fabs(distances[axis]) < 0.1) continue;
+        // Retarget with the committed spring's physics, not its playback state.
+        CASpringAnimation *motion = [CASpringAnimation animationWithKeyPath:paths[axis]];
+        motion.mass = spring.mass;
+        motion.stiffness = spring.stiffness;
+        motion.damping = spring.damping;
+        motion.initialVelocity = spring.initialVelocity;
+        motion.duration = spring.duration;
+        motion.fromValue = @(distances[axis]);
+        motion.toValue = @0;
+        motion.additive = YES;
+        motion.beginTime = 0;
+        [layer addAnimation:motion forKey:keys[axis]];
+    }
+}
+
+void ApolloNavigationTitleGlassRefreshContent(UIView *titleControl, BOOL sameItem) {
+    if (!IsLiquidGlass() || !titleControl.window ||
+        !ApolloNavigationTitlePresentationOwnsControl(titleControl)) return;
+    ApolloNavigationTitleGlassController *controller =
+        objc_getAssociatedObject(titleControl, &kApolloNavigationTitleGlassControllerKey);
+    if (!controller) {
+        controller = [[ApolloNavigationTitleGlassController alloc] initWithTitleControl:titleControl];
+        objc_setAssociatedObject(titleControl, &kApolloNavigationTitleGlassControllerKey,
+                                 controller, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    // Same-page title updates retain the pill spring; page changes discard it.
+    CALayer *layer = titleControl.layer;
+    CASpringAnimation *motion = sameItem ?
+        (id)[layer animationForKey:@"ApolloNavigationTitleActionsShiftX"] : nil;
+    CATransform3D previousTarget = layer.transform;
+    CATransform3D displayed = (layer.presentationLayer ?: layer).transform;
+    CGPoint start = CGPointMake(displayed.m41, displayed.m42);
+    [controller resetContentPlacementPreservingActionsMotion:sameItem];
+    UIView *bar = titleControl.superview;
+    while (bar && ![bar isKindOfClass:UINavigationBar.class]) bar = bar.superview;
+    // Outside layoutSubviews, resolve placement before measuring the new title.
+    [bar setNeedsLayout];
+    [bar layoutIfNeeded];
+    [controller refreshTargets];
+    // Keep the spring's clock/velocity unless fitting changed its endpoint.
+    CATransform3D target = layer.transform;
+    if ([motion isKindOfClass:CASpringAnimation.class] &&
+        (fabs(previousTarget.m41 - target.m41) > 0.1 || fabs(previousTarget.m42 - target.m42) > 0.1)) {
+        ApolloAnimateTitleActionsTranslation(titleControl, start, motion);
+    }
+}
+
+static NSArray<ApolloNavigationTitleGlassController *> *ApolloActionTitleControllers(UINavigationBar *bar) {
+    NSMutableArray *result = [NSMutableArray array];
+    if (!IsLiquidGlass() || !bar.window) return result;
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:bar];
+    for (NSUInteger i = 0; i < queue.count; i++) {
+        UIView *view = queue[i];
+        if (ApolloNavigationTitlePresentationOwnsControl(view)) {
+            id controller = objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
+            if (controller) [result addObject:controller];
+            continue;
+        }
+        [queue addObjectsFromArray:view.subviews];
+    }
+    return result;
+}
+
+void ApolloNavigationTitleActionsWillChange(UINavigationBar *bar) {
+    for (ApolloNavigationTitleGlassController *controller in ApolloActionTitleControllers(bar)) {
+        CALayer *layer = controller.titleControl.layer;
+        CATransform3D displayed = (layer.presentationLayer ?: layer).transform;
+        controller.actionsMotionStart = CGPointMake(displayed.m41, displayed.m42);
+        controller.actionsMotionCaptured = YES;
+    }
+}
+
+void ApolloNavigationTitleActionsDidChange(UINavigationBar *bar, CASpringAnimation *spring) {
+    for (ApolloNavigationTitleGlassController *controller in ApolloActionTitleControllers(bar)) {
+        // Animate from the pre-layout visible position to the final model
+        // position, without per-frame constraint or frame writes.
+        BOOL captured = controller.actionsMotionCaptured;
+        CGPoint start = controller.actionsMotionStart;
+        controller.actionsMotionCaptured = NO;
+        [UIView performWithoutAnimation:^{
+            [bar layoutIfNeeded];
+            [controller refreshTargets];
+        }];
+        ApolloAnimateTitleActionsTranslation(controller.titleControl, start, captured ? spring : nil);
+    }
+}
+
 static void ApolloUpdateNavigationTitleGlass(UIView *titleControl) {
     if (!IsLiquidGlass() || !titleControl.window) return;
+    if (ApolloNavigationTitlePresentationSuppressesControl(titleControl)) {
+        ApolloNavigationTitleGlassController *source =
+            objc_getAssociatedObject(titleControl, &kApolloNavigationTitleGlassControllerKey);
+        [source scheduleTargetRefresh];
+        return;
+    }
 
     ApolloNavigationTitleGlassController *controller =
         objc_getAssociatedObject(titleControl, &kApolloNavigationTitleGlassControllerKey);
@@ -1239,7 +1617,11 @@ void ApolloNavigationTitleGlassRefreshNavigationBar(UINavigationBar *bar) {
             ApolloUpdateNavigationTitleGlass(view);
             ApolloNavigationTitleGlassController *controller =
                 objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
-            if (controller && !controller.glassView) controller.fadeNextInstall = YES;
+            if (controller && !controller.glassView &&
+                !ApolloNavigationTitlePresentationOwnsControl(view) &&
+                !ApolloNavigationTitlePresentationSuppressesControl(view)) {
+                controller.fadeNextInstall = YES;
+            }
             continue;
         }
         for (UIView *child in view.subviews) [queue addObject:child];
@@ -1271,7 +1653,8 @@ void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alph
 // before evaluating (mid push/pop animation, bar not resolvable, zero width) —
 // callers must NOT latch "geometry unchanged" observations against a bail, or
 // the skipped recenter is never retried until the next real geometry change.
-static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
+static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *controller) {
+    UIView *titleControl = controller.titleControl;
     if (!titleControl.window || !titleControl.superview) return NO;
 
     UINavigationBar *bar = nil;
@@ -1280,32 +1663,44 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     }
     if (!bar) return NO;
 
-    // Skip during push/pop so we don't fight UIKit's transition animations. The interruptible
-    // animator on Liquid Glass drives the bar without animation keys on the bar's own layer,
-    // so ask it directly as well.
-    if (bar.layer.animationKeys.count > 0 || ApolloNavTransitionInFlight()) return NO;
-
-    // Measure pre-transform position by subtracting our own previous tx.
-    CGFloat existingTx = titleControl.transform.tx;
-    CGRect frameInBar = [titleControl.superview convertRect:titleControl.frame toView:bar];
-    frameInBar.origin.x -= existingTx;
-
-    CGFloat width = CGRectGetWidth(frameInBar);
-    if (width <= 0) return NO;
-
-    CGFloat unadjustedCenter = CGRectGetMidX(frameInBar);
-
-    // Build a fast set of views to skip when scanning the bar (the title and its
-    // entire descendant tree).
-    NSMutableSet<NSValue *> *titleSubtree = [NSMutableSet set];
-    {
-        NSMutableArray<UIView *> *q = [NSMutableArray arrayWithObject:titleControl];
-        for (NSUInteger index = 0; index < q.count; index++) {
-            UIView *v = q[index];
-            [titleSubtree addObject:[NSValue valueWithNonretainedObject:v]];
-            for (UIView *c in v.subviews) [q addObject:c];
+    UIViewController *topVC = ApolloOwningTopViewController(titleControl);
+    id<UIViewControllerTransitionCoordinator> transition = topVC.transitionCoordinator;
+    if (transition.isAnimated && transition != controller.completedTransition &&
+        !ApolloNavigationTitlePresentationOwnsControl(titleControl)) {
+        // UIKit may animate only nested hosts. Retry explicitly on transition
+        // completion/cancellation instead of relying on another layout pass.
+        if (controller.pendingTransition != transition) {
+            controller.pendingTransition = transition;
+            __weak ApolloNavigationTitleGlassController *weakController = controller;
+            __weak id<UIViewControllerTransitionCoordinator> weakTransition = transition;
+            BOOL registered = [transition animateAlongsideTransition:nil completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                ApolloNavigationTitleGlassController *strongController = weakController;
+                id<UIViewControllerTransitionCoordinator> completed = weakTransition;
+                if (!strongController || strongController.pendingTransition != completed) return;
+                strongController.completedTransition = completed;
+                strongController.pendingTransition = nil;
+                [strongController scheduleTargetRefresh];
+            }];
+            if (!registered) {
+                // NO does not rule out a completion callback. Schedule one
+                // extra check for late registration; the coordinator still
+                // decides whether the transition has ended.
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                    (int64_t)((transition.transitionDuration + 0.05) * NSEC_PER_SEC)),
+                    dispatch_get_main_queue(), ^{ [weakController scheduleTargetRefresh]; });
+            }
         }
+        if (controller.completedTransition != transition) return NO;
     }
+
+    // Preserve upstream's interruptible-transition guard for native titles.
+    // Owned content must still settle when adopted, before its first frame.
+    if (!ApolloNavigationTitlePresentationOwnsControl(titleControl) &&
+        (bar.layer.animationKeys.count > 0 || ApolloNavTransitionInFlight())) return NO;
+
+    // Refit even an empty squeezed title, or the old width cap can persist.
+    CGRect contentFrame = [controller contentFrameInView:bar];
+    CGRect titleBand = [titleControl convertRect:titleControl.bounds toView:bar];
 
     // Walk the bar's view tree to find the nearest visible content edges on
     // either side. Liquid Glass pills are _UINavigationBarPlatterView instances
@@ -1313,24 +1708,36 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     // (don't recurse to the buttons inside, which sit a few points further in).
     // Otherwise recurse into containers (e.g. _UITAMICAdaptorView wrappers) and
     // treat controls / labels / image views / visual-effect bubbles as edges.
-    CGFloat leftLimit = 0;
-    CGFloat rightLimit = CGRectGetWidth(bar.bounds);
-    // Whether a real sibling was actually found on each side, as opposed to
-    // leftLimit/rightLimit just sitting at their empty-bar defaults above —
-    // the centering formula below needs to tell "nothing here" apart from
-    // "content here, and it happens to reach the edge."
-    BOOL foundLeft = NO, foundRight = NO;
+    CGFloat leftLimit = CGRectGetMinX(bar.bounds) + bar.safeAreaInsets.left;
+    CGFloat rightLimit = CGRectGetMaxX(bar.bounds) - bar.safeAreaInsets.right;
+    CGRect collapsedActions = ApolloNavigationActionsCollapsedFrame(bar);
+    if (!CGRectIsNull(collapsedActions)) {
+        if (CGRectGetMidX(collapsedActions) >= CGRectGetMidX(bar.bounds)) {
+            rightLimit = MIN(rightLimit, CGRectGetMinX(collapsedActions));
+        } else {
+            leftLimit = MAX(leftLimit, CGRectGetMaxX(collapsedActions));
+        }
+    }
+    NSArray<UIView *> *managedRoots = ApolloNavigationActionsManagedRoots(bar);
     NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:bar];
     for (NSUInteger index = 0; index < queue.count; index++) {
         UIView *v = queue[index];
         for (UIView *child in v.subviews) {
-            if ([titleSubtree containsObject:[NSValue valueWithNonretainedObject:child]]) continue;
-            // A platter mid-fade (alpha 0) already has its final frame — count
-            // it, or the title parks at a stale center with no later layout
-            // pass to fix it. Removed platters leave the tree, so `hidden` is
-            // enough to skip genuinely dead ones.
-            BOOL isPlatter = [NSStringFromClass(child.class) containsString:@"NavigationBarPlatterView"];
-            if (child.hidden || (!isPlatter && child.alpha == 0)) continue;
+            // Keep fitting independent of the expanded actions. A separate
+            // bounded collision offset below moves only titles needing room.
+            if (ApolloNavigationActionsViewIsInManagedRoots(child, managedRoots)) continue;
+            if (child.hidden || child.alpha < 0.01) continue;
+            NSString *className = NSStringFromClass(child.class);
+            // Exclude both titles and their hosts during navigation.
+            if ([className containsString:@"NavigationBarTitleControl"] ||
+                [className containsString:@"NavigationBarHostedView"] ||
+                [className containsString:@"BarBackground"] ||
+                [className containsString:@"Snapshot"]) continue;
+            if ([titleControl isDescendantOfView:child]) {
+                [queue addObject:child];
+                continue;
+            }
+            BOOL isPlatter = [className containsString:@"NavigationBarPlatterView"];
 
             BOOL isContent = isPlatter ||
                              [child isKindOfClass:[UIControl class]] ||
@@ -1343,155 +1750,122 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
             }
             if (child.bounds.size.width <= 0 || child.bounds.size.height <= 0) continue;
 
-            CGRect sibInBar = [child.superview convertRect:child.frame toView:bar];
-            if (isPlatter) {
-                // Pills are bar chrome — never legitimately underneath the
-                // title. UIKit's wrapper can lag a platter resize (its
-                // constraints were solved against the OLD pill geometry), which
-                // makes the stale title frame overlap the pill; a strict
-                // disjointness test would then drop the pill from the scan
-                // entirely. Side-classify by centers instead.
-                if (CGRectGetMidX(sibInBar) < CGRectGetMidX(frameInBar)) {
-                    leftLimit = MAX(leftLimit, CGRectGetMaxX(sibInBar));
-                    foundLeft = YES;
-                } else {
-                    rightLimit = MIN(rightLimit, CGRectGetMinX(sibInBar));
-                    foundRight = YES;
-                }
-            } else if (CGRectGetMaxX(sibInBar) <= CGRectGetMinX(frameInBar) + 0.5) {
+            CGRect sibInBar = [child convertRect:child.bounds toView:bar];
+            // Exclude non-button surfaces; classify pills by the bar midpoint,
+            // not the potentially misplaced title.
+            if (CGRectGetMaxY(sibInBar) <= CGRectGetMinY(titleBand) ||
+                CGRectGetMinY(sibInBar) >= CGRectGetMaxY(titleBand) ||
+                CGRectGetWidth(sibInBar) >= CGRectGetWidth(bar.bounds) - 1.0) continue;
+            if (CGRectGetMidX(sibInBar) < CGRectGetMidX(bar.bounds)) {
                 leftLimit = MAX(leftLimit, CGRectGetMaxX(sibInBar));
-                foundLeft = YES;
-            } else if (CGRectGetMinX(sibInBar) + 0.5 >= CGRectGetMaxX(frameInBar)) {
+            } else {
                 rightLimit = MIN(rightLimit, CGRectGetMinX(sibInBar));
-                foundRight = YES;
             }
         }
     }
 
-    const CGFloat kEdgePadding = 8.0;
+    const CGFloat kEdgePadding = kApolloTitleButtonSpacing;
 
-    UIViewController *topVC = ApolloOwningTopViewController(titleControl);
+    UIView *jumpBar = ApolloFindJumpBar(titleControl);
+    BOOL searching = jumpBar && ApolloJumpBarIsSearching(jumpBar);
+    CGFloat capsulePadding = !searching &&
+        ApolloResolvedScrollEdgeEffectStyle() != ApolloScrollEdgeEffectStyleHard
+        ? kApolloTitleCapsuleHorizontalPadding : 0.0;
+    ApolloNavigationTitleGeometry geometry = ApolloNavigationTitleCenteredGeometry(
+        bar.bounds, leftLimit, rightLimit, capsulePadding, kEdgePadding);
 
-    // Trailing-cluster reservation (ApolloCommon.h): screens that strip their
-    // right bar buttons in place (Inbox while its Chat hub is up) hold a
-    // reservation on their navigation item so the title doesn't re-balance
-    // against the suddenly-empty trailing side and slide. Record the trailing
-    // content edge whenever one is really there (as an inset from the bar's
-    // trailing edge, so a rotation mid-hold still resolves correctly), and
-    // while the hold is set with no real trailing content, treat the recorded
-    // edge as still present. Both centering arms below then compute the exact
-    // geometry they computed with the buttons up — gap midpoint and overlap
-    // clamp alike — which is what keeps the title still in either
-    // Balance-Title mode.
-    UINavigationItem *navItem = topVC.navigationItem;
-    if (navItem) {
-        if (foundRight) {
-            ApolloNavItemNoteTrailingContentInset(navItem, CGRectGetWidth(bar.bounds) - rightLimit);
-        } else if (ApolloNavItemTrailingReservationHold(navItem)) {
-            CGFloat reservedInset = ApolloNavItemTrailingContentInset(navItem);
-            if (reservedInset > 0) {
-                rightLimit = CGRectGetWidth(bar.bounds) - reservedInset;
-                foundRight = YES;
-            }
-        }
+    // Fit the original title through one constraint, preserving native text
+    // truncation. Priority 999 yields to required transition constraints.
+    // This deferred pass never writes from layoutSubviews, and expanding the
+    // actions does not change the fitted width.
+    CGFloat maximumWidth = geometry.maximumContentWidth;
+    CGFloat fittedWidth = searching ? maximumWidth : MIN(maximumWidth, [controller naturalContentWidth]);
+    BOOL widthChanged = !controller.fittedWidthConstraint ||
+        fabs(controller.fittedWidthConstraint.constant - fittedWidth) > 0.5;
+    if (!controller.fittedWidthConstraint) {
+        controller.fittedWidthConstraint = [titleControl.widthAnchor constraintEqualToConstant:fittedWidth];
+        controller.fittedWidthConstraint.priority = 999;
+        controller.fittedWidthConstraint.identifier = @"ApolloNavigationTitleFittedWidth";
+        controller.fittedWidthConstraint.active = YES;
+    } else if (widthChanged) {
+        controller.fittedWidthConstraint.constant = fittedWidth;
+    }
+    if (widthChanged) {
+        [bar setNeedsLayout];
+        [bar layoutIfNeeded];
     }
 
-    // Subreddit headers only (see the MARK above): size the JumpBar to its
-    // actual content before centering, instead of leaving it at whatever
-    // fixed width Apollo's own layout handed it (measured: exactly 156pt when
-    // the trailing icon cluster has a moderator shield, 204pt otherwise —
-    // never content-dependent on its own). Measured fresh via -sizeThatFits:
-    // every pass — never cached, never read from a possibly-mid-transition
-    // frame — because that's the one thing here that's immune to timing.
-    if (topVC && ApolloSubredditTitleShouldTruncate(topVC)) {
-        UIView *jumpBar = ApolloFindJumpBar(titleControl);
-        CGFloat availableWidth = (rightLimit - kEdgePadding) - (leftLimit + kEdgePadding);
-        if (jumpBar && ApolloJumpBarIsSearching(jumpBar)) {
-            // Search mode: the visible content is the text field, not the name
-            // label measured below — which Apollo hides but leaves populated,
-            // so it still measures as if it were on screen. Sizing to it froze
-            // the bar at the name's width while UIKit had already widened the
-            // title control for editing, leaving the field (and the capsule
-            // around it) centred inside a stale, too-narrow bar. Hand the width
-            // back to Apollo's own layout for as long as editing lasts.
-            CGFloat fullWidth = CGRectGetWidth(titleControl.bounds);
-            if (fullWidth > 0 && fabs(CGRectGetWidth(jumpBar.frame) - fullWidth) > 0.5) {
-                CGRect jumpBarFrame = jumpBar.frame;
-                jumpBarFrame.size.width = fullWidth;
-                jumpBar.frame = jumpBarFrame;
-            }
-        } else if (jumpBar && availableWidth > 0) {
-            id nameLabel = ApolloJumpBarObjectIvar(jumpBar, "nameLabel");
-            id arrowImageView = ApolloJumpBarObjectIvar(jumpBar, "arrowImageView");
-            CGFloat naturalWidth = 0;
-            if ([nameLabel isKindOfClass:[UILabel class]]) {
-                UILabel *label = (UILabel *)nameLabel;
-                CGFloat labelHeight = CGRectGetHeight(label.bounds) > 0 ? CGRectGetHeight(label.bounds) : label.font.lineHeight;
-                CGFloat labelNaturalWidth = ceil([label sizeThatFits:CGSizeMake(CGFLOAT_MAX, labelHeight)].width);
-                CGFloat labelLeading = CGRectGetMinX(label.frame);
-                naturalWidth = labelLeading + labelNaturalWidth;
-                if ([arrowImageView isKindOfClass:[UIView class]]) {
-                    const CGFloat kLabelArrowSpacing = 6.0;
-                    naturalWidth += kLabelArrowSpacing + CGRectGetWidth(((UIView *)arrowImageView).bounds);
-                }
-            }
-            CGFloat desiredWidth = naturalWidth > 0 ? MIN(naturalWidth, availableWidth) : CGRectGetWidth(jumpBar.frame);
-            if (naturalWidth > 0 && fabs(desiredWidth - CGRectGetWidth(jumpBar.frame)) > 0.5) {
-                CGRect jumpBarFrame = jumpBar.frame;
-                jumpBarFrame.size.width = desiredWidth;
-                jumpBar.frame = jumpBarFrame;
-                // Resizing the JumpBar changes titleControl's own natural
-                // frame (it hugs its content) — re-measure before centering.
-                frameInBar = [titleControl.superview convertRect:titleControl.frame toView:bar];
-                frameInBar.origin.x -= existingTx;
-                width = CGRectGetWidth(frameInBar);
-                unadjustedCenter = CGRectGetMidX(frameInBar);
-            }
-        }
+    // Center visible JumpBar content; leave its transparent frame to Apollo/UIKit.
+    contentFrame = [controller contentFrameInView:bar];
+    if (maximumWidth <= 0) {
+        [controller applyOverflowClip:CGRectZero];
+        return YES;
     }
+    if (CGRectIsNull(contentFrame) || CGRectIsEmpty(contentFrame)) {
+        [controller applyOverflowClip:CGRectNull];
+        return NO;
+    }
+    CGFloat targetCenter = geometry.center;
+    CGRect expandedActions = ApolloNavigationActionsExpandedFrame(bar);
+    if (ApolloNavigationTitlePresentationOwnsControl(titleControl) &&
+        !CGRectIsNull(expandedActions) && !CGRectIsEmpty(expandedActions) &&
+        CGRectGetMaxX(expandedActions) > geometry.center &&
+        CGRectGetMaxY(expandedActions) > CGRectGetMinY(titleBand) &&
+        CGRectGetMinY(expandedActions) < CGRectGetMaxY(titleBand)) {
+        // Use the unshifted capsule to avoid feeding back our own correction.
+        CGRect centered = CGRectOffset(contentFrame,
+            geometry.center - CGRectGetMidX(contentFrame), 0);
+        centered = CGRectInset(centered, -capsulePadding, 0);
+        targetCenter += ApolloNavigationTitleExpandedActionsOffset(bar.bounds,
+            centered, leftLimit, CGRectGetMinX(expandedActions), kEdgePadding);
+    }
+    CGFloat delta = targetCenter - CGRectGetMidX(contentFrame);
 
-    CGFloat halfWidth = width / 2.0;
-    CGFloat targetCenter;
-    if (sLGTitleGapCentering && foundLeft && foundRight) {
-        // Content on BOTH sides: park the title at the midpoint of the visual
-        // gap between them. Equal margins by construction — no overlap possible
-        // — and the position no longer depends on which of UIKit's three layout
-        // arms fired or how wide the trailing pill is. This is the case (e.g. a
-        // single back button facing a 3-icon moderator capsule) where a wider
-        // trailing cluster pulls the visual balance point away from true center.
-        targetCenter = (rightLimit - leftLimit >= width + 4.0)
-            ? (leftLimit + rightLimit) / 2.0
-            : unadjustedCenter;  // gap narrower than the title — leave UIKit's layout alone
+    // Convert the correction to the parent's coordinates, preserving UIKit's
+    // own transform. Only track a previous contribution if UIKit has not
+    // replaced that transform since our last pass (e.g. an interactive pop).
+    CGAffineTransform desired = titleControl.transform;
+    CGFloat previous = CGAffineTransformEqualToTransform(desired, controller.lastAppliedTransform)
+        ? controller.appliedTranslationX : 0;
+    CGFloat previousY = CGAffineTransformEqualToTransform(desired, controller.lastAppliedTransform)
+        ? controller.appliedTranslationY : 0;
+    CGPoint origin = [bar convertPoint:CGPointZero toView:titleControl.superview];
+    CGPoint shifted = [bar convertPoint:CGPointMake(delta, 0) toView:titleControl.superview];
+    CGFloat parentDelta = shifted.x - origin.x;
+    CGFloat parentDeltaY = shifted.y - origin.y;
+    if (fabs(delta) >= 0.5) {
+        desired.tx += parentDelta;
+        desired.ty += parentDeltaY;
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        titleControl.transform = desired;
+        [CATransaction commit];
+        controller.appliedTranslationX = previous + parentDelta;
+        controller.appliedTranslationY = previousY + parentDeltaY;
+        controller.lastAppliedTransform = desired;
+        ApolloLogDebug(@"[NavigationTitleLayout] %@ centered edges=%.1f/%.1f content=%.1f max=%.1f shift=%.1f",
+                       NSStringFromClass(topVC.class), leftLimit, rightLimit,
+                       CGRectGetWidth(contentFrame), maximumWidth, delta);
+    }
+    if (CGRectGetWidth(contentFrame) > maximumWidth + 0.5) {
+        CGFloat halfWidth = maximumWidth / 2.0 + capsulePadding;
+        CGRect safe = CGRectMake(targetCenter - halfWidth, CGRectGetMinY(titleBand) - 100,
+                                 halfWidth * 2.0, CGRectGetHeight(titleBand) + 200);
+        [controller applyOverflowClip:[bar convertRect:safe toView:titleControl]];
     } else {
-        // Screen centering (the toggle's OFF mode, and always the rule when
-        // content sits on at most one side, e.g. root screens): prefer the
-        // bar's absolute midpoint, nudged just enough off a pill it would
-        // overlap. Gap math on a one-sided bar would drag the title toward
-        // whichever side is empty for no visual reason — a bare back button
-        // doesn't need to be "balanced against". The nudge is what keeps long
-        // titles from sliding under the trailing pill (#178) without needing
-        // the old bulk-translation bail.
-        CGFloat barCenter = CGRectGetMidX(bar.bounds);
-        CGFloat minCenter = leftLimit + halfWidth + kEdgePadding;
-        CGFloat maxCenter = rightLimit - halfWidth - kEdgePadding;
-        targetCenter = (minCenter > maxCenter)
-            ? unadjustedCenter   // bar too cramped — leave UIKit's layout alone
-            : MIN(MAX(barCenter, minCenter), maxCenter);
+        [controller applyOverflowClip:CGRectNull];
     }
-
-    CGFloat newTx = targetCenter - unadjustedCenter;
-    if (fabs(newTx - existingTx) < 0.5) return YES;   // ran; already in place
-
-    CGAffineTransform desired = (fabs(newTx) < 0.5) ? CGAffineTransformIdentity
-                                                    : CGAffineTransformMakeTranslation(newTx, 0);
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-    titleControl.transform = desired;
-    [CATransaction commit];
     return YES;
 }
 
 %hook _UINavigationBarTitleControl
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    ApolloNavigationTitleGlassController *controller =
+        objc_getAssociatedObject(self, &kApolloNavigationTitleGlassControllerKey);
+    if (controller.overflowMask && !CGRectContainsPoint(controller.overflowClipRect, point)) return NO;
+    return %orig;
+}
 
 - (void)didMoveToWindow {
     %orig;
@@ -1523,6 +1897,7 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     // Refresh outside layoutSubviews so capsule sizing and the recenter's own
     // transform/JumpBar writes cannot feed back into UIKit's navigation-bar
     // layout pass.
+    if (ApolloNavigationTitlePresentationSuppressesControl((UIView *)self)) return;
     ApolloNavigationTitleGlassController *controller =
         objc_getAssociatedObject(self, &kApolloNavigationTitleGlassControllerKey);
     if (controller) {
@@ -1538,6 +1913,18 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
 %end
 
 // MARK: - JumpBar search-mode capsule tracking
+
+static void ApolloRefreshJumpBarSearchPresentation(UIView *jumpBar) {
+    if (!IsLiquidGlass() || !jumpBar.window) return;
+    for (UIView *view = jumpBar.superview; view; view = view.superview) {
+        if (![NSStringFromClass(view.class) isEqualToString:@"_UINavigationBarTitleControl"]) continue;
+        ApolloNavigationTitleGlassController *controller =
+            objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
+        // Settle the field and capsule before the Cancel-item animation commits.
+        [controller refreshTargets];
+        return;
+    }
+}
 //
 // The capsule is only re-measured from _UINavigationBarTitleControl's own
 // layout pass, and that pass does not fire when search mode opens or closes:
@@ -1547,6 +1934,16 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
 // from the JumpBar's own layout is what actually tracks it.
 
 %hook _TtC6Apollo7JumpBar
+
+- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    %orig;
+    ApolloRefreshJumpBarSearchPresentation((UIView *)self);
+}
+
+- (void)searchTextFieldChanged:(UITextField *)field {
+    %orig;
+    ApolloRefreshJumpBarSearchPresentation((UIView *)self);
+}
 
 - (void)layoutSubviews {
     %orig;
@@ -1578,41 +1975,116 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
 // actual frame delta so steady-state layout passes never dirty an ancestor —
 // that's what makes this loop-proof.
 //
-// setNeedsLayout alone is NOT enough to re-run the recenter: the title
-// control's layout pass only asks the glass controller for a *conditional*
-// refresh, and that gate skips alpha<0.01 views when fingerprinting the bar
-// while the recenter deliberately counts an alpha-0 platter (a pill fading in
-// already carries its final frame). So the poke would fire, the gate would
-// report "unchanged", and the title would park stale — exactly the bug this
-// exists to prevent. Force the refresh instead; the frame-delta gate above is
-// what keeps that from running every pass.
+// Refresh when platter visibility changes, even with an unchanged title frame,
+// so only visible platters reserve space.
 static const void *kApolloPlatterLastFrameKey = &kApolloPlatterLastFrameKey;
 
-static void ApolloPokeTitleLayoutNearPlatter(UIView *fromView) {
-    UINavigationBar *bar = nil;
-    for (UIView *v = fromView; v != nil; v = v.superview) {
-        if ([v isKindOfClass:[UINavigationBar class]]) { bar = (UINavigationBar *)v; break; }
-    }
-    if (!bar) return;
+void ApolloNavigationTitlesRefreshBar(UINavigationBar *bar) {
+    if (!IsLiquidGlass() || !bar) return;
+    ApolloNavigationTitlePresentationRefresh(bar);
     NSMutableArray<UIView *> *q = [NSMutableArray arrayWithObject:(UIView *)bar];
-    while (q.count > 0) {
-        UIView *v = q.firstObject;
-        [q removeObjectAtIndex:0];
+    for (NSUInteger index = 0; index < q.count; index++) {
+        UIView *v = q[index];
         NSString *cls = NSStringFromClass(v.class);
         if ([cls containsString:@"NavigationBarContentView"]) {
             [v setNeedsLayout];
         } else if ([cls containsString:@"NavigationBarTitleControl"]) {
             [v setNeedsLayout];
             ApolloUpdateNavigationTitleGlass(v);
-            return;
+            continue;
         }
         for (UIView *c in v.subviews) [q addObject:c];
     }
 }
 
+static void ApolloPokeTitleLayoutNearPlatter(UIView *fromView) {
+    for (UIView *view = fromView; view; view = view.superview) {
+        if ([view isKindOfClass:UINavigationBar.class]) {
+            ApolloNavigationTitlesRefreshBar((UINavigationBar *)view);
+            return;
+        }
+    }
+}
+
 %group ApolloLGPlatterPoke
 
+// MARK: - Keep translated titles reachable through their native host
+//
+// A centered title may extend outside its native wrapper. clipsToBounds=NO
+// makes it visible, not hittable; extend only its entry check and keep UIKit's
+// hit-test traversal intact.
+@interface _UINavigationBarHostedViewWrapper : UIView
+@end
+
+static BOOL ApolloHostedTitleContainsPoint(UIView *container, CGPoint point, UIEvent *event) {
+    for (UIView *child in container.subviews) {
+        if (child.hidden || child.alpha <= 0.01 || !child.userInteractionEnabled) continue;
+        CGPoint childPoint = [child convertPoint:point fromView:container];
+        if ([NSStringFromClass(child.class) containsString:@"NavigationBarTitleControl"]) {
+            if (!objc_getAssociatedObject(child, &kApolloNavigationTitleGlassControllerKey)) continue;
+            // Its native pointInside remains authoritative, including our
+            // zero-width/overflow mask guard and any UIKit-specific hit slop.
+            if ([child pointInside:childPoint withEvent:event]) return YES;
+            continue;
+        }
+        // Keep intervening controls' hit boundaries and sibling regions intact.
+        if ([child pointInside:childPoint withEvent:event] &&
+            ApolloHostedTitleContainsPoint(child, childPoint, event)) return YES;
+    }
+    return NO;
+}
+
+%hook _UINavigationBarHostedViewWrapper
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    BOOL nativeContainsPoint = %orig(point, event);
+    if (nativeContainsPoint) return YES;
+    if (!IsLiquidGlass() || !self.window || self.hidden || self.alpha <= 0.01 ||
+        !self.userInteractionEnabled) return NO;
+    return ApolloHostedTitleContainsPoint(self, point, event);
+}
+
+%end
+
+%hook UINavigationBar
+
+- (void)layoutSubviews {
+    %orig;
+    if (!IsLiquidGlass()) return;
+    // Read/schedule only: bar changes may skip title layout. Check all titles,
+    // including the incoming one during navigation.
+    ApolloNavigationActionsRefresh(self);
+    ApolloNavigationTitlePresentationRefresh(self);
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:(UIView *)self];
+    for (NSUInteger index = 0; index < queue.count; index++) {
+        UIView *view = queue[index];
+        if ([NSStringFromClass(view.class) containsString:@"NavigationBarTitleControl"]) {
+            ApolloNavigationTitleGlassController *controller =
+                objc_getAssociatedObject(view, &kApolloNavigationTitleGlassControllerKey);
+            if (controller) [controller scheduleTargetRefreshIfNeeded];
+            else ApolloUpdateNavigationTitleGlass(view);
+        } else {
+            [queue addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+%end
+
 %hook _UINavigationBarPlatterView
+
+- (void)setAlpha:(CGFloat)alpha {
+    BOOL wasInvisible = self.alpha < 0.01;
+    %orig;
+    BOOL visibilityChanged = wasInvisible != (self.alpha < 0.01);
+    if (IsLiquidGlass() && visibilityChanged) ApolloPokeTitleLayoutNearPlatter(self);
+}
+
+- (void)setHidden:(BOOL)hidden {
+    BOOL changed = self.hidden != hidden;
+    %orig;
+    if (IsLiquidGlass() && changed) ApolloPokeTitleLayoutNearPlatter(self);
+}
 
 - (void)layoutSubviews {
     %orig;
@@ -1637,20 +2109,16 @@ static void ApolloPokeTitleLayoutNearPlatter(UIView *fromView) {
 
 %end
 
-// Settings toggled the centering mode: re-run the recenter on every live nav
-// bar so open screens move immediately instead of waiting for their next
-// natural layout pass. Flipping the toggle changes no geometry at all, so this
-// relies on the poke forcing an unconditional refresh (see above) — a
-// change-gated one would see an identical bar and do nothing.
-void ApolloLGTitleCenteringModeChanged(void) {
+// Global appearance changes may not change UIKit's title frame. Refresh every
+// live bar; local title/action changes use ApolloNavigationTitlesRefreshBar.
+void ApolloNavigationTitlesRefresh(void) {
     if (!IsLiquidGlass()) return;
     for (UIWindow *window in ApolloAllWindows()) {
         NSMutableArray<UIView *> *q = [NSMutableArray arrayWithObject:(UIView *)window];
-        while (q.count > 0) {
-            UIView *v = q.firstObject;
-            [q removeObjectAtIndex:0];
+        for (NSUInteger index = 0; index < q.count; index++) {
+            UIView *v = q[index];
             if ([v isKindOfClass:[UINavigationBar class]]) {
-                ApolloPokeTitleLayoutNearPlatter(v);
+                ApolloNavigationTitlesRefreshBar((UINavigationBar *)v);
                 continue;
             }
             for (UIView *c in v.subviews) [q addObject:c];
@@ -1676,6 +2144,17 @@ void ApolloLGTitleCenteringModeChanged(void) {
 
 %ctor {
     %init;
+    // Also cover programmatic JumpBar entry, which doesn't pass through touch
+    // tracking. The native opening helper has set the field frame by this point.
+    [[NSNotificationCenter defaultCenter] addObserverForName:UITextFieldTextDidBeginEditingNotification
+                                                     object:nil queue:nil
+                                                 usingBlock:^(NSNotification *notification) {
+        UIView *field = notification.object;
+        if ([field isKindOfClass:UITextField.class] &&
+            [NSStringFromClass(field.superview.class) isEqualToString:@"Apollo.JumpBar"]) {
+            ApolloRefreshJumpBarSearchPresentation(field.superview);
+        }
+    }];
     // _UINavigationBarPlatterView only exists on iOS 26+ — register the poke
     // hooks only when the class is present so older runtimes skip it cleanly.
     if (objc_getClass("_UINavigationBarPlatterView")) {
@@ -1688,6 +2167,6 @@ void ApolloLGTitleCenteringModeChanged(void) {
                                                        object:nil
                                                         queue:[NSOperationQueue mainQueue]
                                                    usingBlock:^(__unused NSNotification *notification) {
-        ApolloLGTitleCenteringModeChanged();
+        ApolloNavigationTitlesRefresh();
     }];
 }

--- a/src/ApolloNativeActionMenus.h
+++ b/src/ApolloNativeActionMenus.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
+@class UIView;
 
 NS_ASSUME_NONNULL_BEGIN
+__BEGIN_DECLS
 
 // Runs `action` after the tweak-owned Liquid Glass context menu that was built
 // from `actionController` has completely dismissed. Returns NO when the
@@ -9,4 +11,23 @@ NS_ASSUME_NONNULL_BEGIN
 BOOL ApolloNativeActionMenuPerformAfterDismissal(id actionController,
                                                   dispatch_block_t action);
 
+// Defer collapse until the menu releases this surface; reopening cancels it.
+// Returns NO when no menu owns the surface.
+BOOL ApolloNativeActionMenuDeferNavigationCollapse(UIView *surface,
+                                                    dispatch_block_t collapse);
+
+// Main-thread ownership check for this exact surface, even when detached.
+// Overlapping sessions hold it until the main turn after their last completion;
+// window membership is not an ownership check.
+BOOL ApolloNativeActionMenuOwnsNavigationSurface(UIView * _Nullable surface);
+
+// Coalesce updates by stable key until the last native release. If a callback
+// opens another menu, remaining updates wait again. Returns NO without running
+// `update` when unowned; the caller may apply it immediately. Capture UI owners
+// weakly because the surface retains pending blocks.
+BOOL ApolloNativeActionMenuDeferNavigationUpdate(UIView * _Nullable surface,
+                                                   NSString *key,
+                                                   dispatch_block_t update);
+
+__END_DECLS
 NS_ASSUME_NONNULL_END

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1,6 +1,7 @@
 #import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 #import "ApolloNativeActionMenus.h"
+#import "ApolloNavigationActions.h"
 #import "ApolloNativeActionMetadata.h"
 #import "ApolloSwiftRuntime.h"
 #import "ApolloThemeRuntime.h"
@@ -17,6 +18,9 @@ static char kApolloNativeActionMenuLifecycleFallbackKey;
 static char kApolloNativeActionMenuPresenterKey;
 static char kApolloNativeActionMenuSourceViewKey;
 static char kApolloNativeActionMenuWrappedSourceActionKey;
+static char kApolloNativeActionMenuWindowPresenterKey;
+static char kApolloNativeActionMenuWindowRequestKey;
+static char kApolloNativeActionMenuSurfaceStateKey;
 
 static __weak UIView *sApolloNativeActionMenuSourceView = nil;
 static __weak UIView *sApolloNativeActionMenuConfigurationSourceView = nil;
@@ -24,34 +28,181 @@ static NSUInteger sApolloNativeActionMenuCaptureDepth = 0;
 static BOOL sApolloNativeActionMenuModeratorStyleStack[32];
 static BOOL sApolloNativeActionMenuNextPresentationModeratorStyle = NO;
 
+// Rapid handoffs can share a source across presenters. Track each session's
+// identity without retaining its presenter or source view.
+@interface ApolloNativeActionMenuSurfaceState : NSObject
+@property (nonatomic, weak) UIView *surface;
+@property (nonatomic, weak) UIWindow *window;
+@property (nonatomic) NSUInteger requestGeneration;
+@property (nonatomic, strong) NSMutableSet<NSObject *> *identities;
+@property (nonatomic, strong) NSMutableOrderedSet<NSString *> *updateKeys;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, dispatch_block_t> *updates;
+@end
+
+@implementation ApolloNativeActionMenuSurfaceState
+- (instancetype)init {
+    if ((self = [super init])) {
+        _identities = [NSMutableSet set];
+        _updateKeys = [NSMutableOrderedSet orderedSet];
+        _updates = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+@end
+
+static void ApolloNativeActionMenuReleaseSurface(ApolloNativeActionMenuSurfaceState *state,
+                                                   NSObject *identity) {
+    if (![state.identities containsObject:identity]) return;
+    [state.identities removeObject:identity];
+    // Remove before invoking, then recheck: callbacks can open menus or replace keys.
+    while (state.identities.count == 0 && state.updateKeys.count) {
+        if (!state.surface) {
+            [state.updateKeys removeAllObjects];
+            [state.updates removeAllObjects];
+            break;
+        }
+        NSString *key = state.updateKeys.firstObject;
+        dispatch_block_t update = state.updates[key];
+        [state.updateKeys removeObjectAtIndex:0];
+        [state.updates removeObjectForKey:key];
+        if (update) update();
+    }
+    UIView *surface = state.surface;
+    if (!state.identities.count && !state.updateKeys.count &&
+        objc_getAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey) == state) {
+        objc_setAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey, nil,
+                                 OBJC_ASSOCIATION_ASSIGN);
+    }
+}
+
+@interface ApolloNativeActionMenuSurfaceLease : NSObject
+@property (nonatomic, strong) ApolloNativeActionMenuSurfaceState *state;
+@property (nonatomic, strong) NSObject *identity;
+- (void)invalidate;
+@end
+
+@implementation ApolloNativeActionMenuSurfaceLease
+- (void)invalidate {
+    if (!_identity) return;
+    // UIKit releases render assertions after our completion. Schedule release
+    // before the selected action's next-turn callback; autorelease-delayed
+    // deallocation must not change that order.
+    ApolloNativeActionMenuSurfaceState *state = _state;
+    NSObject *identity = _identity;
+    _state = nil;
+    _identity = nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloNativeActionMenuReleaseSurface(state, identity);
+    });
+}
+- (void)dealloc {
+    // Release abandoned sessions too; invalidation is idempotent.
+    [self invalidate];
+}
+@end
+
+static ApolloNativeActionMenuSurfaceLease *ApolloNativeActionMenuAcquireSurface(UIView *surface,
+                                                                                 NSUInteger generation) {
+    if (!surface) return nil;
+    ApolloNativeActionMenuSurfaceState *state = objc_getAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey);
+    if (!state) {
+        state = [ApolloNativeActionMenuSurfaceState new];
+        state.surface = surface;
+        objc_setAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey, state,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    state.window = surface.window;
+    state.requestGeneration = generation;
+    ApolloNativeActionMenuSurfaceLease *lease = [ApolloNativeActionMenuSurfaceLease new];
+    lease.state = state;
+    lease.identity = [NSObject new];
+    [state.identities addObject:lease.identity];
+    return lease;
+}
+
+BOOL ApolloNativeActionMenuOwnsNavigationSurface(UIView *surface) {
+    ApolloNativeActionMenuSurfaceState *state = objc_getAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey);
+    return state.identities.count > 0;
+}
+
+BOOL ApolloNativeActionMenuDeferNavigationUpdate(UIView *surface, NSString *key, dispatch_block_t update) {
+    ApolloNativeActionMenuSurfaceState *state = objc_getAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey);
+    if (!state.identities.count || !key.length || !update) return NO;
+    [state.updateKeys addObject:key];
+    state.updates[key] = [update copy];
+    return YES;
+}
+
 @interface ApolloNativeActionMenuPresenter : NSObject <UIContextMenuInteractionDelegate>
 @property (nonatomic, strong) UIMenu *menu;
 @property (nonatomic, weak) UIView *sourceView;
-// Issue #249: the REAL tapped control (sort/ellipsis bar button, cell "..."
-// button). The interaction stays on the invisible proxy anchor, but the
-// highlight/dismiss previews target this view so the iOS 26 liquid-glass
-// "magic morph" has a visible source to bloom out of.
+// The tapped control supplies its strip's entire glass surface when owned;
+// otherwise it supplies only geometry, never an arbitrary ancestor.
 @property (nonatomic, weak) UIView *morphSourceView;
 @property (nonatomic, strong) UIContextMenuInteraction *interaction;
 @property (nonatomic, assign) BOOL removeSourceViewOnEnd;
 @property (nonatomic, weak) id actionController;
 @property (nonatomic, copy) dispatch_block_t afterDismissalAction;
+@property (nonatomic, strong) ApolloNativeActionMenuSurfaceLease *surfaceLease;
 // Keep the presentation window and anchor point for the menu's short lifetime.
 // A selected action may push another controller before UIKit asks for its
 // dismissal preview, detaching the nav-bar proxy from the window on iOS 27.
 @property (nonatomic, strong) UIWindow *presentationWindow;
 @property (nonatomic, assign) CGPoint presentationAnchorCenter;
-@property (nonatomic, strong) UIView *dismissalFallbackView;
-// Empty throwaway view pinned over morphSourceView; this is what UIKit portals
-// into the glass platter, so the real control keeps drawing. See
-// ApolloNativeActionMenuCreateMorphStandIn().
+// Reuse the preview in both directions; its window-backed target survives detachment.
 @property (nonatomic, strong) UIView *morphStandInView;
+@property (nonatomic, strong) UIView *morphHostView;
+@property (nonatomic, strong) UITargetedPreview *morphPreview;
+@property (nonatomic, assign) BOOL didBeginPresentation;
+@property (nonatomic, assign) BOOL didRequestConfiguration;
+@property (nonatomic, assign) BOOL dismissing;
+@property (nonatomic, assign) BOOL ended;
+@property (nonatomic, copy) dispatch_block_t pendingPresentationAction;
+@property (nonatomic, weak) UIWindow *requestWindow;
+@property (nonatomic, assign) NSUInteger requestGeneration;
+@property (nonatomic, strong) id nativePresentation;
+- (BOOL)presentFromView:(UIView *)source completion:(dispatch_block_t)completion;
+- (id)nativeHandoffPresentationForSource:(UIView *)source;
+- (void)captureNativePresentation;
+- (void)finishPresentation;
 @end
 
-// The anchor view owns the presenter for exactly as long as the menu can use
-// it. Keep the reverse lookup from ActionController non-owning: the presenter's
-// UIMenu actions retain that controller, so a direct RETAIN association here
-// would close a cycle and prevent the aborted-presentation -dealloc cleanup.
+// Track the latest request separately from retiring sessions, which still own
+// their sources. A weak reference avoids a window/presenter retain cycle.
+static ApolloNativeActionMenuPresenter *ApolloNativeActionMenuActivePresenter(UIWindow *window) {
+    NSHashTable *holder = objc_getAssociatedObject(window, &kApolloNativeActionMenuWindowPresenterKey);
+    return holder.anyObject;
+}
+
+static void ApolloNativeActionMenuSetActivePresenter(UIWindow *window, ApolloNativeActionMenuPresenter *presenter) {
+    if (!window) return;
+    NSHashTable *holder = presenter ? [NSHashTable weakObjectsHashTable] : nil;
+    if (presenter) [holder addObject:presenter];
+    objc_setAssociatedObject(window, &kApolloNativeActionMenuWindowPresenterKey, holder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+BOOL ApolloNativeActionMenuDeferNavigationCollapse(UIView *surface, dispatch_block_t collapse) {
+    ApolloNativeActionMenuSurfaceState *state = objc_getAssociatedObject(surface, &kApolloNativeActionMenuSurfaceStateKey);
+    if (!state.identities.count || !collapse) return NO;
+    __weak UIWindow *weakWindow = state.window;
+    NSUInteger generation = state.requestGeneration;
+    ApolloNativeActionMenuDeferNavigationUpdate(surface, @"native-menu.collapse", ^{
+        UIWindow *window = weakWindow;
+        NSUInteger latest = [objc_getAssociatedObject(window, &kApolloNativeActionMenuWindowRequestKey) unsignedIntegerValue];
+        ApolloNativeActionMenuPresenter *active = ApolloNativeActionMenuActivePresenter(window);
+        if (window && latest == generation && (!active || active.ended)) collapse();
+    });
+    // Ownership includes the completion-to-release gap. Reopening cancels only
+    // this collapse by generation, preserving unrelated geometry updates.
+    ApolloNativeActionMenuPresenter *presenter = ApolloNativeActionMenuActivePresenter(state.window);
+    if (presenter.surfaceLease.state == state && !presenter.ended && !presenter.dismissing) {
+        [presenter.interaction dismissMenu];
+    }
+    return YES;
+}
+
+// The anchor owns the presenter; its menu actions retain ActionController.
+// Keep this reverse lookup weak to avoid a cycle after session cleanup.
 static ApolloNativeActionMenuPresenter *ApolloNativeActionMenuPresenterForController(id actionController) {
     NSHashTable *holder = objc_getAssociatedObject(actionController,
                                                     &kApolloNativeActionMenuPresenterKey);
@@ -834,73 +985,21 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     return [UIMenu menuWithTitle:title children:children];
 }
 
-// Keep the tapped "..." control on screen for the whole menu lifecycle.
-//
-// UIKit builds the liquid-glass platter by portaling the morph preview's view
-// (a CAPortalLayer pointed at its layer). CoreAnimation stops drawing a
-// portaled layer in its original position for as long as the portal is alive —
-// a render-server effect, so from the app's side the control still looks
-// perfectly healthy (hidden NO, alpha 1, contents set) while its *presentation*
-// layer reads opacity 0. Clearing the portal's hidesSourceLayer does not undo
-// it; only the portal going away does. And the portal outlives the dismissal
-// animation — by ~1s on device — so the control sat blank long after the menu
-// was gone, which reads as the dots vanishing and slowly popping back.
-//
-// So don't let UIKit portal the real thing. This pins an empty throwaway view
-// over the control, exactly its size, and hands UIKit that as the preview: the
-// stand-in absorbs the portaling and the control itself never stops drawing.
-//
-// The stand-in is deliberately *blank* rather than a snapshot. The preview's
-// frame is all the morph needs — it drives where the glass platter blooms from
-// and collapses back to — while any pixels in it get carried inside the platter
-// as a second copy of the icon that animates with the morph. With the control
-// now permanently visible underneath, that copy showed up as a duplicate set of
-// dots sliding into place at the end of the dismissal. Empty stand-in, empty
-// platter: the glass shape blooms out of the control and the control is the
-// only thing ever drawing the icon.
-static UIView *ApolloNativeActionMenuCreateMorphStandIn(UIView *sourceView) {
-    UIView *container = sourceView.superview;
-    if (!container || !sourceView.window || CGRectIsEmpty(sourceView.bounds)) return nil;
-
-    UIView *standIn = [[UIView alloc] initWithFrame:sourceView.frame];
-    standIn.backgroundColor = UIColor.clearColor;
-    standIn.opaque = NO;
-    standIn.userInteractionEnabled = NO;
-    standIn.accessibilityElementsHidden = YES;
-    [container insertSubview:standIn aboveSubview:sourceView];
-    ApolloLog(@"[NativeActionMenu] Morphing from a stand-in over %@ so it stays drawn", sourceView);
-    return standIn;
-}
-
-// Matches the treatment the invisible proxy anchor gets below: a contentless
-// preview must not pick up UIPreviewParameters' default platter background or
-// drop shadow, or the empty stand-in would render as a grey box.
-static UITargetedPreview *ApolloNativeActionMenuStandInPreview(UIView *standIn) {
-    UIPreviewParameters *parameters = [UIPreviewParameters new];
-    parameters.backgroundColor = UIColor.clearColor;
-    parameters.visiblePath = [UIBezierPath bezierPathWithRect:standIn.bounds];
-    SEL setAppliesShadowSelector = NSSelectorFromString(@"setAppliesShadow:");
-    if ([parameters respondsToSelector:setAppliesShadowSelector]) {
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(parameters, setAppliesShadowSelector, NO);
-    }
-    return [[UITargetedPreview alloc] initWithView:standIn parameters:parameters];
-}
+// Use the owned glass surface for both morph directions; a blank stand-in
+// leaves two visible lenses and warped glyphs. Non-owned controls use only geometry.
+// All targets need a stable window-hosted view: iOS 27 AnimationKit requires a
+// superview, so UIWindow itself is invalid, even when the source page detaches.
 
 @implementation ApolloNativeActionMenuPresenter
 
-// Normally the teardown in -willEndForConfiguration: takes the stand-in out.
-// This catches the presentation that never got a dismissal (aborted before it
-// opened), so a stale copy can't ride along on a recycled cell.
-- (void)dealloc {
-    [_morphStandInView removeFromSuperview];
-    [_dismissalFallbackView removeFromSuperview];
-}
+// End ownership explicitly, including aborts: the anchor retains its presenter.
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(__unused CGPoint)location {
     UIMenu *menu = self.menu;
-    if (!menu) return nil;
+    if (!menu || self.ended) return nil;
+    self.didRequestConfiguration = YES;
 
-    return [UIContextMenuConfiguration configurationWithIdentifier:nil previewProvider:nil actionProvider:^UIMenu *(__unused NSArray<UIMenuElement *> *suggestedActions) {
+    return [UIContextMenuConfiguration configurationWithIdentifier:NSUUID.UUID previewProvider:nil actionProvider:^UIMenu *(__unused NSArray<UIMenuElement *> *suggestedActions) {
         return menu;
     }];
 }
@@ -937,173 +1036,243 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
     return ApolloNativeActionMenuCompactMenuStyle();
 }
 
+- (UITargetedPreview *)previewForCurrentSource {
+    if (self.ended) return nil;
+    UIWindow *window = self.presentationWindow ?: self.sourceView.window;
+    if (!window) return nil;
+
+    // Preserve a detached source's last target, not the proxy button's 1pt center.
+    UIView *source = self.morphSourceView ?: (self.morphPreview ? nil : self.sourceView);
+    UIView *ownedSurface = ApolloNavigationActionsMenuSourceView(source);
+    UIView *geometry = ownedSurface ?: source;
+    // For non-owned controls, copy native geometry without portaling the live view.
+    if (geometry == source && self.morphSourceView) {
+        SEL selector = NSSelectorFromString(@"_morphView");
+        if ([source respondsToSelector:selector]) {
+            UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(source, selector);
+            if (resolved.window == window) geometry = resolved;
+        }
+    }
+    CGPoint center = self.presentationAnchorCenter;
+    CGSize size = self.morphPreview ? self.morphPreview.view.bounds.size : CGSizeMake(1, 1);
+    if (geometry.window == window && !CGRectIsEmpty(geometry.bounds)) {
+        CGRect rect = [geometry convertRect:geometry.bounds toView:window];
+        center = CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect));
+        if (!self.morphPreview) size = rect.size;
+    }
+    if (!self.morphPreview) {
+        UIView *host = [[UIView alloc] initWithFrame:window.bounds];
+        host.backgroundColor = UIColor.clearColor;
+        host.opaque = NO;
+        host.userInteractionEnabled = NO;
+        host.accessibilityElementsHidden = YES;
+        host.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        [window addSubview:host];
+        self.morphHostView = host;
+        CGPoint targetCenter = [window convertPoint:center toView:host];
+        UIView *previewSource = ownedSurface;
+        if (!previewSource) {
+            UIView *placeholder = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, size}];
+            placeholder.backgroundColor = UIColor.clearColor;
+            placeholder.opaque = NO;
+            placeholder.userInteractionEnabled = NO;
+            placeholder.accessibilityElementsHidden = YES;
+            placeholder.center = targetCenter;
+            [host addSubview:placeholder];
+            self.morphStandInView = placeholder;
+            previewSource = placeholder;
+        }
+        UIPreviewParameters *parameters = [UIPreviewParameters new];
+        parameters.backgroundColor = UIColor.clearColor;
+        parameters.visiblePath = [UIBezierPath bezierPathWithRoundedRect:previewSource.bounds
+            cornerRadius:MIN(size.width, size.height) / 2];
+        parameters.shadowPath = [UIBezierPath bezierPath];
+        UIPreviewTarget *target = [[UIPreviewTarget alloc] initWithContainer:host center:targetCenter];
+        self.morphPreview = [[UITargetedPreview alloc] initWithView:previewSource parameters:parameters target:target];
+    } else if (hypot(self.presentationAnchorCenter.x - center.x,
+                      self.presentationAnchorCenter.y - center.y) > 0.5) {
+        // Follow a live source; retain the last window-backed target if detached.
+        CGPoint targetCenter = [window convertPoint:center toView:self.morphHostView];
+        UIPreviewTarget *target = [[UIPreviewTarget alloc] initWithContainer:self.morphHostView center:targetCenter];
+        [UIView performWithoutAnimation:^{ self.morphStandInView.center = targetCenter; }];
+        self.morphPreview = [self.morphPreview retargetedPreviewWithTarget:target];
+    }
+    self.presentationAnchorCenter = center;
+    return self.morphPreview;
+}
+
 - (UITargetedPreview *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction previewForHighlightingMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
-    // Issue #249: give the liquid morph a visible source. UIKit swaps this
-    // preview for -[UITargetedPreview _resolvedMorphablePreview] and blooms
-    // the menu out of it; the native button path builds it over the control's
-    // _morphView (the glass background platter when there is one, else the
-    // control itself) — see _UIControlMenuSupportTargetedPreviewOverViews().
-    UIView *morphSource = self.morphSourceView;
-    if (morphSource.window) {
-        UIView *morphView = morphSource;
-        SEL morphViewSelector = NSSelectorFromString(@"_morphView");
-        if ([morphSource respondsToSelector:morphViewSelector]) {
-            UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(morphSource, morphViewSelector);
-            if (resolved.window) morphView = resolved;
-        }
-
-        // Hand UIKit a stand-in instead of the control itself, so the control
-        // survives being portaled (see ApolloNativeActionMenuCreateMorphStandIn).
-        // Both the highlight and the dismiss preview reuse the same stand-in;
-        // the teardown in -willEndForConfiguration: takes it back out.
-        UIView *standIn = self.morphStandInView;
-        if (!standIn.window) {
-            [standIn removeFromSuperview];
-            standIn = ApolloNativeActionMenuCreateMorphStandIn(morphView);
-            self.morphStandInView = standIn;
-        }
-        if (standIn) {
-            return ApolloNativeActionMenuStandInPreview(standIn);
-        }
-        return [[UITargetedPreview alloc] initWithView:morphView];
-    }
-
-    // Fallback (real control gone/windowless): the invisible proxy anchor.
-    // No morph in this case, but the menu still appears anchored correctly.
-    UIView *sourceView = self.sourceView;
-    if (!sourceView) return nil;
-
-    UIPreviewParameters *parameters = [UIPreviewParameters new];
-    parameters.backgroundColor = UIColor.clearColor;
-    parameters.visiblePath = [UIBezierPath bezierPathWithRect:sourceView.bounds];
-    SEL setAppliesShadowSelector = NSSelectorFromString(@"setAppliesShadow:");
-    if ([parameters respondsToSelector:setAppliesShadowSelector]) {
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(parameters, setAppliesShadowSelector, NO);
-    }
-    return [[UITargetedPreview alloc] initWithView:sourceView parameters:parameters];
+    return [self previewForCurrentSource];
 }
 
 - (UITargetedPreview *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction previewForDismissingMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
-    // Dismissal deliberately does NOT reuse the morph-view preview: UIKit
-    // snapshots that view and flies it from the collapsed menu's anchor back to
-    // the control's frame, so the "..." button visibly glides back into its row
-    // after every menu dismissal. Returning an invisible preview anchored on
-    // the proxy keeps the menu's own fade-out and lets the real control simply
-    // reappear in place (restored in willEndForConfiguration below) with no
-    // flight. Do not return nil here — nil makes UIKit fall back to the
-    // presentation (morph) preview and the glide comes back.
-    UIView *sourceView = self.sourceView;
-    if (!sourceView) return nil;
+    return [self previewForCurrentSource];
+}
 
-    // iOS 27 throws if initWithView:parameters: is handed a view that is no
-    // longer in a window. A menu action can legitimately navigate before UIKit
-    // requests this dismissal preview, which detaches a nav-bar source and its
-    // proxy. Preserve the invisible-preview behavior by substituting a
-    // temporary 1pt anchor in the original presentation window.
-    if (!sourceView.window) {
-        UIWindow *window = self.presentationWindow;
-        if (!window) {
-            for (UIWindow *candidate in ApolloAllWindows()) {
-                if (candidate.isKeyWindow) {
-                    window = candidate;
-                    break;
-                }
-            }
-        }
-        if (!window) {
-            ApolloLog(@"[NativeActionMenu] No window for dismissal preview");
-            return nil;
-        }
-
-        UIView *fallback = self.dismissalFallbackView;
-        if (!fallback.window) {
-            [fallback removeFromSuperview];
-            CGPoint center = self.presentationAnchorCenter;
-            fallback = [[UIView alloc] initWithFrame:CGRectMake(center.x - 0.5,
-                                                                center.y - 0.5,
-                                                                1.0,
-                                                                1.0)];
-            fallback.backgroundColor = UIColor.clearColor;
-            fallback.opaque = NO;
-            fallback.userInteractionEnabled = NO;
-            fallback.accessibilityElementsHidden = YES;
-            [window addSubview:fallback];
-            self.dismissalFallbackView = fallback;
-            ApolloLog(@"[NativeActionMenu] Original dismissal anchor detached; using window fallback");
-        }
-        sourceView = fallback;
-    }
-
-    UIPreviewParameters *parameters = [UIPreviewParameters new];
-    parameters.backgroundColor = UIColor.clearColor;
-    parameters.visiblePath = [UIBezierPath bezierPathWithRect:CGRectZero];
-    SEL setAppliesShadowSelector = NSSelectorFromString(@"setAppliesShadow:");
-    if ([parameters respondsToSelector:setAppliesShadowSelector]) {
-        ((void (*)(id, SEL, BOOL))objc_msgSend)(parameters, setAppliesShadowSelector, NO);
-    }
-    return [[UITargetedPreview alloc] initWithView:sourceView parameters:parameters];
+- (void)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(__unused UIContextMenuConfiguration *)configuration animator:(__unused id<UIContextMenuInteractionAnimating>)animator {
+    self.didBeginPresentation = YES;
+    [self captureNativePresentation];
 }
 
 - (void)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction willEndForConfiguration:(__unused UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator {
-    // The morph hid the real control for the menu's lifetime. With the
-    // dismissal preview above being invisible, nothing re-reveals it visually —
-    // restore it right as the dismissal starts so the button is sitting in its
-    // own row while the menu fades (idempotent with UIKit's own end-of-
-    // animation unhide bookkeeping).
-    UIView *morphSource = self.morphSourceView;
-    if (morphSource) {
-        UIView *morphView = morphSource;
-        SEL morphViewSelector = NSSelectorFromString(@"_morphView");
-        if ([morphSource respondsToSelector:morphViewSelector]) {
-            UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(morphSource, morphViewSelector);
-            if (resolved) morphView = resolved;
-        }
-        for (UIView *restore in @[morphView, morphSource]) {
-            if (restore.hidden) restore.hidden = NO;
-            if (restore.alpha < 0.999) restore.alpha = 1.0;
-        }
+    if (self.ended || self.dismissing) return;
+    [self captureNativePresentation];
+    self.dismissing = YES;
+    // Retain this preview/anchor through reverse morph and late preview callbacks.
+    if (animator) [animator addCompletion:^{ [self finishPresentation]; }];
+    else [self finishPresentation];
+}
+
+- (void)finishPresentation {
+    if (self.ended) return;
+    self.ended = YES;
+    UIView *source = self.sourceView;
+    BOOL ownsAnchor = objc_getAssociatedObject(source, &kApolloNativeActionMenuControllerKey) == self;
+    if (self.interaction) [source removeInteraction:self.interaction];
+    if (ownsAnchor) {
+        objc_setAssociatedObject(source, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        if (self.removeSourceViewOnEnd) [source removeFromSuperview];
+    }
+    if (ApolloNativeActionMenuPresenterForController(self.actionController) == self) {
+        ApolloNativeActionMenuSetPresenterForController(self.actionController, nil);
+    }
+    UIWindow *window = self.presentationWindow;
+    dispatch_block_t selectedAction = self.afterDismissalAction;
+    if (!selectedAction && ApolloNativeActionMenuActivePresenter(window) == self) {
+        ApolloNativeActionMenuSetActivePresenter(self.presentationWindow, nil);
+    }
+    // UIKit owns source visibility: never reset hidden/alpha or remove the real surface.
+    [self.morphStandInView removeFromSuperview];
+    self.morphStandInView = nil;
+    [self.morphHostView removeFromSuperview];
+    self.morphHostView = nil;
+    self.morphPreview = nil;
+    self.interaction = nil;
+    self.nativePresentation = nil;
+    self.menu = nil;
+    self.presentationWindow = nil;
+    [self.surfaceLease invalidate];
+    self.surfaceLease = nil;
+    dispatch_block_t next = self.pendingPresentationAction;
+    self.pendingPresentationAction = nil;
+    if (selectedAction) {
+        // Reserve the window through next-turn action execution, blocking competing menus.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.afterDismissalAction = nil;
+            if (ApolloNativeActionMenuActivePresenter(window) == self) {
+                ApolloNativeActionMenuSetActivePresenter(window, nil);
+            }
+            selectedAction();
+        });
+    } else if (next) {
+        dispatch_async(dispatch_get_main_queue(), next);
+    }
+}
+
+- (void)captureNativePresentation {
+    if (self.ended || self.nativePresentation) return;
+    SEL presentations = NSSelectorFromString(@"presentationsByIdentifier");
+    if (![self.interaction respondsToSelector:presentations]) return;
+    id values = ((id (*)(id, SEL))objc_msgSend)(self.interaction, presentations);
+    // Capture the sole presentation before dismissMenu clears it mid-animation;
+    // UIKit's internal identifier differs from our configuration identifier.
+    if ([values isKindOfClass:NSDictionary.class] && [values count] == 1) {
+        self.nativePresentation = [values allValues].firstObject;
+    }
+}
+
+- (id)nativeHandoffPresentationForSource:(UIView *)source {
+    UIView *surface = ApolloNavigationActionsMenuSourceView(source);
+    if (!self.dismissing || !self.didBeginPresentation || !surface ||
+        surface != self.morphPreview.view || surface.window != self.presentationWindow ||
+        !self.didRequestConfiguration || !ApolloNativeActionMenuMagicMorphEnabled()) return nil;
+
+    SEL disappearance = NSSelectorFromString(@"disappearanceTransition");
+    if (![self.interaction respondsToSelector:NSSelectorFromString(@"setOutgoingPresentation:")]) return nil;
+    id previous = self.nativePresentation;
+    id transition = [previous respondsToSelector:disappearance] ?
+        ((id (*)(id, SEL))objc_msgSend)(previous, disappearance) : nil;
+    Class morph = objc_getClass("_UIContextMenuLiquidMorphPresentationAnimation");
+    // Never reuse A's inherited outgoing transition for B -> C, and never
+    // start a competing lens if UIKit cannot provide a compatible handoff.
+    return morph && [transition isKindOfClass:morph] ? previous : nil;
+}
+
+- (BOOL)presentFromView:(UIView *)source completion:(dispatch_block_t)completion {
+    UIWindow *window = source.window;
+    if (!window || self.ended) return NO;
+    NSUInteger latest = [objc_getAssociatedObject(window, &kApolloNativeActionMenuWindowRequestKey) unsignedIntegerValue];
+    if (!self.requestGeneration) {
+        self.requestWindow = window;
+        self.requestGeneration = latest + 1;
+        objc_setAssociatedObject(window, &kApolloNativeActionMenuWindowRequestKey, @(self.requestGeneration), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else if (self.requestWindow != window || self.requestGeneration != latest) {
+        // Reject stale queued taps before they can dismiss a newer menu.
+        [self finishPresentation];
+        return NO;
+    }
+    ApolloNativeActionMenuPresenter *active = ApolloNativeActionMenuActivePresenter(window);
+    if (active == self && self.interaction) return YES;
+    if (active != self && active.afterDismissalAction) {
+        // Chosen actions take priority, including those awaiting next-turn execution.
+        [self finishPresentation];
+        return YES;
+    }
+    id previousPresentation = [active nativeHandoffPresentationForSource:source];
+    if (active && active != self && !active.ended && !previousPresentation) {
+        // Dismiss an open/preparing menu first. Compatible requests during
+        // dismissal reuse its outgoing transition instead of this queue.
+        __weak UIView *weakSource = source;
+        active.pendingPresentationAction = ^{
+            UIView *liveSource = weakSource;
+            if (liveSource.window == window) [self presentFromView:liveSource completion:completion];
+        };
+        if (!active.dismissing) [active.interaction dismissMenu];
+        return YES;
     }
 
-    UIView *sourceView = self.sourceView;
-    UIContextMenuInteraction *menuInteraction = self.interaction;
-    BOOL removeSourceViewOnEnd = self.removeSourceViewOnEnd;
-    UIView *standInView = self.morphStandInView;
-    UIView *dismissalFallbackView = self.dismissalFallbackView;
-    id actionController = self.actionController;
-    self.morphStandInView = nil;
-    self.dismissalFallbackView = nil;
-    // Issue #249: tear down at dismissal END, not START — removing the anchor
-    // (the interaction's host view) while the menu is still morphing back into
-    // the source button cuts the dismissal animation short. The stand-in goes
-    // at the same point: it is what the collapsing platter is portaling, and
-    // pulling it early would empty the platter mid-animation.
-    void (^teardown)(void) = ^{
-        if (sourceView && menuInteraction) {
-            [sourceView removeInteraction:menuInteraction];
-            objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
-        }
-        if (ApolloNativeActionMenuPresenterForController(actionController) == self) {
-            ApolloNativeActionMenuSetPresenterForController(actionController, nil);
-        }
-        [standInView removeFromSuperview];
-        [dismissalFallbackView removeFromSuperview];
-        if (removeSourceViewOnEnd) {
-            [sourceView removeFromSuperview];
-        }
-        // Read at dismissal END rather than capturing at dismissal START. An
-        // action handler may run between those callbacks on a future UIKit and
-        // store its work after this method has already begun.
-        dispatch_block_t afterDismissalAction = self.afterDismissalAction;
-        self.afterDismissalAction = nil;
-        if (afterDismissalAction) {
-            dispatch_async(dispatch_get_main_queue(), afterDismissalAction);
-        }
-    };
-    if (animator) {
-        [animator addCompletion:teardown];
-    } else {
-        teardown();
+    UIContextMenuInteraction *interaction = [[UIContextMenuInteraction alloc] initWithDelegate:self];
+    SEL present = NSSelectorFromString(@"_presentMenuAtLocation:");
+    if (![interaction respondsToSelector:present]) return NO;
+    // Share UIKit's outgoing transition to avoid competing return/open glass animations.
+    SEL setOutgoing = NSSelectorFromString(@"setOutgoingPresentation:");
+    if (previousPresentation && [interaction respondsToSelector:setOutgoing]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(interaction, setOutgoing, previousPresentation);
     }
+    BOOL removeAnchor = NO;
+    UIView *anchor = ApolloNativeActionMenuCreateProxyAnchorView(source, &removeAnchor);
+    if (!anchor.window) return NO;
+    self.sourceView = anchor;
+    self.morphSourceView = ApolloNativeActionMenuViewShouldMorph(source) ? source : nil;
+    self.presentationWindow = window;
+    self.presentationAnchorCenter = [source convertPoint:CGPointMake(CGRectGetMidX(source.bounds),
+        CGRectGetMidY(source.bounds)) toView:window];
+    self.removeSourceViewOnEnd = removeAnchor;
+    self.interaction = interaction;
+    [anchor addInteraction:interaction];
+    objc_setAssociatedObject(anchor, &kApolloNativeActionMenuControllerKey, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloNativeActionMenuSetPresenterForController(self.actionController, self);
+    ApolloNativeActionMenuSetActivePresenter(window, self);
+    // Acquire before configuration/preview to protect preparation from late item updates.
+    self.surfaceLease = ApolloNativeActionMenuAcquireSurface(
+        ApolloNavigationActionsMenuSourceView(self.morphSourceView), self.requestGeneration);
+
+    SEL driver = NSSelectorFromString(@"_setFallbackDriverStyle:");
+    if ([interaction respondsToSelector:driver]) {
+        ((void (*)(id, SEL, NSUInteger))objc_msgSend)(interaction, driver, 1);
+    }
+    CGPoint location = CGPointMake(CGRectGetMidX(anchor.bounds), CGRectGetMidY(anchor.bounds));
+    ((void (*)(id, SEL, CGPoint))objc_msgSend)(interaction, present, location);
+    [self captureNativePresentation];
+    // Configuration is synchronous; display can be delayed. Only rejection
+    // before configuration lacks an end animator; delayed willDisplay is not failure.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!self.didRequestConfiguration && !self.ended) [self finishPresentation];
+    });
+    ApolloLog(@"[NativeActionMenu] Presentation requested for %@ (%lu sections)",
+        NSStringFromClass(source.class), (unsigned long)self.menu.children.count);
+    if (completion) completion();
+    return YES;
 }
 
 @end
@@ -1331,60 +1500,10 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
     }
     objc_setAssociatedObject(actionController, &kApolloNativeActionMenuSourceViewKey, sourceView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    BOOL removeAnchorViewOnEnd = NO;
-    UIView *anchorView = ApolloNativeActionMenuCreateProxyAnchorView(sourceView, &removeAnchorViewOnEnd);
-    if (!anchorView || !anchorView.window) {
-        ApolloLog(@"[NativeActionMenu] Could not create anchor view for %@", actionController);
-        return NO;
-    }
-
     ApolloNativeActionMenuPresenter *menuPresenter = [ApolloNativeActionMenuPresenter new];
     menuPresenter.menu = menu;
-    menuPresenter.sourceView = anchorView;
     menuPresenter.actionController = actionController;
-    menuPresenter.presentationWindow = anchorView.window;
-    menuPresenter.presentationAnchorCenter =
-        [anchorView convertPoint:CGPointMake(CGRectGetMidX(anchorView.bounds),
-                                             CGRectGetMidY(anchorView.bounds))
-                          toView:anchorView.window];
-    BOOL morphable = ApolloNativeActionMenuViewShouldMorph(sourceView);
-    menuPresenter.morphSourceView = morphable ? sourceView : nil;
-    menuPresenter.removeSourceViewOnEnd = removeAnchorViewOnEnd;
-    ApolloLog(@"[NativeActionMenu] source=%@ %.0fx%.0f morph=%@",
-              NSStringFromClass(sourceView.class),
-              CGRectGetWidth(sourceView.bounds), CGRectGetHeight(sourceView.bounds),
-              morphable ? @"yes" : @"no");
-
-    UIContextMenuInteraction *interaction = [[UIContextMenuInteraction alloc] initWithDelegate:menuPresenter];
-    if (![interaction respondsToSelector:NSSelectorFromString(@"_presentMenuAtLocation:")]) {
-        ApolloLog(@"[NativeActionMenu] UIContextMenuInteraction cannot present programmatically");
-        return NO;
-    }
-
-    menuPresenter.interaction = interaction;
-
-    [anchorView addInteraction:interaction];
-    objc_setAssociatedObject(anchorView, &kApolloNativeActionMenuControllerKey, menuPresenter, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloNativeActionMenuSetPresenterForController(actionController, menuPresenter);
-
-    // Issue #249: a programmatic presentation has no active click driver, so
-    // -[UIContextMenuInteraction menuAppearance] falls back to the interaction's
-    // fallbackDriverStyle — which defaults to 0 and resolves to the "rich"
-    // (long-press preview) appearance instead of the compact button-menu one.
-    // Compact appearance is what makes UIKit force preferredLayout 3 and compute
-    // the glass attachment point. UIKit's own programmatic presenters set the
-    // fallback first (UITextItemInteractionHandler, _UISearchSuggestionController).
-    SEL fallbackDriverStyleSelector = NSSelectorFromString(@"_setFallbackDriverStyle:");
-    if ([interaction respondsToSelector:fallbackDriverStyleSelector]) {
-        ((void (*)(id, SEL, NSUInteger))objc_msgSend)(interaction, fallbackDriverStyleSelector, 1);
-    }
-
-    CGPoint location = CGPointMake(CGRectGetMidX(anchorView.bounds), CGRectGetMidY(anchorView.bounds));
-    ((void (*)(id, SEL, CGPoint))objc_msgSend)(interaction, NSSelectorFromString(@"_presentMenuAtLocation:"), location);
-
-    ApolloLog(@"[NativeActionMenu] Presented native menu with %lu item(s)", (unsigned long)menu.children.count);
-    if (completion) completion();
-    return YES;
+    return [menuPresenter presentFromView:sourceView completion:completion];
 }
 
 static BOOL ApolloNativeActionMenuCanFallbackPresent(id presenter, id actionController) {

--- a/src/ApolloNavigationActions.h
+++ b/src/ApolloNavigationActions.h
@@ -1,0 +1,30 @@
+#import <UIKit/UIKit.h>
+
+__BEGIN_DECLS
+
+// Returns the original custom content inside the item's viewport.
+UIView *ApolloNavigationActionsContentView(UIBarButtonItem *item);
+// UIKit owns this surface during menu transitions: do not duplicate it, alter
+// its visibility, or change its geometry until native ownership ends.
+UIView *ApolloNavigationActionsMenuSourceView(UIView *action);
+
+// Defers measurement, so calling from a layout callback is safe.
+void ApolloNavigationActionsRefresh(UINavigationBar *navigationBar);
+
+// Physical bar coordinates. Keep the collapsed reservation for stable title
+// width; the expanded edge is used only for optional collision displacement.
+CGRect ApolloNavigationActionsCollapsedFrame(UINavigationBar *navigationBar);
+CGRect ApolloNavigationActionsExpandedFrame(UINavigationBar *navigationBar);
+
+// Excludes action views from title measurement. Discover once per traversal;
+// do not cache across layout/content changes.
+NSArray<UIView *> *ApolloNavigationActionsManagedRoots(UINavigationBar *navigationBar);
+
+static inline BOOL ApolloNavigationActionsViewIsInManagedRoots(UIView *view, NSArray<UIView *> *roots) {
+    for (UIView *root in roots) {
+        if (view == root || [view isDescendantOfView:root]) return YES;
+    }
+    return NO;
+}
+
+__END_DECLS

--- a/src/ApolloNavigationActions.xm
+++ b/src/ApolloNavigationActions.xm
@@ -1,0 +1,931 @@
+#import "ApolloNavigationActions.h"
+#import "ApolloNavigationActionsDiscovery.h"
+#import "ApolloNativeActionMenus.h"
+#import "ApolloCommon.h"
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import <QuartzCore/QuartzCore.h>
+
+// Use the pill's spring for glyphs without changing button frames,
+// which translation measures when inserting its globe.
+static const NSTimeInterval kActionsAnimationDuration = 0.36;
+static CASpringAnimation *ApolloActionsSpring(NSString *keyPath) {
+    CASpringAnimation *spring = [CASpringAnimation animationWithKeyPath:keyPath];
+    spring.mass = 1;
+    spring.stiffness = 644;
+    spring.damping = 2 * 0.78 * sqrt(spring.stiffness);
+    spring.duration = kActionsAnimationDuration;
+    return spring;
+}
+
+// Each page owns one strip and glass surface. Never hide native ancestors,
+// save their transient alpha, or duplicate the More glyph.
+static char kActionsOwnerKey;
+static char kActionsControllerKey;
+static char kActionsRefreshKey;
+static char kActionsStandardItemKey;
+static char kActionsStandardMoreKey;
+static char kActionsScrollOwnerKey;
+static NSUInteger sActionsModelWriteDepth;
+@class ApolloNavigationActionsOwner;
+
+@interface ApolloNavigationActionsControllerBox : NSObject
+@property (nonatomic, weak) UIViewController *controller;
+@end
+@implementation ApolloNavigationActionsControllerBox
+@end
+
+@interface ApolloNavigationActionsScrollOwnerBox : NSObject
+@property (nonatomic, weak) ApolloNavigationActionsOwner *owner;
+@end
+@implementation ApolloNavigationActionsScrollOwnerBox
+@end
+
+// The item's customView contains its glass and original buttons/targets/menus.
+// Its trailing-anchored viewport resizes while More stays fixed in the window.
+@interface ApolloNavigationActionsStrip : UIControl
+@property (nonatomic, strong) UIView *content;
+@property (nonatomic, strong) UIVisualEffectView *surface;
+@property (nonatomic, weak) UIButton *more;
+@property (nonatomic, weak) ApolloNavigationActionsOwner *owner;
+@property (nonatomic, weak) UIBarButtonItem *barItem;
+@property (nonatomic, strong) NSLayoutConstraint *widthConstraint;
+@property (nonatomic) CGFloat expandedWidth;
+@property (nonatomic) CGFloat moreMidX;
+@property (nonatomic) BOOL expanded;
+@property (nonatomic) BOOL originalAccessibilityHidden;
+@property (nonatomic, strong) NSHashTable<CALayer *> *animatedIconLayers;
+@property (nonatomic, copy) NSString *iconMotionKey;
+@property (nonatomic, copy) NSString *iconOpacityKey;
+- (instancetype)initWithContent:(UIView *)content more:(UIButton *)more;
+- (void)remeasure;
+- (void)applyExpanded:(BOOL)expanded;
+- (void)publishSize;
+- (void)displayExpanded:(BOOL)expanded;
+- (void)animateIconsExpanded:(BOOL)expanded entering:(BOOL)entering;
+- (void)removeIconAnimations;
+@end
+
+@interface ApolloNavigationActionsStandardItem : NSObject
+@property (nonatomic, weak) UIBarButtonItem *item;
+@property (nonatomic, weak) ApolloNavigationActionsOwner *owner;
+@property (nonatomic) BOOL hidden;
+@end
+@implementation ApolloNavigationActionsStandardItem
+@end
+
+@interface ApolloNavigationActionsOwner : NSObject
+@property (nonatomic, weak) UINavigationItem *item;
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, strong) NSArray<ApolloNavigationActionsStrip *> *strips;
+@property (nonatomic, strong) NSMutableArray<ApolloNavigationActionsStandardItem *> *standardItems;
+@property (nonatomic, weak) UIBarButtonItem *moreItem;
+@property (nonatomic, strong) UIBarButtonItem *inboxDisclosure;
+@property (nonatomic, copy) UIAction *nativePrimaryAction;
+@property (nonatomic, copy) UIMenu *nativeMenu;
+@property (nonatomic, strong) UIViewPropertyAnimator *animator;
+@property (nonatomic, strong) NSHashTable<UIPanGestureRecognizer *> *pans;
+@property (nonatomic, weak) UIView *scrollRegistrationRoot;
+@property (nonatomic, weak) UIGestureRecognizer *backGesture;
+@property (nonatomic, strong) id resignObserver;
+@property (nonatomic) BOOL expanded;
+@property (nonatomic) BOOL preparing;
+@property (nonatomic) BOOL needsGeometryTransition;
+@property (nonatomic) BOOL geometryDeferred;
+@property (nonatomic) BOOL needsAnimationSettlement;
+- (void)prepareItems:(NSArray<UIBarButtonItem *> *)items;
+- (BOOL)deferGeometryUpdate;
+- (void)publishExpandedState;
+- (void)settleAnimationIfNeeded;
+- (void)setExpanded:(BOOL)expanded animated:(BOOL)animated;
+- (void)watchScrollViews;
+- (void)scrolled:(UIPanGestureRecognizer *)pan;
+- (void)restoreStandardItems;
+- (void)applyStandardExpanded:(BOOL)expanded;
+@end
+
+static BOOL ApolloActionsMoreName(NSString *name) {
+    NSString *lower = name.lowercaseString;
+    // Matching "options" would mistake moderatorOptionsButtonTapped for More.
+    return [lower containsString:@"more"] || [lower containsString:@"ellipsis"];
+}
+
+static UIButton *ApolloActionsFindMore(UIView *root) {
+    if ([root isKindOfClass:UIButton.class]) {
+        UIButton *button = (UIButton *)root;
+        if (ApolloActionsMoreName(button.accessibilityLabel)) return button;
+        for (id target in button.allTargets) {
+            for (NSString *action in [button actionsForTarget:target forControlEvent:UIControlEventTouchUpInside]) {
+                if (ApolloActionsMoreName(action)) return button;
+            }
+        }
+    }
+    for (UIView *child in root.subviews) {
+        UIButton *more = ApolloActionsFindMore(child);
+        if (more) return more;
+    }
+    return nil;
+}
+
+static NSUInteger ApolloActionsControlCount(UIView *root) {
+    if ([root isKindOfClass:UIControl.class]) return 1;
+    NSUInteger count = 0;
+    for (UIView *child in root.subviews) count += ApolloActionsControlCount(child);
+    return count;
+}
+
+static void ApolloActionsSetPrimaryAction(UIBarButtonItem *item, UIAction *action) {
+    // Preserve Apollo's artwork/title when UIKit copies the action's metadata.
+    UIImage *image = item.image;
+    NSString *title = item.title;
+    item.primaryAction = action;
+    item.image = image;
+    item.title = title;
+}
+
+UIView *ApolloNavigationActionsContentView(UIBarButtonItem *item) {
+    UIView *view = item.customView;
+    return [view isKindOfClass:ApolloNavigationActionsStrip.class]
+        ? ((ApolloNavigationActionsStrip *)view).content : view;
+}
+
+UIView *ApolloNavigationActionsMenuSourceView(UIView *action) {
+    for (UIView *view = action; view; view = view.superview) {
+        if ([view isKindOfClass:ApolloNavigationActionsStrip.class]) {
+            return ((ApolloNavigationActionsStrip *)view).surface;
+        }
+    }
+    return nil;
+}
+
+@implementation ApolloNavigationActionsStrip
+- (instancetype)initWithContent:(UIView *)content more:(UIButton *)more {
+    self = [super initWithFrame:CGRectMake(0, 0, 44, 44)];
+    if (!self) return nil;
+    _content = content;
+    _more = more;
+    _originalAccessibilityHidden = content.accessibilityElementsHidden;
+    _animatedIconLayers = [NSHashTable weakObjectsHashTable];
+    _iconMotionKey = [NSString stringWithFormat:@"ApolloReborn.actions.motion.%p", self];
+    _iconOpacityKey = [NSString stringWithFormat:@"ApolloReborn.actions.opacity.%p", self];
+    self.clipsToBounds = NO;
+    Class effectClass = NSClassFromString(@"UIGlassEffect");
+    UIVisualEffect *effect = ((id (*)(id, SEL, NSInteger))objc_msgSend)(effectClass, NSSelectorFromString(@"effectWithStyle:"), 0);
+    self.surface = [[UIVisualEffectView alloc] initWithEffect:effect];
+    self.surface.frame = self.bounds;
+    self.surface.clipsToBounds = YES;
+    self.surface.layer.cornerRadius = 22;
+    Class cornerClass = NSClassFromString(@"UICornerConfiguration");
+    SEL capsule = NSSelectorFromString(@"capsuleConfiguration");
+    SEL setter = NSSelectorFromString(@"setCornerConfiguration:");
+    if ([cornerClass respondsToSelector:capsule] && [self.surface respondsToSelector:setter]) {
+        id configuration = ((id (*)(id, SEL))objc_msgSend)(cornerClass, capsule);
+        ((void (*)(id, SEL, id))objc_msgSend)(self.surface, setter, configuration);
+    }
+    [self addSubview:self.surface];
+    self.widthConstraint = [self.widthAnchor constraintEqualToConstant:44];
+    self.widthConstraint.active = YES;
+    [self addTarget:self action:@selector(reveal:) forControlEvents:UIControlEventTouchUpInside];
+    self.accessibilityLabel = @"Show navigation actions";
+    self.accessibilityHint = @"Expands the page's buttons. Scrolling closes them.";
+    [self remeasure];
+    [self applyExpanded:NO];
+    return self;
+}
+- (BOOL)deferGeometryForNativeMenu {
+    if (!ApolloNativeActionMenuOwnsNavigationSurface(self.surface)) return NO;
+    [self.owner deferGeometryUpdate];
+    return YES;
+}
+- (void)remeasure {
+    if ([self deferGeometryForNativeMenu]) return;
+    // Measure the full source, including late globes, not the clipped viewport.
+    CGRect moreFrame = [self.more convertRect:self.more.bounds toView:self.content];
+    BOOL changed = fabs(self.moreMidX - CGRectGetMidX(moreFrame)) > 0.01;
+    self.moreMidX = CGRectGetMidX(moreFrame);
+    self.expandedWidth = MAX(44, ceil(self.moreMidX + 22));
+    CGFloat width = self.expanded ? self.expandedWidth : 44;
+    if (fabs(self.widthConstraint.constant - width) > 0.01) {
+        self.widthConstraint.constant = width;
+        [self invalidateIntrinsicContentSize];
+        changed = YES;
+    }
+    if (changed) [self setNeedsLayout];
+}
+- (CGSize)intrinsicContentSize {
+    return CGSizeMake(self.expanded ? self.expandedWidth : 44, 44);
+}
+- (CGSize)sizeThatFits:(CGSize)size { return self.intrinsicContentSize; }
+- (CGSize)systemLayoutSizeFittingSize:(CGSize)size { return self.intrinsicContentSize; }
+- (CGSize)systemLayoutSizeFittingSize:(CGSize)size withHorizontalFittingPriority:(UILayoutPriority)horizontal verticalFittingPriority:(UILayoutPriority)vertical {
+    return self.intrinsicContentSize;
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if ([self deferGeometryForNativeMenu]) return;
+    // Async host resizing must preserve the surface's right edge and animated width.
+    CGRect glassFrame = self.surface.frame;
+    glassFrame.origin = CGPointMake(self.bounds.size.width - glassFrame.size.width, (self.bounds.size.height - 44) / 2);
+    if (!CGRectEqualToRect(self.surface.frame, glassFrame)) self.surface.frame = glassFrame;
+    [self layoutContent];
+}
+- (void)layoutContent {
+    if ([self deferGeometryForNativeMenu]) return;
+    CGSize size = self.content.bounds.size;
+    CGRect frame = CGRectMake(self.surface.bounds.size.width - 22 - self.moreMidX,
+        (44 - size.height) / 2, size.width, size.height);
+    if (!CGRectEqualToRect(self.content.frame, frame)) self.content.frame = frame;
+}
+- (void)publishSize {
+    if ([self deferGeometryForNativeMenu]) return;
+    self.barItem.width = self.intrinsicContentSize.width;
+    CGRect frame = self.frame;
+    frame.size = self.intrinsicContentSize;
+    self.frame = frame;
+    [self layoutIfNeeded];
+}
+- (void)displayExpanded:(BOOL)expanded {
+    if ([self deferGeometryForNativeMenu]) return;
+    CGFloat width = expanded ? self.expandedWidth : 44;
+    self.surface.frame = CGRectMake(self.bounds.size.width - width, (self.bounds.size.height - 44) / 2, width, 44);
+    [self layoutContent];
+}
+- (void)animateIconsExpanded:(BOOL)expanded entering:(BOOL)entering {
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:self.content];
+    NSHashTable<CALayer *> *liveLayers = [NSHashTable weakObjectsHashTable];
+    for (NSUInteger i = 0; i < queue.count; i++) {
+        UIView *view = queue[i];
+        if (view == self.more) continue; // The one original More never animates.
+        if (![view isKindOfClass:UIButton.class]) {
+            [queue addObjectsFromArray:view.subviews];
+            continue;
+        }
+        UIButton *button = (id)view;
+        UIImageView *glyph = button.imageView;
+        if (!glyph.image) continue;
+        CALayer *layer = glyph.layer;
+        [liveLayers addObject:layer];
+        CGFloat distance = self.moreMidX - CGRectGetMidX([button convertRect:button.bounds toView:self.content]);
+        // Drift from the disclosure side, but don't cross into the More glyph.
+        CGFloat offset = MIN(18, MAX(0, distance - 32));
+        BOOL continuing = [layer animationForKey:self.iconMotionKey] != nil;
+        CALayer *presentation = layer.presentationLayer;
+        CGFloat fromX = (expanded && entering) ? offset : 0;
+        CGFloat fromOpacity = (expanded && entering) ? -1 : 0;
+        if (continuing && presentation) {
+            fromX = [[presentation valueForKeyPath:@"transform.translation.x"] doubleValue] -
+                [[layer valueForKeyPath:@"transform.translation.x"] doubleValue];
+            fromOpacity = presentation.opacity - layer.opacity;
+        }
+        CASpringAnimation *motion = ApolloActionsSpring(@"transform.translation.x");
+        motion.additive = YES;
+        motion.fromValue = @(fromX);
+        motion.toValue = @(expanded ? 0 : offset);
+        CASpringAnimation *opacity = ApolloActionsSpring(@"opacity");
+        opacity.additive = YES;
+        opacity.fromValue = @(fromOpacity);
+        opacity.toValue = @(expanded ? 0 : -1);
+        // Hold until completion clips the strip, then remove both animations.
+        // Leave model visibility/transform untouched for navigation and app snapshots.
+        for (CAAnimation *animation in @[motion, opacity]) {
+            animation.fillMode = kCAFillModeForwards;
+            animation.removedOnCompletion = NO;
+        }
+        [layer addAnimation:motion forKey:self.iconMotionKey];
+        [layer addAnimation:opacity forKey:self.iconOpacityKey];
+    }
+    for (CALayer *layer in self.animatedIconLayers) {
+        if ([liveLayers containsObject:layer]) continue;
+        [layer removeAnimationForKey:self.iconMotionKey];
+        [layer removeAnimationForKey:self.iconOpacityKey];
+    }
+    self.animatedIconLayers = liveLayers;
+}
+- (void)removeIconAnimations {
+    for (CALayer *layer in self.animatedIconLayers) {
+        [layer removeAnimationForKey:self.iconMotionKey];
+        [layer removeAnimationForKey:self.iconOpacityKey];
+    }
+    [self.animatedIconLayers removeAllObjects];
+}
+- (void)applyExpanded:(BOOL)expanded {
+    if ([self deferGeometryForNativeMenu]) return;
+    self.expanded = expanded;
+    self.isAccessibilityElement = !expanded;
+    self.accessibilityTraits = UIAccessibilityTraitButton;
+    self.content.accessibilityElementsHidden = expanded ? self.originalAccessibilityHidden : YES;
+    [self remeasure];
+}
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hit = [super hitTest:point withEvent:event];
+    // Keep drawing the real More; route taps to Apollo only after expansion settles.
+    return hit && (!self.expanded || self.owner.animator) ? self : hit;
+}
+- (BOOL)accessibilityActivate { [self.owner setExpanded:YES animated:YES]; return YES; }
+- (void)reveal:(id)sender { [self.owner setExpanded:YES animated:YES]; }
+- (void)dealloc {
+    [self removeIconAnimations];
+    if (self.content.superview == self.surface.contentView) self.content.accessibilityElementsHidden = self.originalAccessibilityHidden;
+}
+@end
+
+static UINavigationController *ApolloActionsNavigation(UINavigationBar *bar) {
+    for (UIResponder *responder = bar.nextResponder; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:UINavigationController.class]) return (id)responder;
+    }
+    return nil;
+}
+
+static BOOL ApolloActionsAppController(UIViewController *controller) {
+    return [NSStringFromClass(controller.class) hasPrefix:@"Apollo."] ||
+        [NSStringFromClass(controller.navigationController.class) hasPrefix:@"Apollo."];
+}
+
+static ApolloNavigationActionsOwner *ApolloActionsOwner(UINavigationItem *item, BOOL create) {
+    if (!item) return nil;
+    ApolloNavigationActionsOwner *owner = objc_getAssociatedObject(item, &kActionsOwnerKey);
+    if (!owner && create) {
+        owner = [ApolloNavigationActionsOwner new];
+        owner.item = item;
+        objc_setAssociatedObject(item, &kActionsOwnerKey, owner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    ApolloNavigationActionsControllerBox *box = objc_getAssociatedObject(item, &kActionsControllerKey);
+    if (box.controller) owner.controller = box.controller;
+    return owner;
+}
+
+static void ApolloActionsSetScrollOwner(UIPanGestureRecognizer *pan, ApolloNavigationActionsOwner *owner) {
+    ApolloNavigationActionsScrollOwnerBox *box = objc_getAssociatedObject(pan, &kActionsScrollOwnerKey);
+    ApolloNavigationActionsOwner *previous = box.owner;
+    if (previous == owner) return;
+    if (previous) {
+        [pan removeTarget:previous action:@selector(scrolled:)];
+        [previous.pans removeObject:pan];
+    }
+    if (owner) {
+        if (!box) box = [ApolloNavigationActionsScrollOwnerBox new];
+        box.owner = owner;
+        [pan addTarget:owner action:@selector(scrolled:)];
+        [owner.pans addObject:pan];
+    }
+    objc_setAssociatedObject(pan, &kActionsScrollOwnerKey, owner ? box : nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloActionsUpdateScrollOwner(UIScrollView *scrollView) {
+    ApolloNavigationActionsOwner *owner = nil;
+    if (scrollView.window) {
+        // Incoming pages can attach before becoming topViewController.
+        // Walk past child controllers to find the actual page owner.
+        for (UIResponder *responder = scrollView.nextResponder; responder; responder = responder.nextResponder) {
+            if (![responder isKindOfClass:UIViewController.class]) continue;
+            owner = ApolloActionsOwner(((UIViewController *)responder).navigationItem, NO);
+            if (owner) break;
+        }
+    }
+    ApolloActionsSetScrollOwner(scrollView.panGestureRecognizer, owner);
+}
+
+static NSArray<UIBarButtonItem *> *ApolloActionsInboxItems(UINavigationItem *item, NSArray<UIBarButtonItem *> *items) {
+    ApolloNavigationActionsControllerBox *box = objc_getAssociatedObject(item, &kActionsControllerKey);
+    if (!IsLiquidGlass() || ![NSStringFromClass(box.controller.class) isEqual:@"Apollo.InboxViewController"]) return items;
+    ApolloNavigationActionsOwner *owner = ApolloActionsOwner(item, YES);
+    NSMutableArray *native = [items mutableCopy] ?: [NSMutableArray array];
+    if (owner.inboxDisclosure) [native removeObjectIdenticalTo:owner.inboxDisclosure];
+    // Inbox compose/selection modes and lone actions need no added disclosure.
+    if (box.controller.isEditing || native.count < 2) return native;
+    NSUInteger actionable = 0;
+    for (UIBarButtonItem *candidate in native) {
+        if (ApolloActionsMoreName(candidate.accessibilityLabel) ||
+            ApolloActionsMoreName(NSStringFromSelector(candidate.action))) return native;
+        if (candidate.customView || [candidate.title isEqualToString:@"Cancel"] ||
+            [candidate.title isEqualToString:@"Done"] || [candidate.title isEqualToString:@"Edit"]) return native;
+        ApolloNavigationActionsStandardItem *state = objc_getAssociatedObject(candidate, &kActionsStandardItemKey);
+        BOOL nativeHidden = state ? state.hidden : candidate.hidden;
+        if (!nativeHidden && (candidate.action || candidate.primaryAction || candidate.menu)) actionable++;
+    }
+    if (actionable < 2) return native;
+    if (!owner.inboxDisclosure) {
+        UIImage *image = [[UIImage imageNamed:@"option-more" inBundle:NSBundle.mainBundle compatibleWithTraitCollection:box.controller.traitCollection]
+            imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        if (!image) return native;
+        __weak ApolloNavigationActionsOwner *weakOwner = owner;
+        owner.inboxDisclosure = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:nil action:nil];
+        owner.inboxDisclosure.accessibilityLabel = @"More Options";
+        // Inbox has no native More menu; this button closes the expanded group.
+        owner.inboxDisclosure.primaryAction = [UIAction actionWithTitle:@"" image:image identifier:nil handler:^(__unused UIAction *action) {
+            [weakOwner setExpanded:NO animated:YES];
+        }];
+    }
+    [native insertObject:owner.inboxDisclosure atIndex:0];
+    return native;
+}
+
+@implementation ApolloNavigationActionsOwner
+- (instancetype)init {
+    self = [super init];
+    if (!self) return nil;
+    _standardItems = [NSMutableArray array];
+    _pans = [NSHashTable weakObjectsHashTable];
+    __weak typeof(self) weakSelf = self;
+    _resignObserver = [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationWillResignActiveNotification
+        object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+            // Finish our animation without retaining UIKit's transient hidden/alpha state.
+            [weakSelf setExpanded:NO animated:NO];
+        }];
+    return self;
+}
+- (void)dealloc {
+    [NSNotificationCenter.defaultCenter removeObserver:self.resignObserver];
+    for (UIPanGestureRecognizer *pan in self.pans) [pan removeTarget:self action:@selector(scrolled:)];
+    [self.backGesture removeTarget:self action:@selector(backGestureChanged:)];
+    [self restoreStandardItems];
+}
+- (void)restoreStandardItems {
+    sActionsModelWriteDepth++;
+    for (ApolloNavigationActionsStandardItem *state in self.standardItems) {
+        state.item.hidden = state.hidden;
+        objc_setAssociatedObject(state.item, &kActionsStandardItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    [self.standardItems removeAllObjects];
+    if (self.moreItem) {
+        objc_setAssociatedObject(self.moreItem, &kActionsStandardMoreKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloActionsSetPrimaryAction(self.moreItem, self.nativePrimaryAction);
+        self.moreItem.menu = self.nativeMenu;
+    }
+    self.moreItem = nil;
+    self.nativeMenu = nil;
+    self.nativePrimaryAction = nil;
+    sActionsModelWriteDepth--;
+}
+- (BOOL)deferGeometryUpdate {
+    for (ApolloNavigationActionsStrip *strip in self.strips) {
+        if (!ApolloNativeActionMenuOwnsNavigationSurface(strip.surface)) continue;
+        if (!self.geometryDeferred) {
+            self.geometryDeferred = YES;
+            __weak typeof(self) weakSelf = self;
+            ApolloNativeActionMenuDeferNavigationUpdate(strip.surface, @"navigation-actions.geometry", ^{
+                ApolloNavigationActionsOwner *owner = weakSelf;
+                if (!owner) return;
+                owner.geometryDeferred = NO;
+                // Setters may run during the menu; use the latest items on release.
+                [owner prepareItems:owner.item.rightBarButtonItems];
+                // A spring may have finished during native ownership; publish
+                // its final width and remove held glyph animations as well.
+                [owner settleAnimationIfNeeded];
+            });
+        }
+        return YES;
+    }
+    return NO;
+}
+- (void)prepareItems:(NSArray<UIBarButtonItem *> *)items {
+    if (self.preparing) return;
+    // Freeze all geometry and icon cleanup while UIKit owns the surface,
+    // including late action insertion and overlapping menu sessions.
+    if ([self deferGeometryUpdate]) return;
+    self.preparing = YES;
+    BOOL retargetAnimation = NO;
+    NSMutableArray *strips = [NSMutableArray array];
+    for (UIBarButtonItem *item in items) {
+        UIView *source = ApolloNavigationActionsContentView(item);
+        ApolloNavigationActionsStrip *strip = [item.customView isKindOfClass:ApolloNavigationActionsStrip.class]
+            ? (id)item.customView : nil;
+        UIButton *more = strip.more ?: ApolloActionsFindMore(source);
+        if (!strip && more && ApolloActionsControlCount(source) > 1) {
+            strip = [[ApolloNavigationActionsStrip alloc] initWithContent:source more:more];
+            item.customView = strip;
+            // setCustomView: detaches the old view even if reparented; adopt it afterward.
+            [strip.surface.contentView addSubview:source];
+            // Hide the item's default glass, not ancestor views, to avoid double glass.
+            if (@available(iOS 26.0, *)) item.hidesSharedBackground = YES;
+            // Match native transitions without sharing views between pages.
+            if (@available(iOS 26.0, *)) {
+                if (!item.identifier) item.identifier = @"ApolloReborn.navigation-actions";
+            }
+            ApolloLog(@"[NavigationActions] Installed native item strip on %@", NSStringFromClass(self.controller.class));
+        }
+        if (strip) {
+            strip.owner = self;
+            strip.barItem = item;
+            CGFloat previousWidth = strip.expandedWidth;
+            CGFloat previousMoreMidX = strip.moreMidX;
+            if (!self.animator) {
+                [strip applyExpanded:self.expanded];
+                // Animate late slots from the current pill/title presentation,
+                // rather than publishing the new width immediately.
+                if (self.expanded && fabs(previousWidth - strip.expandedWidth) > 0.01) {
+                    self.needsGeometryTransition = YES;
+                    retargetAnimation = YES;
+                } else {
+                    [strip displayExpanded:self.expanded];
+                }
+            } else {
+                [strip remeasure];
+                retargetAnimation |= fabs(previousWidth - strip.expandedWidth) > 0.01 ||
+                    fabs(previousMoreMidX - strip.moreMidX) > 0.01 || ![self.strips containsObject:strip];
+            }
+            [strips addObject:strip];
+        }
+    }
+    retargetAnimation |= self.animator && self.strips.count != strips.count;
+    // Buttons may move to a new container while UIKit retains the outgoing strip.
+    // Remove their old effects immediately.
+    for (ApolloNavigationActionsStrip *oldStrip in self.strips) {
+        if (![strips containsObject:oldStrip]) [oldStrip removeIconAnimations];
+    }
+    self.strips = strips;
+    // Non-custom items use item.hidden; lone actions and pages without More stay native.
+    UIBarButtonItem *more = items.firstObject;
+    BOOL standard = strips.count == 0 && items.count > 1 && !more.customView &&
+        (ApolloActionsMoreName(more.accessibilityLabel) || ApolloActionsMoreName(NSStringFromSelector(more.action)));
+    BOOL same = standard && more == self.moreItem && self.standardItems.count == items.count - 1;
+    if (same) {
+        for (NSUInteger i = 1; i < items.count; i++) if (self.standardItems[i - 1].item != items[i]) same = NO;
+    }
+    if (!same) {
+        [self restoreStandardItems];
+        if (standard) {
+            self.moreItem = more;
+            self.nativeMenu = more.menu;
+            self.nativePrimaryAction = more.primaryAction;
+            ApolloNavigationActionsStandardItem *moreState = [ApolloNavigationActionsStandardItem new];
+            moreState.item = more; moreState.owner = self;
+            objc_setAssociatedObject(more, &kActionsStandardMoreKey, moreState, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            for (NSUInteger i = 1; i < items.count; i++) {
+                ApolloNavigationActionsStandardItem *state = [ApolloNavigationActionsStandardItem new];
+                state.item = items[i]; state.owner = self; state.hidden = items[i].hidden;
+                objc_setAssociatedObject(items[i], &kActionsStandardItemKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                [self.standardItems addObject:state];
+            }
+            if (@available(iOS 26.0, *)) {
+                if (!more.identifier) more.identifier = @"ApolloReborn.navigation-actions";
+            }
+            [self applyStandardExpanded:self.expanded];
+        }
+    }
+    self.preparing = NO;
+    // Retarget mid-reveal source updates from the current presentation to avoid a snap.
+    if (retargetAnimation) [self setExpanded:self.expanded animated:YES];
+}
+- (void)applyStandardExpanded:(BOOL)expanded {
+    sActionsModelWriteDepth++;
+    for (ApolloNavigationActionsStandardItem *state in self.standardItems) state.item.hidden = state.hidden || !expanded;
+    UIBarButtonItem *more = self.moreItem;
+    if (more) {
+        if (expanded) {
+            ApolloActionsSetPrimaryAction(more, self.nativePrimaryAction);
+            more.menu = self.nativeMenu;
+        } else {
+            UIImage *image = more.image;
+            NSString *title = more.title;
+            __weak typeof(self) weakSelf = self;
+            more.menu = nil;
+            ApolloActionsSetPrimaryAction(more, [UIAction actionWithTitle:title ?: @"" image:image identifier:nil
+                handler:^(__unused UIAction *action) { [weakSelf setExpanded:YES animated:YES]; }]);
+        }
+    }
+    sActionsModelWriteDepth--;
+}
+- (void)setExpanded:(BOOL)expanded animated:(BOOL)animated {
+    if (self.expanded == expanded && !self.animator && !self.needsGeometryTransition &&
+        !self.needsAnimationSettlement) return;
+    if (!expanded) {
+        __weak typeof(self) weakSelf = self;
+        for (ApolloNavigationActionsStrip *strip in self.strips) {
+            if (ApolloNativeActionMenuDeferNavigationCollapse(strip.surface, ^{
+                ApolloNavigationActionsOwner *owner = weakSelf;
+                BOOL visible = owner.controller.navigationController.navigationBar.topItem == owner.item;
+                // A final pan Changed may already have started collapse; don't restart it.
+                if (owner.expanded) [owner setExpanded:NO animated:animated && visible];
+            })) return;
+        }
+    } else {
+        for (ApolloNavigationActionsStrip *strip in self.strips) {
+            __weak typeof(self) weakSelf = self;
+            if (ApolloNativeActionMenuDeferNavigationUpdate(strip.surface, @"navigation-actions.expansion", ^{
+                ApolloNavigationActionsOwner *owner = weakSelf;
+                BOOL visible = owner.controller.navigationController.navigationBar.topItem == owner.item;
+                [owner setExpanded:YES animated:animated && visible];
+            })) return;
+        }
+    }
+    self.needsGeometryTransition = NO;
+    // Supersede deferred settlement so it cannot snap or clean up this new transition.
+    self.needsAnimationSettlement = NO;
+    // Reversals begin from presentation state, not a guessed endpoint.
+    UIViewPropertyAnimator *previous = self.animator;
+    BOOL entering = !self.expanded || previous != nil;
+    self.animator = nil;
+    [previous stopAnimation:NO];
+    [previous finishAnimationAtPosition:UIViewAnimatingPositionCurrent];
+    if (self.strips.count == 0 && !self.moreItem) {
+        self.expanded = NO;
+        return;
+    }
+    UINavigationBar *bar = self.controller.navigationController.navigationBar;
+    // Resetting an outgoing item must not move or lay out the new page's title.
+    if (bar.topItem != self.item) bar = nil;
+    [bar layoutIfNeeded];
+    ApolloNavigationTitleActionsWillChange(bar);
+    self.expanded = expanded;
+    if (animated && bar.window && !UIAccessibilityIsReduceMotionEnabled()) {
+        // Reserve hit-test space before reveal; shrink it only after collapse.
+        // Glass and content share a lightly underdamped spring, keeping More
+        // pinned throughout the bounce without exposing the host's width jump.
+        CASpringAnimation *spring = ApolloActionsSpring(nil);
+        UISpringTimingParameters *timing = [[UISpringTimingParameters alloc] initWithMass:spring.mass
+            stiffness:spring.stiffness damping:spring.damping initialVelocity:CGVectorMake(0, 0)];
+        UIViewPropertyAnimator *animator = [[UIViewPropertyAnimator alloc] initWithDuration:kActionsAnimationDuration
+            timingParameters:timing];
+        self.animator = animator;
+        if (expanded) [UIView performWithoutAnimation:^{ [self publishExpandedState]; }];
+        [animator addAnimations:^{
+            for (ApolloNavigationActionsStrip *strip in self.strips) [strip displayExpanded:expanded];
+            [self applyStandardExpanded:expanded];
+        }];
+        __weak typeof(self) weakSelf = self;
+        __weak UIViewPropertyAnimator *weakAnimator = animator;
+        [animator addCompletion:^(__unused UIViewAnimatingPosition position) {
+            ApolloNavigationActionsOwner *owner = weakSelf;
+            if (!owner || owner.animator != weakAnimator) return;
+            owner.animator = nil;
+            // A menu may acquire the source mid-spring; defer the entire settlement.
+            owner.needsAnimationSettlement = YES;
+            [owner settleAnimationIfNeeded];
+        }];
+        [animator startAnimation];
+        for (ApolloNavigationActionsStrip *strip in self.strips) [strip animateIconsExpanded:expanded entering:entering];
+        ApolloNavigationTitleActionsDidChange(bar, spring);
+    } else {
+        self.needsAnimationSettlement = YES;
+        [UIView performWithoutAnimation:^{
+            [self settleAnimationIfNeeded];
+            [self applyStandardExpanded:expanded];
+        }];
+        ApolloNavigationTitleActionsDidChange(bar, nil);
+    }
+    if (expanded) [self watchScrollViews];
+    ApolloLog(@"[NavigationActions] %@ %@", NSStringFromClass(self.controller.class), expanded ? @"expanded" : @"collapsed");
+}
+- (void)publishExpandedState {
+    if ([self deferGeometryUpdate]) return;
+    for (ApolloNavigationActionsStrip *strip in self.strips) {
+        [strip applyExpanded:self.expanded];
+        [strip publishSize];
+    }
+    // iOS 27's SwiftUI host caches custom-item width until the navigation model
+    // changes. Reuse current identities, including any late native replacement.
+    [self.item setRightBarButtonItems:self.item.rightBarButtonItems animated:NO];
+    UINavigationBar *bar = self.controller.navigationController.navigationBar;
+    if (bar.topItem != self.item) return; // Never drive the page we navigated to.
+    [bar setNeedsLayout];
+    [bar layoutIfNeeded];
+}
+- (void)settleAnimationIfNeeded {
+    if (!self.needsAnimationSettlement || self.animator || [self deferGeometryUpdate]) return;
+    self.needsAnimationSettlement = NO;
+    [UIView performWithoutAnimation:^{
+        // Queued updates may replace items or start a spring; use live state.
+        [self publishExpandedState];
+        if (self.animator) return;
+        // Publishing can synchronously open another menu; defer cleanup again.
+        if ([self deferGeometryUpdate]) {
+            self.needsAnimationSettlement = YES;
+            return;
+        }
+        for (ApolloNavigationActionsStrip *strip in self.strips) {
+            [strip displayExpanded:self.expanded];
+            [strip removeIconAnimations];
+        }
+    }];
+}
+- (void)watchScrollViews {
+    if (!self.controller.isViewLoaded) return;
+    UIGestureRecognizer *backGesture = self.controller.navigationController.interactivePopGestureRecognizer;
+    if (backGesture != self.backGesture) {
+        [self.backGesture removeTarget:self action:@selector(backGestureChanged:)];
+        self.backGesture = backGesture;
+        [backGesture addTarget:self action:@selector(backGestureChanged:)];
+    }
+    UIView *root = self.controller.view;
+    if (root == self.scrollRegistrationRoot) return;
+    // Scan once per page; attachment hooks register later scroll views.
+    // Expanding must not rescan loaded post/comment cells.
+    for (UIPanGestureRecognizer *pan in self.pans.allObjects) {
+        ApolloActionsSetScrollOwner(pan, nil);
+    }
+    [self.pans removeAllObjects];
+    self.scrollRegistrationRoot = root;
+    NSMutableArray *queue = [NSMutableArray arrayWithObject:root];
+    for (NSUInteger i = 0; i < queue.count; i++) {
+        UIView *view = queue[i];
+        if ([view isKindOfClass:UIScrollView.class]) {
+            ApolloActionsUpdateScrollOwner((UIScrollView *)view);
+        }
+        [queue addObjectsFromArray:view.subviews];
+    }
+}
+- (void)scrolled:(UIPanGestureRecognizer *)pan {
+    if (self.expanded && (pan.state == UIGestureRecognizerStateBegan || pan.state == UIGestureRecognizerStateChanged)) {
+        [self setExpanded:NO animated:YES];
+    }
+}
+- (void)backGestureChanged:(UIGestureRecognizer *)gesture {
+    if (gesture.state == UIGestureRecognizerStateBegan) [self setExpanded:NO animated:NO];
+}
+@end
+
+static void ApolloActionsPrepare(UINavigationItem *item, NSArray *items) {
+    if (!IsLiquidGlass()) return;
+    ApolloNavigationActionsControllerBox *box = objc_getAssociatedObject(item, &kActionsControllerKey);
+    if (!box.controller || !ApolloActionsAppController(box.controller)) return;
+    [ApolloActionsOwner(item, YES) prepareItems:items];
+}
+
+void ApolloNavigationActionsRefresh(UINavigationBar *bar) {
+    if (!bar || !IsLiquidGlass() || [objc_getAssociatedObject(bar, &kActionsRefreshKey) boolValue]) return;
+    objc_setAssociatedObject(bar, &kActionsRefreshKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak UINavigationBar *weakBar = bar;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UINavigationBar *bar = weakBar;
+        if (!bar) return;
+        objc_setAssociatedObject(bar, &kActionsRefreshKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        UIViewController *top = ApolloActionsNavigation(bar).topViewController;
+        if (!top || bar.topItem != top.navigationItem) return;
+        ApolloActionsPrepare(top.navigationItem, top.navigationItem.rightBarButtonItems);
+    });
+}
+
+CGRect ApolloNavigationActionsCollapsedFrame(UINavigationBar *bar) {
+    ApolloNavigationActionsOwner *owner = ApolloActionsOwner(bar.topItem, NO);
+    for (ApolloNavigationActionsStrip *strip in owner.strips) {
+        if (![strip isDescendantOfView:bar]) continue;
+        CGRect rect = [strip convertRect:strip.bounds toView:bar];
+        return CGRectMake(CGRectGetMaxX(rect) - 44, CGRectGetMidY(rect) - 22, 44, 44);
+    }
+    if (owner.moreItem) {
+        UIView *view = ApolloNavigationActionsItemViewCandidates(owner.moreItem).lastObject;
+        if ([view isDescendantOfView:bar]) {
+            CGRect rect = [view convertRect:view.bounds toView:bar];
+            return CGRectMake(CGRectGetMidX(rect) - 22, CGRectGetMidY(rect) - 22, 44, 44);
+        }
+    }
+    return CGRectNull;
+}
+
+CGRect ApolloNavigationActionsExpandedFrame(UINavigationBar *bar) {
+    ApolloNavigationActionsOwner *owner = ApolloActionsOwner(bar.topItem, NO);
+    if (!owner.expanded) return CGRectNull;
+    CGRect result = CGRectNull;
+    for (ApolloNavigationActionsStrip *strip in owner.strips) {
+        if (![strip isDescendantOfView:bar]) continue;
+        CGRect rect = [strip convertRect:strip.bounds toView:bar];
+        // Model endpoint, not the spring's per-frame glass width. More is
+        // trailing-anchored in either state, including interrupted collapse.
+        rect = CGRectMake(CGRectGetMaxX(rect) - strip.expandedWidth,
+            CGRectGetMidY(rect) - 22, strip.expandedWidth, 44);
+        result = CGRectIsNull(result) ? rect : CGRectUnion(result, rect);
+    }
+    if (owner.moreItem) {
+        for (UIBarButtonItem *item in owner.item.rightBarButtonItems) {
+            if (item.hidden) continue;
+            UIView *view = ApolloNavigationActionsItemViewCandidates(item).lastObject;
+            if (![view isDescendantOfView:bar]) continue;
+            CGRect rect = [view convertRect:view.bounds toView:bar];
+            if (CGRectIsEmpty(rect)) continue;
+            result = CGRectIsNull(result) ? rect : CGRectUnion(result, rect);
+        }
+    }
+    return result;
+}
+
+NSArray<UIView *> *ApolloNavigationActionsManagedRoots(UINavigationBar *bar) {
+    ApolloNavigationActionsOwner *owner = ApolloActionsOwner(bar.topItem, NO);
+    if (owner.strips.count == 0 && !owner.moreItem) return @[];
+    return ApolloNavigationActionsDiscoverGroups(bar, bar.topItem);
+}
+
+%group ApolloNavigationActionsHooks
+%hook UIViewController
+- (UINavigationItem *)navigationItem {
+    UINavigationItem *item = %orig;
+    if (IsLiquidGlass() && ApolloActionsAppController(self)) {
+        ApolloNavigationActionsControllerBox *box = objc_getAssociatedObject(item, &kActionsControllerKey);
+        if (!box) {
+            box = [ApolloNavigationActionsControllerBox new];
+            objc_setAssociatedObject(item, &kActionsControllerKey, box, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        box.controller = self;
+    }
+    return item;
+}
+- (void)viewWillAppear:(BOOL)animated {
+    ApolloActionsPrepare(self.navigationItem, self.navigationItem.rightBarButtonItems);
+    %orig(animated);
+    ApolloActionsPrepare(self.navigationItem, self.navigationItem.rightBarButtonItems);
+}
+- (void)viewWillDisappear:(BOOL)animated {
+    [ApolloActionsOwner(self.navigationItem, NO) setExpanded:NO animated:NO];
+    %orig(animated);
+}
+%end
+
+%hook UINavigationItem
+- (void)setRightBarButtonItems:(NSArray<UIBarButtonItem *> *)items {
+    items = ApolloActionsInboxItems(self, items);
+    ApolloActionsPrepare(self, items);
+    %orig(items);
+    ApolloActionsPrepare(self, self.rightBarButtonItems);
+}
+- (void)setRightBarButtonItems:(NSArray<UIBarButtonItem *> *)items animated:(BOOL)animated {
+    items = ApolloActionsInboxItems(self, items);
+    ApolloActionsPrepare(self, items);
+    %orig(items, animated);
+    ApolloActionsPrepare(self, self.rightBarButtonItems);
+}
+- (void)setRightBarButtonItem:(UIBarButtonItem *)item {
+    ApolloActionsPrepare(self, item ? @[item] : @[]);
+    %orig(item);
+    ApolloActionsPrepare(self, self.rightBarButtonItems);
+}
+- (void)setRightBarButtonItem:(UIBarButtonItem *)item animated:(BOOL)animated {
+    ApolloActionsPrepare(self, item ? @[item] : @[]);
+    %orig(item, animated);
+    ApolloActionsPrepare(self, self.rightBarButtonItems);
+}
+%end
+
+%hook UIBarButtonItem
+- (void)setMenu:(UIMenu *)menu {
+    ApolloNavigationActionsStandardItem *state = sActionsModelWriteDepth ? nil : objc_getAssociatedObject(self, &kActionsStandardMoreKey);
+    if (state.owner) {
+        state.owner.nativeMenu = menu;
+        UIMenu *effectiveMenu = state.owner.expanded ? menu : nil;
+        %orig(effectiveMenu);
+    } else {
+        %orig(menu);
+    }
+}
+- (void)setPrimaryAction:(UIAction *)action {
+    ApolloNavigationActionsStandardItem *state = sActionsModelWriteDepth ? nil : objc_getAssociatedObject(self, &kActionsStandardMoreKey);
+    if (state.owner) state.owner.nativePrimaryAction = action;
+    %orig(action);
+    if (state.owner && !state.owner.expanded) [state.owner applyStandardExpanded:NO];
+}
+- (void)setHidden:(BOOL)hidden {
+    ApolloNavigationActionsStandardItem *state = sActionsModelWriteDepth ? nil : objc_getAssociatedObject(self, &kActionsStandardItemKey);
+    if (state) {
+        state.hidden = hidden;
+        BOOL effectiveHidden = hidden || !state.owner.expanded;
+        %orig(effectiveHidden);
+    } else {
+        %orig(hidden);
+    }
+}
+%end
+
+%hook UIScrollView
+- (void)didMoveToWindow {
+    %orig;
+    if (IsLiquidGlass()) ApolloActionsUpdateScrollOwner(self);
+}
+- (void)didMoveToSuperview {
+    %orig;
+    // Reparenting inside the same window need not change window membership.
+    if (IsLiquidGlass()) ApolloActionsUpdateScrollOwner(self);
+}
+%end
+
+%hook UINavigationController
+- (void)pushViewController:(UIViewController *)controller animated:(BOOL)animated {
+    [ApolloActionsOwner(self.topViewController.navigationItem, NO) setExpanded:NO animated:NO];
+    ApolloActionsPrepare(controller.navigationItem, controller.navigationItem.rightBarButtonItems);
+    %orig(controller, animated);
+}
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    [ApolloActionsOwner(self.topViewController.navigationItem, NO) setExpanded:NO animated:NO];
+    return %orig(animated);
+}
+- (NSArray *)popToViewController:(UIViewController *)controller animated:(BOOL)animated {
+    [ApolloActionsOwner(self.topViewController.navigationItem, NO) setExpanded:NO animated:NO];
+    return %orig(controller, animated);
+}
+- (NSArray *)popToRootViewControllerAnimated:(BOOL)animated {
+    [ApolloActionsOwner(self.topViewController.navigationItem, NO) setExpanded:NO animated:NO];
+    return %orig(animated);
+}
+- (void)setViewControllers:(NSArray *)controllers animated:(BOOL)animated {
+    [ApolloActionsOwner(self.topViewController.navigationItem, NO) setExpanded:NO animated:NO];
+    for (UIViewController *controller in controllers) ApolloActionsPrepare(controller.navigationItem, controller.navigationItem.rightBarButtonItems);
+    %orig(controllers, animated);
+}
+%end
+%end
+
+%ctor {
+    if (@available(iOS 26.0, *)) {
+        %init(ApolloNavigationActionsHooks);
+        ApolloLog(@"[NavigationActions] Page-owned native strip hooks installed");
+    }
+}

--- a/src/ApolloNavigationActionsDiscovery.h
+++ b/src/ApolloNavigationActionsDiscovery.h
@@ -1,0 +1,102 @@
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import "ApolloNavigationActions.h"
+#include <math.h>
+
+// Discover ownership from live item views, not private class names: UIKit may
+// register old platter classes without using them. Discovery is read-only.
+static inline NSArray<UIView *> *ApolloNavigationActionsItemViewCandidates(UIBarButtonItem *item) {
+    NSMutableArray<UIView *> *views = [NSMutableArray array];
+    if (item.customView) [views addObject:item.customView];
+    SEL selector = NSSelectorFromString(@"view");
+    @try {
+        id native = [item respondsToSelector:selector]
+            ? ((id (*)(id, SEL))objc_msgSend)(item, selector)
+            : [item valueForKey:@"view"];
+        if ([native isKindOfClass:UIView.class] && ![views containsObject:native]) [views addObject:native];
+    } @catch (__unused NSException *exception) {
+        // The public customView is still a valid anchor when attached.
+    }
+    return views;
+}
+
+static inline BOOL ApolloNavigationActionsContainsAnchor(UIView *view, NSArray<UIView *> *anchors) {
+    for (UIView *anchor in anchors) if ([anchor isDescendantOfView:view]) return YES;
+    return NO;
+}
+
+static inline BOOL ApolloNavigationActionsSubtreeIsExclusive(UIView *root, NSArray<UIView *> *rightViews,
+                                                              NSArray<UIView *> *leftViews, UIView *titleView) {
+    if (titleView && [titleView isDescendantOfView:root]) return NO;
+    for (UIView *left in leftViews) if ([left isDescendantOfView:root]) return NO;
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:root];
+    for (NSUInteger index = 0; index < queue.count; index++) {
+        UIView *view = queue[index];
+        // Search/title controls are excluded even when exposed as item anchors.
+        if ([view isKindOfClass:UISearchBar.class] || [view isKindOfClass:UITextField.class] ||
+            [NSStringFromClass(view.class) containsString:@"NavigationBarTitleControl"]) return NO;
+        // Custom right items own their entire subtree, including gestures.
+        if (ApolloNavigationActionsViewIsInManagedRoots(view, rightViews)) continue;
+        BOOL containsRight = ApolloNavigationActionsContainsAnchor(view, rightViews);
+        if (([view isKindOfClass:UIControl.class] || [view isKindOfClass:UILabel.class]) && !containsRight) return NO;
+        // Only ancestors of right-item anchors may own platter gestures.
+        if (!containsRight && view.gestureRecognizers.count > 0) return NO;
+        [queue addObjectsFromArray:view.subviews];
+    }
+    return YES;
+}
+
+static inline BOOL ApolloNavigationActionsValidGroupFrame(CGRect rect, CGRect anchorRect,
+                                                           UINavigationBar *bar) {
+    if (CGRectIsNull(rect) || CGRectIsInfinite(rect) || CGRectIsEmpty(rect) ||
+        !isfinite(rect.origin.x) || !isfinite(rect.origin.y) ||
+        !isfinite(rect.size.width) || !isfinite(rect.size.height)) return NO;
+    if (CGRectGetWidth(rect) >= CGRectGetWidth(bar.bounds) - 1.0 ||
+        CGRectGetHeight(rect) > MAX(64.0, CGRectGetHeight(anchorRect) + 16.0) ||
+        CGRectGetMaxY(rect) <= CGRectGetMinY(anchorRect) || CGRectGetMinY(rect) >= CGRectGetMaxY(anchorRect)) return NO;
+    return YES;
+}
+
+static inline NSArray<UIView *> *ApolloNavigationActionsDiscoverGroups(UINavigationBar *bar,
+                                                                      UINavigationItem *item) {
+    if (!bar || !item || CGRectGetWidth(bar.bounds) <= 0) return @[];
+    NSMutableArray<UIView *> *rightViews = [NSMutableArray array];
+    NSMutableArray<UIView *> *leftViews = [NSMutableArray array];
+    for (UIBarButtonItem *button in item.leftBarButtonItems) {
+        for (UIView *view in ApolloNavigationActionsItemViewCandidates(button)) {
+            if ([view isDescendantOfView:bar]) [leftViews addObject:view];
+        }
+    }
+    for (UIBarButtonItem *button in item.rightBarButtonItems) {
+        // UIKit can detach a custom view while retaining its native wrapper.
+        for (UIView *view in ApolloNavigationActionsItemViewCandidates(button)) {
+            // Hidden anchors still belong to the item and stay out of title fitting.
+            CGRect rect = [view isDescendantOfView:bar] ? [view convertRect:view.bounds toView:bar] : CGRectNull;
+            if (ApolloNavigationActionsValidGroupFrame(rect, rect, bar) && ![rightViews containsObject:view]) {
+                [rightViews addObject:view];
+            }
+        }
+    }
+    NSMutableArray<UIView *> *roots = [NSMutableArray array];
+    for (UIView *anchor in rightViews) {
+        CGRect anchorRect = [anchor convertRect:anchor.bounds toView:bar];
+        UIView *root = nil;
+        for (UIView *candidate = anchor; candidate && candidate != bar; candidate = candidate.superview) {
+            CGRect rect = [candidate convertRect:candidate.bounds toView:bar];
+            if (!ApolloNavigationActionsValidGroupFrame(rect, anchorRect, bar) ||
+                !ApolloNavigationActionsSubtreeIsExclusive(candidate, rightViews, leftViews, item.titleView)) break;
+            // Ownership follows item membership, not position or wrapper class:
+            // split right-item groups may cross the midpoint in either direction.
+            // The guards above exclude shared planes and unrelated controls.
+            root = candidate;
+        }
+        if (!root) continue;
+        BOOL covered = NO;
+        for (UIView *existing in [roots copy]) {
+            if ([root isDescendantOfView:existing]) { covered = YES; break; }
+            if ([existing isDescendantOfView:root]) [roots removeObject:existing];
+        }
+        if (!covered) [roots addObject:root];
+    }
+    return roots;
+}

--- a/src/ApolloNavigationTitleGeometry.h
+++ b/src/ApolloNavigationTitleGeometry.h
@@ -1,0 +1,80 @@
+#ifndef ApolloNavigationTitleGeometry_h
+#define ApolloNavigationTitleGeometry_h
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <math.h>
+
+typedef struct {
+    CGFloat center;
+    CGFloat maximumContentWidth;
+} ApolloNavigationTitleGeometry;
+
+// Coordinates are physical left/right in barBounds' space; callers resolve RTL.
+// Edges come from buttons or safe-area boundaries on empty sides. Use the
+// collapsed pill edge so expansion never changes the title's centered base size.
+// center is the bar midpoint. Enforce maximumContentWidth before centering;
+// it excludes capsule padding, and zero means hide the content and capsule.
+// Invalid/negative sizes and padding become zero; invalid edges use bar boundaries.
+static inline ApolloNavigationTitleGeometry ApolloNavigationTitleCenteredGeometry(
+    CGRect barBounds, CGFloat leftEdge, CGFloat rightEdge,
+    CGFloat capsulePadding, CGFloat edgePadding) {
+    CGFloat barMin = isfinite(barBounds.origin.x) ? barBounds.origin.x : 0.0;
+    CGFloat barWidth = isfinite(barBounds.size.width) && barBounds.size.width > 0.0
+        ? barBounds.size.width : 0.0;
+    CGFloat barMax = barMin + barWidth;
+    // Even individually finite caller values can overflow when combined.
+    if (!isfinite(barMax)) {
+        barWidth = 0.0;
+        barMax = barMin;
+    }
+    CGFloat barCenter = barMin + barWidth * 0.5;
+
+    CGFloat left = isfinite(leftEdge) ? fmin(fmax(leftEdge, barMin), barMax) : barMin;
+    CGFloat right = isfinite(rightEdge) ? fmin(fmax(rightEdge, barMin), barMax) : barMax;
+    CGFloat sidePadding = isfinite(edgePadding) && edgePadding > 0.0 ? edgePadding : 0.0;
+    CGFloat glassPadding = isfinite(capsulePadding) && capsulePadding > 0.0 ? capsulePadding : 0.0;
+
+    ApolloNavigationTitleGeometry result = { barCenter, 0.0 };
+    CGFloat availableHalfWidth = fmin(barCenter - left, right - barCenter);
+    // Use the tighter side symmetrically; subtract padding before doubling to avoid overflow.
+    if (availableHalfWidth <= 0.0 || sidePadding >= availableHalfWidth) return result;
+    availableHalfWidth -= sidePadding;
+    if (glassPadding >= availableHalfWidth) return result;
+
+    result.maximumContentWidth = (availableHalfWidth - glassPadding) * 2.0;
+    return result;
+}
+
+// For expanded right-hand actions, shift the full title capsule left only enough
+// to clear the pill, bounded by the left controls/safe area. Never resize it;
+// the caller handles any remaining overlap. Collapse targets an offset of zero.
+// Use the unshifted title frame and final expanded edge, not animated frames.
+// Coordinates are physical in barBounds' space. Nonfinite/empty frames don't move;
+// invalid edges use bar boundaries, and negative/invalid padding becomes zero.
+static inline CGFloat ApolloNavigationTitleExpandedActionsOffset(
+    CGRect barBounds, CGRect centeredTitleFrame, CGFloat leftEdge,
+    CGFloat expandedActionsLeftEdge, CGFloat edgePadding) {
+    CGFloat barMin = barBounds.origin.x;
+    CGFloat barWidth = barBounds.size.width;
+    CGFloat titleMin = centeredTitleFrame.origin.x;
+    CGFloat titleWidth = centeredTitleFrame.size.width;
+    if (!isfinite(barMin) || !isfinite(barWidth) || barWidth <= 0.0 ||
+        !isfinite(titleMin) || !isfinite(titleWidth) || titleWidth <= 0.0) return 0.0;
+
+    CGFloat barMax = barMin + barWidth;
+    CGFloat titleMax = titleMin + titleWidth;
+    if (!isfinite(barMax) || !isfinite(titleMax)) return 0.0;
+
+    CGFloat left = isfinite(leftEdge) ? fmin(fmax(leftEdge, barMin), barMax) : barMin;
+    CGFloat right = isfinite(expandedActionsLeftEdge)
+        ? fmin(fmax(expandedActionsLeftEdge, barMin), barMax) : barMax;
+    CGFloat padding = isfinite(edgePadding) && edgePadding > 0.0 ? edgePadding : 0.0;
+    CGFloat leftTravel = titleMin - left - padding;
+    CGFloat neededTravel = titleMax - right + padding;
+    if (!isfinite(leftTravel) || !isfinite(neededTravel) ||
+        leftTravel <= 0.0 || neededTravel <= 0.0) return 0.0;
+
+    return -fmin(leftTravel, neededTravel);
+}
+
+#endif

--- a/src/ApolloNavigationTitlePresentation.h
+++ b/src/ApolloNavigationTitlePresentation.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+__BEGIN_DECLS
+
+// Deferred, change-gated presentation maintenance. Safe to call from bar layout.
+// The UINavigationItem model and the actual custom titleView remain unchanged.
+void ApolloNavigationTitlePresentationRefresh(UINavigationBar *navigationBar);
+BOOL ApolloNavigationTitlePresentationOwnsControl(UIView *titleControl);
+BOOL ApolloNavigationTitlePresentationSuppressesControl(UIView *titleControl);
+BOOL ApolloNavigationTitleContainsNativeSearchSurface(UIView *view);
+
+__END_DECLS

--- a/src/ApolloNavigationTitlePresentation.xm
+++ b/src/ApolloNavigationTitlePresentation.xm
@@ -1,0 +1,773 @@
+#import "ApolloNavigationTitlePresentation.h"
+#import "ApolloNavigationActions.h"
+#import "ApolloCommon.h"
+#import <objc/message.h>
+#import <objc/runtime.h>
+#include <string.h>
+
+// UIKit may hide the title to fit the uncollapsed action group. Host a native
+// title control outside that allocator, preserving the item's original custom
+// view, actions and interactions rather than cloning or replacing them.
+static char kApolloTitlePresentationOwnerKey;
+static char kApolloTitlePresentationItemOwnerKey;
+static char kApolloTitlePresentationItemTokenKey;
+static char kApolloTitlePresentationOwnedKey;
+static char kApolloTitlePresentationSourceKey;
+static NSUInteger sApolloTitlePresentationWriteDepth;
+
+static BOOL ApolloTitlePresentationAvailable(void) {
+    // IsLiquidGlass checks the linked SDK; also require a glass-capable OS.
+    return IsLiquidGlass() && objc_getClass("UIGlassEffect") != Nil &&
+        objc_getClass("_UINavigationBarTitleControl") != Nil;
+}
+
+@interface _UINavigationBarTitleControl : UIControl
+@end
+
+@class ApolloTitlePresentationOwner;
+
+@interface ApolloTitlePresentationOwnerBox : NSObject
+@property (nonatomic, weak) ApolloTitlePresentationOwner *owner;
+@end
+@implementation ApolloTitlePresentationOwnerBox
+@end
+
+@interface ApolloTitlePresentationSource : NSObject
+@property (nonatomic, weak) UIView *view;
+@property (nonatomic, weak) ApolloTitlePresentationOwner *owner;
+@property (nonatomic, strong) id navigationItemToken;
+@property (nonatomic) CGFloat nativeAlpha;
+@property (nonatomic) BOOL nativeHidden;
+@property (nonatomic) BOOL nativeInteraction;
+@property (nonatomic) BOOL nativeAccessibilityHidden;
+@property (nonatomic, copy) NSDictionary *attributes;
+@property (nonatomic, copy) id menuProvider;
+@property (nonatomic, strong) id documentProperties;
+@property (nonatomic, strong) UIView *customView;
+@property (nonatomic, copy) NSAttributedString *attributedTitle;
+@end
+@implementation ApolloTitlePresentationSource
+@end
+
+@interface ApolloTitlePresentationOwner : NSObject
+@property (nonatomic, weak) UINavigationBar *bar;
+@property (nonatomic, weak) UINavigationItem *item;
+@property (nonatomic, strong) UIView *control;
+@property (nonatomic, strong) NSMutableArray<ApolloTitlePresentationSource *> *sources;
+@property (nonatomic, strong) NSArray<NSLayoutConstraint *> *placementConstraints;
+@property (nonatomic, strong) NSLayoutConstraint *topConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *heightConstraint;
+@property (nonatomic, strong) UIView *customView;
+@property (nonatomic) CGRect customOriginalFrame;
+@property (nonatomic) BOOL customOriginalTAMIC;
+@property (nonatomic) UIViewAutoresizing customOriginalAutoresizingMask;
+@property (nonatomic, copy) NSDictionary *appliedAttributes;
+@property (nonatomic, copy) id appliedMenu;
+@property (nonatomic, strong) id appliedDocument;
+@property (nonatomic, copy) NSAttributedString *appliedTitle;
+@property (nonatomic, strong) UIFont *appliedPreferredFont;
+@property (nonatomic, strong) id<UIViewControllerTransitionCoordinator> pendingTransition;
+@property (nonatomic, weak) id<UIViewControllerTransitionCoordinator> completedTransition;
+@property (nonatomic) BOOL ready;
+@property (nonatomic) BOOL scheduled;
+@property (nonatomic) BOOL refreshing;
+@property (nonatomic, copy) NSString *lastHostDiagnostic;
+- (instancetype)initWithBar:(UINavigationBar *)bar;
+- (void)scheduleRefresh;
+- (void)refresh;
+- (void)resetPresentation;
+- (void)restoreSource:(ApolloTitlePresentationSource *)source;
+- (ApolloTitlePresentationSource *)captureSource:(UIView *)view;
+@end
+
+static id ApolloTitlePresentationRead(id object, NSString *name) {
+    SEL selector = NSSelectorFromString(name);
+    return [object respondsToSelector:selector]
+        ? ((id (*)(id, SEL))objc_msgSend)(object, selector) : nil;
+}
+
+static id ApolloTitlePresentationItemToken(UINavigationItem *item) {
+    if (!item) return nil;
+    id token = objc_getAssociatedObject(item, &kApolloTitlePresentationItemTokenKey);
+    if (!token) {
+        token = [NSObject new];
+        objc_setAssociatedObject(item, &kApolloTitlePresentationItemTokenKey, token,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return token;
+}
+
+static id ApolloTitlePresentationReadOrCaptured(id object, NSString *name, id captured) {
+    SEL selector = NSSelectorFromString(name);
+    // A supported getter's nil clears the value; never replay stale metadata.
+    return [object respondsToSelector:selector]
+        ? ((id (*)(id, SEL))objc_msgSend)(object, selector) : captured;
+}
+
+static NSAttributedString *ApolloTitlePresentationSourceTitle(ApolloTitlePresentationSource *source) {
+    UIView *view = source.view;
+    BOOL hasAttributedGetter = [view respondsToSelector:NSSelectorFromString(@"attributedTitle")];
+    NSAttributedString *title = ApolloTitlePresentationReadOrCaptured(view, @"attributedTitle", source.attributedTitle);
+    if (hasAttributedGetter && title) return title;
+    if ([view respondsToSelector:NSSelectorFromString(@"title")]) {
+        NSString *plain = ApolloTitlePresentationRead(view, @"title");
+        // Preserve matching formatting, but honor direct plaintext updates.
+        if ([plain isKindOfClass:NSString.class]) {
+            return [title.string isEqualToString:plain] ? title : [[NSAttributedString alloc] initWithString:plain];
+        }
+        return nil;
+    }
+    return title;
+}
+
+static BOOL ApolloTitlePresentationEqual(id left, id right) {
+    return left == right || [left isEqual:right];
+}
+
+static BOOL ApolloTitlePresentationIsControl(UIView *view) {
+    Class cls = NSClassFromString(@"_UINavigationBarTitleControl");
+    return cls && [view isKindOfClass:cls];
+}
+
+static UINavigationController *ApolloTitlePresentationNavigation(UINavigationBar *bar) {
+    for (UIResponder *responder = bar; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:UINavigationController.class] &&
+            ((UINavigationController *)responder).navigationBar == bar) {
+            return (UINavigationController *)responder;
+        }
+    }
+    return nil;
+}
+
+static BOOL ApolloTitlePresentationIsAppNavigation(UINavigationController *navigation) {
+    if ([NSStringFromClass(navigation.class) hasPrefix:@"Apollo."]) return YES;
+    const char *image = class_getImageName(navigation.topViewController.class);
+    if (!image) return NO;
+    return [[NSString stringWithUTF8String:image] hasPrefix:NSBundle.mainBundle.bundlePath] ||
+        strstr(image, "ApolloReborn") != NULL;
+}
+
+static UIView *ApolloTitlePresentationSourceAncestor(UIView *custom) {
+    // Follow the custom view even if UIKit detached its title subtree.
+    for (UIView *view = custom.superview; view; view = view.superview) {
+        if (ApolloTitlePresentationIsControl(view) &&
+            !ApolloNavigationTitlePresentationOwnsControl(view)) return view;
+    }
+    return nil;
+}
+
+static BOOL ApolloTitlePresentationVisible(UIView *view, UINavigationBar *bar) {
+    if (!view.window || ![view isDescendantOfView:bar]) return NO;
+    for (UIView *ancestor = view; ancestor && ancestor != bar; ancestor = ancestor.superview) {
+        ApolloTitlePresentationSource *state = objc_getAssociatedObject(ancestor, &kApolloTitlePresentationSourceKey);
+        CGFloat alpha = state ? state.nativeAlpha : ancestor.alpha;
+        BOOL hidden = state ? state.nativeHidden : ancestor.hidden;
+        if (hidden || alpha <= 0.01) return NO;
+    }
+    return YES;
+}
+
+static UIView *ApolloTitlePresentationHost(UINavigationBar *bar) {
+    Class hostClass = NSClassFromString(@"_UINavigationBarHostedViewContainer");
+    if (!hostClass || CGRectGetWidth(bar.bounds) <= 0) return nil;
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:bar];
+    for (NSUInteger index = 0; index < queue.count; index++) {
+        UIView *view = queue[index];
+        if (ApolloTitlePresentationIsControl(view)) continue;
+        if ([view isKindOfClass:hostClass] && view.userInteractionEnabled &&
+            ApolloTitlePresentationVisible(view, bar)) {
+            CGRect rect = [view convertRect:view.bounds toView:bar];
+            // Use the full-width plane below the actions, not narrower wrappers
+            // whose width UIKit allocates from the action group.
+            if (!CGRectIsNull(rect) && !CGRectIsInfinite(rect) && !CGRectIsEmpty(rect) &&
+                CGRectGetMinX(rect) <= CGRectGetMinX(bar.bounds) + 1.0 &&
+                CGRectGetMaxX(rect) >= CGRectGetMaxX(bar.bounds) - 1.0 &&
+                CGRectIntersectsRect(rect, bar.bounds)) return view;
+        }
+        [queue addObjectsFromArray:view.subviews];
+    }
+    return nil;
+}
+
+static NSArray<UIView *> *ApolloTitlePresentationVisibleSources(UINavigationBar *bar, UINavigationItem *item) {
+    NSMutableArray<UIView *> *result = [NSMutableArray array];
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:bar];
+    NSAttributedString *itemAttributed = ApolloTitlePresentationRead(item, @"attributedTitle");
+    NSString *expectedTitle = itemAttributed.string ?: item.title ?: @"";
+    for (NSUInteger index = 0; index < queue.count; index++) {
+        UIView *view = queue[index];
+        if (ApolloNavigationTitlePresentationOwnsControl(view)) continue;
+        if (ApolloTitlePresentationIsControl(view)) {
+            if (!ApolloTitlePresentationVisible(view, bar)) continue;
+            ApolloTitlePresentationSource *state = objc_getAssociatedObject(view, &kApolloTitlePresentationSourceKey);
+            UIView *custom = state ? state.customView : ApolloTitlePresentationRead(view, @"titleView");
+            NSString *title = state ? ApolloTitlePresentationSourceTitle(state).string : ApolloTitlePresentationRead(view, @"title");
+            if (item.titleView ? custom == item.titleView : (!custom && [title ?: @"" isEqualToString:expectedTitle])) {
+                [result addObject:view];
+            }
+            continue;
+        }
+        [queue addObjectsFromArray:view.subviews];
+    }
+    return result;
+}
+
+static SEL ApolloTitlePresentationConfigureSelector(void) {
+    return NSSelectorFromString(@"setTitleAttributes:titleMenuProvider:documentProperties:titleView:attributedTitle:");
+}
+
+static void ApolloTitlePresentationConfigure(UIView *control, NSDictionary *attributes,
+                                             id menu, id document, UIView *custom,
+                                             NSAttributedString *title) {
+    sApolloTitlePresentationWriteDepth++;
+    ((BOOL (*)(id, SEL, id, id, id, id, id))objc_msgSend)(control,
+        ApolloTitlePresentationConfigureSelector(), attributes, menu, document, custom, title);
+    [control setNeedsUpdateConstraints];
+    [control updateConstraintsIfNeeded];
+    sApolloTitlePresentationWriteDepth--;
+}
+
+static void ApolloTitlePresentationDetachCustom(UIView *source) {
+    if (!source || ![source respondsToSelector:NSSelectorFromString(@"setTitleView:")]) return;
+    sApolloTitlePresentationWriteDepth++;
+    ((void (*)(id, SEL, id))objc_msgSend)(source, NSSelectorFromString(@"setTitleView:"), nil);
+    // Tear down _UITAMICAdaptorView before transfer; otherwise it keeps writing
+    // the custom view's frame after reparenting.
+    [source setNeedsUpdateConstraints];
+    [source updateConstraintsIfNeeded];
+    sApolloTitlePresentationWriteDepth--;
+}
+
+@implementation ApolloTitlePresentationOwner
+
+- (instancetype)initWithBar:(UINavigationBar *)bar {
+    self = [super init];
+    if (!self) return nil;
+    _bar = bar;
+    _sources = [NSMutableArray array];
+    return self;
+}
+
+- (void)dealloc {
+    [self resetPresentation];
+}
+
+- (void)scheduleRefresh {
+    if (self.scheduled) return;
+    self.scheduled = YES;
+    __weak ApolloTitlePresentationOwner *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloTitlePresentationOwner *owner = weakSelf;
+        if (!owner) return;
+        owner.scheduled = NO;
+        [owner refresh];
+    });
+}
+
+- (ApolloTitlePresentationSource *)captureSource:(UIView *)view {
+    if (!view || view == self.control) return nil;
+    ApolloTitlePresentationSource *state = objc_getAssociatedObject(view, &kApolloTitlePresentationSourceKey);
+    if (state && state.owner != self) [state.owner restoreSource:state];
+    state = objc_getAssociatedObject(view, &kApolloTitlePresentationSourceKey);
+    if (state) return state;
+    state = [ApolloTitlePresentationSource new];
+    state.view = view;
+    state.owner = self;
+    state.navigationItemToken = ApolloTitlePresentationItemToken(self.item);
+    state.nativeAlpha = view.alpha;
+    state.nativeHidden = view.hidden;
+    state.nativeInteraction = view.userInteractionEnabled;
+    state.nativeAccessibilityHidden = view.accessibilityElementsHidden;
+    state.attributes = ApolloTitlePresentationRead(view, @"titleAttributes");
+    state.menuProvider = ApolloTitlePresentationRead(view, @"titleMenuProvider");
+    state.documentProperties = ApolloTitlePresentationRead(view, @"documentProperties");
+    state.customView = ApolloTitlePresentationRead(view, @"titleView");
+    state.attributedTitle = ApolloTitlePresentationRead(view, @"attributedTitle");
+    if (!state.attributedTitle) {
+        NSString *plainTitle = ApolloTitlePresentationRead(view, @"title");
+        if ([plainTitle isKindOfClass:NSString.class]) {
+            state.attributedTitle = [[NSAttributedString alloc] initWithString:plainTitle];
+        }
+    }
+    objc_setAssociatedObject(view, &kApolloTitlePresentationSourceKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self.sources addObject:state];
+    return state;
+}
+
+- (void)restoreSource:(ApolloTitlePresentationSource *)state {
+    UIView *view = state.view;
+    if (!view) return;
+    if (objc_getAssociatedObject(view, &kApolloTitlePresentationSourceKey) != state) return;
+    objc_setAssociatedObject(view, &kApolloTitlePresentationSourceKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    sApolloTitlePresentationWriteDepth++;
+    // Restore only titleView; preserve native metadata updates made while hidden.
+    SEL setTitleView = NSSelectorFromString(@"setTitleView:");
+    if ([view respondsToSelector:setTitleView] &&
+        ApolloTitlePresentationRead(view, @"titleView") != state.customView) {
+        ((void (*)(id, SEL, id))objc_msgSend)(view, setTitleView, state.customView);
+        [view setNeedsUpdateConstraints];
+        [view updateConstraintsIfNeeded];
+    }
+    view.alpha = state.nativeAlpha;
+    view.hidden = state.nativeHidden;
+    view.userInteractionEnabled = state.nativeInteraction;
+    view.accessibilityElementsHidden = state.nativeAccessibilityHidden;
+    sApolloTitlePresentationWriteDepth--;
+}
+
+- (void)resetPresentation {
+    self.ready = NO;
+    // Release our adaptor before the native control reclaims the custom view.
+    ApolloTitlePresentationDetachCustom(self.control);
+    [NSLayoutConstraint deactivateConstraints:self.placementConstraints];
+    self.placementConstraints = nil;
+    self.topConstraint = nil;
+    self.heightConstraint = nil;
+    [self.control removeFromSuperview];
+    self.control = nil;
+    if (self.customView) {
+        self.customView.translatesAutoresizingMaskIntoConstraints = self.customOriginalTAMIC;
+        self.customView.autoresizingMask = self.customOriginalAutoresizingMask;
+        self.customView.frame = self.customOriginalFrame;
+    }
+    for (ApolloTitlePresentationSource *state in [self.sources copy]) [self restoreSource:state];
+    [self.sources removeAllObjects];
+    ApolloTitlePresentationOwnerBox *box = objc_getAssociatedObject(self.item, &kApolloTitlePresentationItemOwnerKey);
+    if (box.owner == self) box.owner = nil;
+    self.customView = nil;
+    self.item = nil;
+    self.appliedAttributes = nil;
+    self.appliedMenu = nil;
+    self.appliedDocument = nil;
+    self.appliedTitle = nil;
+    self.appliedPreferredFont = nil;
+}
+
+- (void)refresh {
+    if (self.refreshing) return;
+    UINavigationBar *bar = self.bar;
+    UINavigationController *navigation = ApolloTitlePresentationNavigation(bar);
+    UIViewController *top = navigation.topViewController;
+    UINavigationItem *item = bar.topItem;
+    id<UIViewControllerTransitionCoordinator> transition = top.transitionCoordinator;
+    BOOL transitioning = transition.isAnimated && transition != self.completedTransition;
+    if (!ApolloTitlePresentationAvailable() || !bar.window || !item ||
+        !ApolloTitlePresentationIsAppNavigation(navigation) ||
+        ApolloNavigationTitleContainsNativeSearchSurface(item.titleView)) {
+        BOOL wasReady = self.ready;
+        [self resetPresentation];
+        if (wasReady) ApolloNavigationTitlesRefreshBar(bar);
+        return;
+    }
+    if (transitioning) {
+        if (self.pendingTransition != transition) {
+            self.pendingTransition = transition;
+            __weak ApolloTitlePresentationOwner *weakSelf = self;
+            __weak id<UIViewControllerTransitionCoordinator> weakTransition = transition;
+            [transition animateAlongsideTransition:nil completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                ApolloTitlePresentationOwner *owner = weakSelf;
+                id<UIViewControllerTransitionCoordinator> completed = weakTransition;
+                if (!owner || owner.pendingTransition != completed) return;
+                owner.completedTransition = completed;
+                owner.pendingTransition = nil;
+                [owner scheduleRefresh];
+            }];
+        }
+    }
+    // Keep the centered outgoing title until UIKit promotes the incoming item.
+    if (item != top.navigationItem) return;
+    if (!transitioning) self.pendingTransition = nil;
+    UIView *presentationHost = ApolloTitlePresentationHost(bar);
+    if (!presentationHost) {
+        if (transitioning && self.ready) return;
+        NSString *diagnostic = [NSString stringWithFormat:@"%@ host unavailable", NSStringFromClass(top.class)];
+        if (![diagnostic isEqualToString:self.lastHostDiagnostic]) {
+            self.lastHostDiagnostic = diagnostic;
+            ApolloLog(@"[NavigationTitlePresentation] %@; retaining native title", diagnostic);
+        }
+        BOOL wasReady = self.ready;
+        [self resetPresentation];
+        if (wasReady) ApolloNavigationTitlesRefreshBar(bar);
+        // Retry on the next layout; hosting at bar root would cover the actions.
+        return;
+    }
+    self.refreshing = YES;
+    id itemToken = ApolloTitlePresentationItemToken(item);
+
+    BOOL itemChanged = item != self.item;
+    BOOL newItem = itemChanged || item.titleView != self.customView;
+    BOOL changed = newItem;
+    if (newItem) {
+        // A new-comments title can be replaced after loading. For the same item,
+        // retain its control, placement and glass even after the push completes.
+        BOOL retainOutgoing = self.item && self.control && (transitioning || !itemChanged);
+        if (retainOutgoing) {
+            ApolloTitlePresentationOwnerBox *oldBox = objc_getAssociatedObject(self.item,
+                &kApolloTitlePresentationItemOwnerKey);
+            if (oldBox.owner == self) oldBox.owner = nil;
+            // Keep outgoing sources suppressed until transition copies detach;
+            // reuse this centered control for the incoming configuration.
+            ApolloTitlePresentationDetachCustom(self.control);
+            if (self.customView) {
+                self.customView.translatesAutoresizingMaskIntoConstraints = self.customOriginalTAMIC;
+                self.customView.autoresizingMask = self.customOriginalAutoresizingMask;
+                self.customView.frame = self.customOriginalFrame;
+            }
+            self.customView = nil;
+            self.appliedAttributes = nil;
+            self.appliedMenu = nil;
+            self.appliedDocument = nil;
+            self.appliedTitle = nil;
+            self.appliedPreferredFont = nil;
+        } else {
+            [self resetPresentation];
+        }
+        self.item = item;
+        self.customView = item.titleView;
+        self.customOriginalFrame = self.customView.frame;
+        self.customOriginalTAMIC = self.customView.translatesAutoresizingMaskIntoConstraints;
+        self.customOriginalAutoresizingMask = self.customView.autoresizingMask;
+        ApolloTitlePresentationOwnerBox *box = [ApolloTitlePresentationOwnerBox new];
+        box.owner = self;
+        objc_setAssociatedObject(item, &kApolloTitlePresentationItemOwnerKey, box, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    for (ApolloTitlePresentationSource *source in [self.sources copy]) {
+        if (!source.view) {
+            [self.sources removeObject:source];
+        } else if (!source.navigationItemToken ||
+                   (!transitioning && source.navigationItemToken != itemToken)) {
+            [self restoreSource:source];
+            [self.sources removeObject:source];
+        }
+    }
+    UIView *ancestor = ApolloTitlePresentationSourceAncestor(self.customView);
+    if (ancestor) {
+        NSUInteger count = self.sources.count;
+        [self captureSource:ancestor];
+        changed |= self.sources.count != count;
+    }
+    for (UIView *source in ApolloTitlePresentationVisibleSources(bar, item)) {
+        NSUInteger count = self.sources.count;
+        [self captureSource:source];
+        changed |= self.sources.count != count;
+    }
+    ApolloTitlePresentationSource *source = nil;
+    for (ApolloTitlePresentationSource *candidate in self.sources.reverseObjectEnumerator) {
+        if (candidate.navigationItemToken == itemToken) { source = candidate; break; }
+    }
+
+    NSDictionary *sourceAttributes = ApolloTitlePresentationReadOrCaptured(source.view, @"titleAttributes", source.attributes);
+    NSAttributedString *sourceTitle = ApolloTitlePresentationSourceTitle(source);
+    NSMutableDictionary *attributes = [sourceAttributes mutableCopy] ?: [NSMutableDictionary dictionary];
+    [attributes addEntriesFromDictionary:bar.titleTextAttributes ?: @{}];
+    UIFont *preferredFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline compatibleWithTraitCollection:bar.traitCollection];
+    if (!attributes[NSFontAttributeName]) attributes[NSFontAttributeName] = preferredFont;
+    if (!attributes[NSForegroundColorAttributeName]) attributes[NSForegroundColorAttributeName] = UIColor.labelColor;
+    // The source control owns resolved metadata, including nil. Use the item
+    // only when no source was captured.
+    id menu = source ? ApolloTitlePresentationReadOrCaptured(source.view, @"titleMenuProvider", source.menuProvider)
+        : ApolloTitlePresentationRead(item, @"titleMenuProvider");
+    id document = source ? ApolloTitlePresentationReadOrCaptured(source.view, @"documentProperties", source.documentProperties)
+        : ApolloTitlePresentationRead(item, @"documentProperties");
+    NSAttributedString *title = ApolloTitlePresentationRead(item, @"attributedTitle");
+    // The attributed item title wins; preserve source formatting only for matching text.
+    if (!title && [sourceTitle.string isEqualToString:item.title ?: @""]) title = sourceTitle;
+    if (!title) title = [[NSAttributedString alloc] initWithString:item.title ?: @""];
+    if (!self.customView && title.length == 0 && !menu && !document) {
+        [self resetPresentation];
+        self.refreshing = NO;
+        return;
+    }
+
+    BOOL configurationChanged = !self.control || !ApolloTitlePresentationEqual(attributes, self.appliedAttributes) ||
+        menu != self.appliedMenu || document != self.appliedDocument ||
+        !ApolloTitlePresentationEqual(title, self.appliedTitle) ||
+        !ApolloTitlePresentationEqual(preferredFont, self.appliedPreferredFont);
+    if (!self.control) {
+        Class cls = NSClassFromString(@"_UINavigationBarTitleControl");
+        UIView *control = [[cls alloc] initWithFrame:CGRectMake(0, 0, 1, 21)];
+        if (!control || ![control respondsToSelector:ApolloTitlePresentationConfigureSelector()]) {
+            [self resetPresentation];
+            self.refreshing = NO;
+            return;
+        }
+        objc_setAssociatedObject(control, &kApolloTitlePresentationOwnedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        control.translatesAutoresizingMaskIntoConstraints = NO;
+        self.control = control;
+    }
+
+    // Detach all native adaptors for this custom view. Setter hooks keep them
+    // detached until teardown, including during offscreen updates.
+    if (self.customView) {
+        for (ApolloTitlePresentationSource *state in self.sources) {
+            if (ApolloTitlePresentationRead(state.view, @"titleView") == self.customView) {
+                ApolloTitlePresentationDetachCustom(state.view);
+            }
+        }
+    }
+    if (configurationChanged || (self.customView && ![self.customView isDescendantOfView:self.control])) {
+        ApolloTitlePresentationConfigure(self.control, attributes, menu, document, self.customView, title);
+        SEL setContentAlpha = NSSelectorFromString(@"setContentAlpha:");
+        if ([self.control respondsToSelector:setContentAlpha]) {
+            ((void (*)(id, SEL, CGFloat))objc_msgSend)(self.control, setContentAlpha, 1.0);
+        }
+        self.appliedAttributes = attributes;
+        self.appliedMenu = menu;
+        self.appliedDocument = document;
+        self.appliedTitle = title;
+        self.appliedPreferredFont = preferredFont;
+        changed = YES;
+    }
+
+    CGFloat height = self.customView.intrinsicContentSize.height;
+    if (!isfinite(height) || height <= 0) height = CGRectGetHeight(source.view.bounds);
+    if (!isfinite(height) || height <= 0) height = CGRectGetHeight(self.customView.bounds);
+    if (!isfinite(height) || height <= 0) height = ((UIFont *)attributes[NSFontAttributeName]).lineHeight;
+    height = MIN(44.0, MAX(1.0, ceil(height)));
+    CGRect actionsFrame = ApolloNavigationActionsCollapsedFrame(bar);
+    CGFloat centerY = CGRectGetMinY(bar.bounds) + MIN(CGRectGetHeight(bar.bounds), 44.0) / 2.0;
+    if (!CGRectIsNull(actionsFrame) && !CGRectIsEmpty(actionsFrame)) {
+        centerY = CGRectGetMidY(actionsFrame);
+    } else {
+        NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:bar];
+        for (NSUInteger index = 0; index < queue.count; index++) {
+            UIView *view = queue[index];
+            if (view == self.control || view.hidden || view.alpha <= 0.01) continue;
+            if ([NSStringFromClass(view.class) containsString:@"NavigationBarPlatterView"]) {
+                CGRect rect = [view convertRect:view.bounds toView:bar];
+                if (!CGRectIsEmpty(rect)) { centerY = CGRectGetMidY(rect); break; }
+            }
+            [queue addObjectsFromArray:view.subviews];
+        }
+    }
+    CGFloat topOffset = centerY - CGRectGetMinY(bar.bounds) - height / 2.0;
+    if (self.control.superview != presentationHost) {
+        [NSLayoutConstraint deactivateConstraints:self.placementConstraints];
+        [presentationHost addSubview:self.control];
+        self.topConstraint = [self.control.topAnchor constraintEqualToAnchor:bar.topAnchor constant:topOffset];
+        self.heightConstraint = [self.control.heightAnchor constraintEqualToConstant:height];
+        self.placementConstraints = @[
+            [self.control.centerXAnchor constraintEqualToAnchor:bar.centerXAnchor],
+            self.topConstraint, self.heightConstraint
+        ];
+        // The glass controller's priority-999 constraint owns the fitted width.
+        [NSLayoutConstraint activateConstraints:self.placementConstraints];
+        changed = YES;
+    } else {
+        if (fabs(self.topConstraint.constant - topOffset) > 0.1) {
+            self.topConstraint.constant = topOffset;
+            changed = YES;
+        }
+        if (fabs(self.heightConstraint.constant - height) > 0.1) {
+            self.heightConstraint.constant = height;
+            changed = YES;
+        }
+    }
+
+    // Reattaching the hosted plane can deactivate bar constraints without
+    // changing this control's parent. Restore missing constraints outside layout.
+    for (NSLayoutConstraint *constraint in self.placementConstraints) {
+        if (!constraint.active) {
+            constraint.active = YES;
+            changed = YES;
+        }
+    }
+
+    // Moving into the window may create a deferred adaptor; update before
+    // checking whether the custom view was adopted.
+    [self.control updateConstraintsIfNeeded];
+    BOOL customReady = !self.customView || [self.customView isDescendantOfView:self.control];
+    self.ready = self.control.window == bar.window && customReady;
+    if (self.ready) {
+        sApolloTitlePresentationWriteDepth++;
+        for (ApolloTitlePresentationSource *state in self.sources) {
+            UIView *view = state.view;
+            if (view.alpha != 0) view.alpha = 0;
+            if (view.userInteractionEnabled) view.userInteractionEnabled = NO;
+            if (!view.accessibilityElementsHidden) view.accessibilityElementsHidden = YES;
+        }
+        sApolloTitlePresentationWriteDepth--;
+    } else {
+        [self resetPresentation];
+    }
+    if (self.ready && (newItem || configurationChanged)) {
+        // Fit immediately so a new multiline title never shows the old JumpBar offset.
+        ApolloNavigationTitleGlassRefreshContent(self.control, !itemChanged);
+    }
+    self.refreshing = NO;
+    NSString *diagnostic = [NSString stringWithFormat:@"%@ host=%@ ready=%d sources=%lu",
+        NSStringFromClass(top.class), NSStringFromClass(presentationHost.class), self.ready, (unsigned long)self.sources.count];
+    if (![diagnostic isEqualToString:self.lastHostDiagnostic]) {
+        self.lastHostDiagnostic = diagnostic;
+        ApolloLog(@"[NavigationTitlePresentation] %@", diagnostic);
+    }
+    if (changed) {
+        [bar setNeedsLayout];
+        ApolloNavigationTitlesRefreshBar(bar);
+        ApolloLogDebug(@"[NavigationTitlePresentation] %@ native title ready=%d custom=%d sources=%lu",
+            NSStringFromClass(top.class), self.ready, self.customView != nil, (unsigned long)self.sources.count);
+    }
+}
+@end
+
+void ApolloNavigationTitlePresentationRefresh(UINavigationBar *bar) {
+    if (!bar || !ApolloTitlePresentationAvailable()) return;
+    ApolloTitlePresentationOwner *owner = objc_getAssociatedObject(bar, &kApolloTitlePresentationOwnerKey);
+    if (!owner) {
+        owner = [[ApolloTitlePresentationOwner alloc] initWithBar:bar];
+        objc_setAssociatedObject(bar, &kApolloTitlePresentationOwnerKey, owner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    [owner scheduleRefresh];
+}
+
+BOOL ApolloNavigationTitlePresentationOwnsControl(UIView *control) {
+    return [objc_getAssociatedObject(control, &kApolloTitlePresentationOwnedKey) boolValue];
+}
+
+BOOL ApolloNavigationTitlePresentationSuppressesControl(UIView *control) {
+    ApolloTitlePresentationSource *source = objc_getAssociatedObject(control, &kApolloTitlePresentationSourceKey);
+    return source.owner.ready;
+}
+
+static void ApolloTitlePresentationItemChanged(UINavigationItem *item) {
+    ApolloTitlePresentationOwnerBox *box = objc_getAssociatedObject(item, &kApolloTitlePresentationItemOwnerKey);
+    [box.owner scheduleRefresh];
+}
+
+%group ApolloTitlePresentationHooks
+%hook _UINavigationBarTitleControl
+- (void)setTitleView:(UIView *)view {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) {
+        source.customView = view;
+        %orig(source.owner.ready ? nil : view);
+        [source.owner scheduleRefresh];
+        return;
+    }
+    %orig(view);
+}
+- (BOOL)setTitleAttributes:(NSDictionary *)attributes titleMenuProvider:(id)menu
+        documentProperties:(id)document titleView:(UIView *)view attributedTitle:(NSAttributedString *)title {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) {
+        source.attributes = attributes;
+        source.menuProvider = menu;
+        source.documentProperties = document;
+        source.customView = view;
+        source.attributedTitle = title;
+        // Nested setters must not replace the captured view with our forwarded nil.
+        sApolloTitlePresentationWriteDepth++;
+        BOOL changed = %orig(attributes, menu, document, source.owner.ready ? nil : view, title);
+        sApolloTitlePresentationWriteDepth--;
+        [source.owner scheduleRefresh];
+        return changed;
+    }
+    return %orig(attributes, menu, document, view, title);
+}
+- (void)setAlpha:(CGFloat)alpha {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) {
+        source.nativeAlpha = alpha;
+        %orig(source.owner.ready ? 0.0 : alpha);
+        return;
+    }
+    %orig(alpha);
+}
+- (void)setHidden:(BOOL)hidden {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) source.nativeHidden = hidden;
+    %orig(hidden);
+}
+- (void)setUserInteractionEnabled:(BOOL)enabled {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) {
+        source.nativeInteraction = enabled;
+        %orig(source.owner.ready ? NO : enabled);
+        return;
+    }
+    %orig(enabled);
+}
+- (void)setAccessibilityElementsHidden:(BOOL)hidden {
+    ApolloTitlePresentationSource *source = sApolloTitlePresentationWriteDepth ? nil :
+        objc_getAssociatedObject(self, &kApolloTitlePresentationSourceKey);
+    if (source) {
+        source.nativeAccessibilityHidden = hidden;
+        %orig(source.owner.ready ? YES : hidden);
+        return;
+    }
+    %orig(hidden);
+}
+%end
+
+%hook UINavigationItem
+- (void)setTitle:(NSString *)title {
+    %orig(title);
+    ApolloTitlePresentationItemChanged(self);
+}
+- (void)setTitleView:(UIView *)view {
+    %orig(view);
+    ApolloTitlePresentationItemChanged(self);
+}
+- (void)setAttributedTitle:(NSAttributedString *)title {
+    %orig(title);
+    ApolloTitlePresentationItemChanged(self);
+}
+- (void)setTitleMenuProvider:(id)provider {
+    %orig(provider);
+    ApolloTitlePresentationItemChanged(self);
+}
+- (void)setDocumentProperties:(id)document {
+    %orig(document);
+    ApolloTitlePresentationItemChanged(self);
+}
+%end
+
+%hook UIViewController
+- (void)viewWillAppear:(BOOL)animated {
+    %orig(animated);
+    UINavigationController *navigation = self.navigationController;
+    UINavigationBar *bar = navigation.navigationBar;
+    if (!bar || !ApolloTitlePresentationIsAppNavigation(navigation)) return;
+    ApolloNavigationTitlePresentationRefresh(bar);
+    ApolloTitlePresentationOwner *owner = objc_getAssociatedObject(bar,
+        &kApolloTitlePresentationOwnerKey);
+    if (navigation.topViewController == self && bar.topItem == self.navigationItem) [owner refresh];
+}
+- (void)viewDidAppear:(BOOL)animated {
+    %orig(animated);
+    UINavigationBar *bar = self.navigationController.navigationBar;
+    ApolloTitlePresentationOwner *owner = objc_getAssociatedObject(bar, &kApolloTitlePresentationOwnerKey);
+    if (self.navigationController.topViewController == self) {
+        owner.completedTransition = self.transitionCoordinator;
+        owner.pendingTransition = nil;
+        ApolloNavigationTitlePresentationRefresh(bar);
+    }
+}
+%end
+
+%hook UINavigationBar
+- (void)didMoveToWindow {
+    %orig;
+    ApolloTitlePresentationOwner *owner = objc_getAssociatedObject(self, &kApolloTitlePresentationOwnerKey);
+    if (!self.window) [owner resetPresentation];
+    else ApolloNavigationTitlePresentationRefresh(self);
+}
+- (void)setTitleTextAttributes:(NSDictionary *)attributes {
+    %orig(attributes);
+    ApolloNavigationTitlePresentationRefresh(self);
+}
+%end
+%end
+
+%ctor {
+    Class cls = NSClassFromString(@"_UINavigationBarTitleControl");
+    if (ApolloTitlePresentationAvailable() && [cls instancesRespondToSelector:ApolloTitlePresentationConfigureSelector()]) {
+        %init(ApolloTitlePresentationHooks);
+        ApolloLog(@"[NavigationTitlePresentation] Native title ownership hooks installed");
+    }
+}

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -192,10 +192,6 @@ extern BOOL sIPadTabBarBottom;
 // dock/grow); the field stays put and results populate the feed in place. Liquid Glass only;
 // mutually exclusive with the default nav-hide mode. See ApolloSearchInPlace.xm.
 extern BOOL sKeepSearchBarInPlace;
-// Liquid Glass title placement: ON (default) = centered in the gap between the
-// back pill and the trailing pill; OFF = centered on the screen, nudged only to
-// clear a pill. See ApolloRecenterTitleControl in ApolloLiquidGlass.xm.
-extern BOOL sLGTitleGapCentering;
 // When ON (default), press-and-hold on a post info row shows the glass-slider
 // magnifier loupe: slide to pick an icon, release to activate it (upvote /
 // comments / posted / % upvoted / translation). See ApolloStatsRowTouch.xm.

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -64,7 +64,6 @@ BOOL sClassicTabBarScrollBehavior = NO;
 ApolloTabBarHideStyle sTabBarHideStyle = ApolloTabBarHideStyleLeft;
 BOOL sIPadTabBarBottom = NO;   // opt-in (default OFF via registerDefaults, UDKeyIPadTabBarBottom); iPad-gated in the module
 BOOL sKeepSearchBarInPlace = NO;
-BOOL sLGTitleGapCentering = YES;   // effective default ON via registerDefaults (UDKeyLGTitleGapCentering)
 BOOL sIconRowMagnifier = YES;   // effective default ON via registerDefaults (UDKeyIconRowMagnifier)
 BOOL sInfoRowTapUpvote = YES;      // effective default ON via registerDefaults (UDKeyInfoRowTapUpvote)
 BOOL sInfoRowTapComments = YES;    // effective default ON via registerDefaults (UDKeyInfoRowTapComments)

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -23,6 +23,10 @@ __BEGIN_DECLS
 // YES while a custom theme is active and the table is compiled.
 BOOL ApolloThemeRuntimeIsActive(void);
 
+// Native adaptive label color for Liquid Glass navigation chrome, independent
+// of the custom theme's content palette.
+UIColor *ApolloNavigationChromeColor(void);
+
 // Cached dynamic colour for a token, or nil if inactive / out of range.
 UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token);
 

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -798,9 +798,12 @@ static UIView *NavigationTitleControlForDescendant(UIView *view) {
 }
 
 static BOOL NavigationTitleOwnsButtonLabel(UIView *view) {
-    if (![view isKindOfClass:UILabel.class]) return NO;
+    // Asking UIButton for titleLabel from a label setter re-enters its lazy
+    // title update. Identify the existing generated label without that getter.
+    Class buttonLabelClass = objc_getClass("UIButtonLabel");
+    if (!buttonLabelClass || ![view isKindOfClass:buttonLabelClass]) return NO;
     for (UIView *ancestor = view.superview; ancestor; ancestor = ancestor.superview) {
-        if ([ancestor isKindOfClass:UIButton.class] && ((UIButton *)ancestor).titleLabel == view) {
+        if ([ancestor isKindOfClass:UIButton.class]) {
             // Retain ownership while UIKit moves the title between adaptors.
             return NavigationTitleControlForDescendant(ancestor) != nil ||
                 (!ancestor.window && objc_getAssociatedObject(ancestor, kApolloThemeNavigationButtonTitlesKey) != nil);
@@ -824,7 +827,17 @@ static NSMutableDictionary<NSNumber *, id> *NavigationButtonTitleSources(UIButto
     return sources;
 }
 
+static __thread NSUInteger sNavigationChromeColorReadDepth;
+
+UIColor *ApolloNavigationChromeColor(void) {
+    sNavigationChromeColorReadDepth++;
+    UIColor *color = UIColor.labelColor;
+    sNavigationChromeColorReadDepth--;
+    return color;
+}
+
 static UIColor *NavigationTitlePrimaryColor(void) {
+    if (IsLiquidGlass()) return ApolloNavigationChromeColor();
     return ApolloThemeCurrentSnapshot()->enabled
         ? ApolloThemeRuntimeColor(ApolloThemeTokenLabel) : UIColor.labelColor;
 }
@@ -1744,6 +1757,7 @@ void ApolloThemeRuntimeInvalidate(void) {
 }
 
 + (UIColor *)labelColor {
+    if (sNavigationChromeColorReadDepth) return %orig;
     UIColor *c = SemColor(ApolloThemeTokenLabel, (uintptr_t)__builtin_return_address(0));
     if (c) return c;
     return %orig;
@@ -1965,12 +1979,19 @@ void ApolloThemeRuntimeInvalidate(void) {
 }
 
 - (void)setTextColor:(UIColor *)textColor {
+    if (ApolloThemeCurrentSnapshot()->enabled && NavigationTitleOwnsButtonLabel(self)) {
+        %orig(textColor);
+        return;
+    }
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
     %orig(ThemedTextColorForSourceColor(textColor, (id)self, caller));
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-    if (sAttributedTextAssignmentBypass) {
+    // Navigation buttons already theme their state table. Do not recolor the
+    // generated label again, undoing its native chrome color.
+    if (sAttributedTextAssignmentBypass ||
+        (ApolloThemeCurrentSnapshot()->enabled && NavigationTitleOwnsButtonLabel(self))) {
         %orig(attributedText);
         return;
     }
@@ -2306,6 +2327,26 @@ static void ApolloThemeRestoreOverlayPillText(id node) {
 
 %end // ApolloThemeRuntimeHooks
 
+static char kApolloNavigationDualTitleTintPinnedKey;
+
+%group ApolloNavigationDualTitleChrome
+%hook ApolloDualLabelTitleButton
+
+- (void)setTintColor:(UIColor *)color {
+    // System-button vibrancy uses tint even when attributed text is neutral.
+    UIColor *chrome = ApolloNavigationChromeColor();
+    // Install an explicit tint once; later native nil resets must not restart
+    // UIKit's title transition or return the button to its inherited accent.
+    if (objc_getAssociatedObject(self, &kApolloNavigationDualTitleTintPinnedKey) &&
+        [((UIView *)self).tintColor isEqual:chrome]) return;
+    objc_setAssociatedObject(self, &kApolloNavigationDualTitleTintPinnedKey,
+        @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    %orig(chrome);
+}
+
+%end
+%end
+
 // ===========================================================================
 // Constructor
 // ===========================================================================
@@ -2315,6 +2356,12 @@ static void ApolloThemeRestoreOverlayPillText(id node) {
         FindRuntimeImages();
         BuildByteFilter();
         %init(ApolloThemeRuntimeHooks);
+        if (IsLiquidGlass() && NSClassFromString(@"UIGlassEffect")) {
+            Class dualTitleButton = NSClassFromString(@"Apollo.DualLabelTitleButton");
+            if (dualTitleButton) {
+                %init(ApolloNavigationDualTitleChrome, ApolloDualLabelTitleButton = dualTitleButton);
+            }
+        }
         BOOL haveTM = objc_getClass("_TtC6Apollo12ThemeManager") != nil;
         if (haveTM) %init(ApolloThemeRuntimeManagerHook);
         ApolloLog(@"ThemeRuntime: ctor — UIColor hooks installed, ThemeManager hook=%d", haveTM);

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -403,6 +403,9 @@ static const void *kApolloThemeBackgroundColorPassthroughKey = &kApolloThemeBack
 static const void *kApolloThemeOriginalAttributedTextKey =
     &kApolloThemeOriginalAttributedTextKey;
 static __thread NSInteger sAttributedTextAssignmentBypass;
+static const void *kApolloThemeNavigationButtonTitlesKey =
+    &kApolloThemeNavigationButtonTitlesKey;
+static __thread NSInteger sNavigationButtonTitleAssignmentBypass;
 
 void ApolloThemeRuntimeSetFontPinned(id view, BOOL pinned) {
     if (!view) return;
@@ -787,8 +790,63 @@ static void SetLabelAttributedTextWithoutRecapture(UILabel *label,
     sAttributedTextAssignmentBypass--;
 }
 
+static UIView *NavigationTitleControlForDescendant(UIView *view) {
+    for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
+        if ([NSStringFromClass(ancestor.class) isEqualToString:@"_UINavigationBarTitleControl"]) return ancestor;
+    }
+    return nil;
+}
+
+static BOOL NavigationTitleOwnsButtonLabel(UIView *view) {
+    if (![view isKindOfClass:UILabel.class]) return NO;
+    for (UIView *ancestor = view.superview; ancestor; ancestor = ancestor.superview) {
+        if ([ancestor isKindOfClass:UIButton.class] && ((UIButton *)ancestor).titleLabel == view) {
+            // Retain ownership while UIKit moves the title between adaptors.
+            return NavigationTitleControlForDescendant(ancestor) != nil ||
+                (!ancestor.window && objc_getAssociatedObject(ancestor, kApolloThemeNavigationButtonTitlesKey) != nil);
+        }
+    }
+    return NO;
+}
+
+static NSMutableDictionary<NSNumber *, id> *NavigationButtonTitleSources(UIButton *button,
+                                                                       BOOL create) {
+    NSMutableDictionary *sources = objc_getAssociatedObject(button, kApolloThemeNavigationButtonTitlesKey);
+    if (!sources && create) {
+        sources = [NSMutableDictionary dictionary];
+        // iOS 27 getters fall back to Normal for unset states. Adopt Normal
+        // only; the setter hook captures explicit states without inventing copies.
+        NSAttributedString *normal = [button attributedTitleForState:UIControlStateNormal];
+        if (normal) sources[@(UIControlStateNormal)] = [normal copy];
+        objc_setAssociatedObject(button, kApolloThemeNavigationButtonTitlesKey,
+                                 sources, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return sources;
+}
+
+static UIColor *NavigationTitlePrimaryColor(void) {
+    return ApolloThemeCurrentSnapshot()->enabled
+        ? ApolloThemeRuntimeColor(ApolloThemeTokenLabel) : UIColor.labelColor;
+}
+
+static NSAttributedString *NavigationTitleAttributedText(NSAttributedString *source,
+                                                        id owner, UIColor *primaryColor) {
+    if (!source.length) return source;
+    NSAttributedString *base = ApolloThemeCurrentSnapshot()->enabled
+        ? ThemedAttributedText(source, owner, (uintptr_t)&NavigationTitleAttributedText) : source;
+    if (!primaryColor) return base;
+    NSMutableAttributedString *colored = [base mutableCopy];
+    [colored addAttribute:NSForegroundColorAttributeName value:primaryColor
+                    range:NSMakeRange(0, colored.length)];
+    return colored;
+}
+
+static void ApplyThemeToNavigationTitleControl(UIView *titleControl);
+
 static void RefreshFontOnTextControl(UIView *view, ApolloThemeFont target) {
     if (FontPinned(view)) return;
+    // UIButton owns this label; theme its state table so updates persist.
+    if (NavigationTitleOwnsButtonLabel(view)) return;
     if ([view isKindOfClass:[UILabel class]] &&
         AttributedTextSuppliesAllTextFonts(((UILabel *)view).attributedText)) {
         UILabel *label = (UILabel *)view;
@@ -826,6 +884,11 @@ static BOOL ViewIsFontRefreshable(UIView *view) {
 // bar's labels never chain back to Apollo classes individually). Outside a
 // vetted subtree, each text control is gated exactly like the sink hooks.
 static void RefreshFontsInViewTree(UIView *view, ApolloThemeFont target, BOOL vetted) {
+    if ([NSStringFromClass(view.class) isEqualToString:@"_UINavigationBarTitleControl"]) {
+        // Apply font and color together to avoid briefly restoring old colors.
+        ApplyThemeToNavigationTitleControl(view);
+        return;
+    }
     if (!vetted && ([view isKindOfClass:[UINavigationBar class]] || [view isKindOfClass:[UITabBar class]])) {
         if (!ChromeBarLooksApolloOwned(view)) return; // foreign chrome: leave the whole subtree alone
         vetted = YES;
@@ -864,6 +927,7 @@ static void RethemeFontOnAttach(UIView *view) {
     if (!snapshot->enabled || sFontBypass) return;
     if (!view.window) return;
     if (FontPinned(view)) return;
+    if (NavigationTitleOwnsButtonLabel(view)) return;
     // An attributed label's visible font and color come from its string, while
     // UILabel.font remains the backing line-box font. Theme the attributed
     // runs in place, but leave that backing font untouched: replacing it can
@@ -894,31 +958,57 @@ static void RethemeFontOnAttach(UIView *view) {
     sFontBypass--;
 }
 
-static void ApplyThemeColorToNavigationTitleLabels(UIView *view, UIColor *primaryColor) {
-    const ApolloThemeRuntimeSnapshot *snapshot = ApolloThemeCurrentSnapshot();
+static void ApplyThemeToNavigationTitleContent(UIView *view, ApolloThemeFont target,
+                                              UIColor *primaryColor) {
+    if ([view isKindOfClass:UIButton.class]) {
+        UIButton *button = (UIButton *)view;
+        NSMutableDictionary<NSNumber *, id> *sources = NavigationButtonTitleSources(button, YES);
+        for (NSNumber *state in sources.allKeys) {
+            id source = sources[state];
+            if (source == NSNull.null) continue;
+            NSAttributedString *themed = NavigationTitleAttributedText(source, button, primaryColor);
+            if ([themed isEqualToAttributedString:[button attributedTitleForState:state.unsignedIntegerValue]]) continue;
+            sNavigationButtonTitleAssignmentBypass++;
+            [button setAttributedTitle:themed forState:state.unsignedIntegerValue];
+            sNavigationButtonTitleAssignmentBypass--;
+        }
+        if (![button attributedTitleForState:UIControlStateNormal].length) {
+            // Plain titles use titleLabel.font but button-state colors.
+            UILabel *label = button.titleLabel;
+            UIFont *font = label.font;
+            if (!FontPinned(label) && FontIsThemeable(font)) {
+                sFontBypass++;
+                UIFont *themed = ApolloThemeFontApply(target, font);
+                if (themed && ![themed.fontName isEqualToString:font.fontName]) label.font = themed;
+                sFontBypass--;
+            }
+            if (primaryColor && ![[button titleColorForState:UIControlStateNormal] isEqual:primaryColor]) {
+                [button setTitleColor:primaryColor forState:UIControlStateNormal];
+            }
+        }
+    }
     if ([view isKindOfClass:[UILabel class]]) {
+        if (NavigationTitleOwnsButtonLabel(view)) return;
         UILabel *label = (UILabel *)view;
         NSAttributedString *original =
             objc_getAssociatedObject(label, kApolloThemeOriginalAttributedTextKey);
         NSAttributedString *source = original ?: label.attributedText;
         if (source.length > 0) {
-            NSAttributedString *base = snapshot->enabled
-                ? ThemedAttributedText(source, label,
-                                       (uintptr_t)&ApplyThemeColorToNavigationTitleLabels)
-                : source;
-            NSMutableAttributedString *colored = [base mutableCopy];
-            [colored addAttribute:NSForegroundColorAttributeName
-                            value:primaryColor
-                            range:NSMakeRange(0, colored.length)];
+            // A separate font pass would restore old colors and restart the
+            // two-line comments title's content transitions on every layout.
+            NSAttributedString *colored = NavigationTitleAttributedText(source, label, primaryColor);
             if (![colored isEqualToAttributedString:label.attributedText]) {
                 SetLabelAttributedTextWithoutRecapture(label, colored);
             }
-        } else if (![label.textColor isEqual:primaryColor]) {
-            label.textColor = primaryColor;
+        } else {
+            RefreshFontOnTextControl(view, target);
+            if (primaryColor && ![label.textColor isEqual:primaryColor]) label.textColor = primaryColor;
         }
+    } else if (ViewIsFontRefreshable(view)) {
+        RefreshFontOnTextControl(view, target);
     }
     for (UIView *subview in view.subviews) {
-        ApplyThemeColorToNavigationTitleLabels(subview, primaryColor);
+        ApplyThemeToNavigationTitleContent(subview, target, primaryColor);
     }
 }
 
@@ -929,11 +1019,7 @@ static void ApplyThemeToNavigationTitleControl(UIView *titleControl) {
     ApolloThemeFont target = snapshot->enabled
         ? snapshot->fontChoices[CurrentRuntimeMode()]
         : ApolloThemeFontSystem;
-    RefreshFontsInViewTree(titleControl, target, YES);
-    UIColor *primary = snapshot->enabled
-        ? ApolloThemeRuntimeColor(ApolloThemeTokenLabel)
-        : [UIColor labelColor];
-    if (primary) ApplyThemeColorToNavigationTitleLabels(titleControl, primary);
+    ApplyThemeToNavigationTitleContent(titleControl, target, NavigationTitlePrimaryColor());
 }
 
 // Per-thread text-sink bypass (ASDK builds nodes off the main thread, so a
@@ -1904,6 +1990,27 @@ void ApolloThemeRuntimeInvalidate(void) {
 %hook UIButton
 
 - (void)setAttributedTitle:(NSAttributedString *)title forState:(UIControlState)state {
+    if (sNavigationButtonTitleAssignmentBypass) {
+        %orig(title, state);
+        return;
+    }
+    // Capture both title lines before attachment so retheming uses the raw source.
+    BOOL dualTitle = [NSStringFromClass(self.class) isEqualToString:@"Apollo.DualLabelTitleButton"];
+    NSMutableDictionary<NSNumber *, id> *sources = NavigationButtonTitleSources(self, dualTitle);
+    if (sources) {
+        sources[@(state)] = title ? [title copy] : NSNull.null;
+        UIView *control = NavigationTitleControlForDescendant(self);
+        // Recoloring this system button after attachment triggers UIKit's title
+        // fade-out/in. Apply the glass appearance on its first assignment;
+        // classic builds retain their attach path and the original button.
+        BOOL prepareGlassDualTitle = dualTitle && IsLiquidGlass() &&
+            NSClassFromString(@"UIGlassEffect") != Nil;
+        if (prepareGlassDualTitle ||
+            (control && ChromeBarLooksApolloOwned(NavigationBarForDescendant(control)))) {
+            %orig(NavigationTitleAttributedText(title, self, NavigationTitlePrimaryColor()), state);
+            return;
+        }
+    }
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
     %orig(ThemedAttributedText(title, (id)self, caller), state);
 }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -7110,6 +7110,14 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (ApolloDeferGlobeGeometry(globe, container, ^{
         ApolloApplyGlobeMergeForNavItem(weakItem);
     })) return;
+    // Host changes must update tint too: standalone glass uses native chrome,
+    // while a merged globe keeps the action group's accent and translated state.
+    id target = globe.allTargets.anyObject;
+    UIViewController *controller = [target isKindOfClass:UIViewController.class] ? target : nil;
+    BOOL visibleTranslationApplied = [objc_getAssociatedObject(controller, kApolloVisibleTranslationAppliedKey) boolValue];
+    UIColor *normalTint = IsLiquidGlass() && !container ? ApolloNavigationChromeColor()
+        : (ApolloThemeAccentColor() ?: controller.viewIfLoaded.tintColor ?: UIColor.systemBlueColor);
+    globe.tintColor = visibleTranslationApplied ? UIColor.systemGreenColor : normalTint;
     UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
 
     if (container) {
@@ -7253,7 +7261,11 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (standalone && standalone.customView == globe && [navItem.rightBarButtonItems containsObject:standalone]) {
         return;  // already hosted as its own item — leave UIKit's wrapper alone
     }
-    globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+    // A standalone glass item has its own circular surface, with no neighboring
+    // moderator slot to nudge toward. Preserve legacy edge alignment outside glass.
+    globe.contentHorizontalAlignment = IsLiquidGlass()
+        ? UIControlContentHorizontalAlignmentCenter : UIControlContentHorizontalAlignmentRight;
+    globe.imageEdgeInsets = UIEdgeInsetsZero;
     globe.frame = CGRectMake(0.0, 0.0, kApolloGlobeMergeSlotWidth, 32.0);
     if (!standalone) {
         standalone = [[UIBarButtonItem alloc] initWithCustomView:globe];
@@ -7443,7 +7455,6 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
 
     BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
-    BOOL visibleTranslationApplied = [objc_getAssociatedObject(vc, kApolloVisibleTranslationAppliedKey) boolValue];
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
     UIImage *globeImage = [[UIImage systemImageNamed:@"globe"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -7452,16 +7463,10 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
         globeButton.frame = CGRectMake(0.0, 0.0, 36.0, 32.0);
-        // The standalone fallback right-aligns; a native action container
-        // supplies the final globe slot and centering when one is available.
-        globeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];
 
-    UIColor *themeTintColor = ApolloThemeAccentColor() ?: vc.view.tintColor ?: [UIColor systemBlueColor];
-    UIColor *resolvedTint = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
-    globeButton.tintColor = resolvedTint;
     globeButton.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -10,6 +10,8 @@
 #include <string.h>
 
 #import "ApolloCommon.h"
+#import "ApolloNavigationActions.h"
+#import "ApolloNativeActionMenus.h"
 #import "ApolloDeletedCommentsData.h"
 #import "ApolloState.h"
 #import "ApolloToast.h"
@@ -57,7 +59,6 @@ static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedMode
 // Set when the user explicitly toggled away from a translated thread (so we
 // don't clobber the user's preference when sAutoTranslateOnAppear is on).
 static const void *kApolloThreadOriginalModeKey = &kApolloThreadOriginalModeKey;
-static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
 static const void *kApolloVisibleTranslationAppliedKey = &kApolloVisibleTranslationAppliedKey;
 static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
 // Phase D — vote resilience. When we install a translated string into a text
@@ -86,13 +87,13 @@ static const void *kApolloCommentOwnedTextNodeKey = &kApolloCommentOwnedTextNode
 // The globe-installation code uses this to gate visibility on
 // sTranslatePostTitles in addition to sEnableBulkTranslation.
 static const void *kApolloFeedTranslationVCKey = &kApolloFeedTranslationVCKey;
-// Liquid Glass globe-merge: instead of adding the translation globe as a SEPARATE
-// trailing bar button item (which iOS 26 spaces apart from Apollo's mod/sort/more
-// container with a visible inter-group gap), we inject the globe button directly
-// into Apollo's existing trailing container so all icons form one evenly-spaced
-// group. kApolloGlobeMergeButtonKey holds the globe UIButton on the navigationItem;
-// sApplyingGlobeMerge guards the setRightBarButtonItem(s) re-injection hook.
+// Share the native action container to align the globe with taller moderator
+// buttons and avoid Liquid Glass's inter-item gap (#393). Track it on the nav
+// item; sApplyingGlobeMerge guards rebuild-hook recursion.
 static const void *kApolloGlobeMergeButtonKey = &kApolloGlobeMergeButtonKey;
+// A deferred removal is feature intent, not another layout request. Native
+// item setters must not turn it back into an insertion while the menu is open.
+static const void *kApolloGlobeRemovalPendingKey = &kApolloGlobeRemovalPendingKey;
 // Fallback for screens with no multi-button container to merge into: the globe
 // is shown as its own trailing bar button item (the pre-26 behavior).
 static const void *kApolloGlobeStandaloneItemKey = &kApolloGlobeStandaloneItemKey;
@@ -7009,23 +7010,16 @@ static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewControll
     return YES;
 }
 
-// MARK: - Liquid Glass globe-merge helpers
+// MARK: - Navigation globe-merge helpers
 //
-// On iOS 26, each custom-view UIBarButtonItem is hosted in its own
-// NavigationButtonBar item wrapper, and the bar inserts ~16pt of inter-item
-// spacing between separate items — far more than the ~2-3pt Apollo gets by
-// hand-packing its mod/sort/more buttons into ONE combined custom-view
-// container (CGRectGetMaxX layout). Added as a separate item, the globe sits
-// visibly isolated with a big gap before Apollo's cluster (issue #393). The
-// fix: inject the globe button straight into Apollo's container so every icon
-// is one evenly-spaced group. Apollo rebuilds that container on various events,
-// so the setRightBarButtonItem(s) hook re-applies this after each rebuild.
+// Merge into Apollo's mod/sort/more row on both builds. Standard builds retain
+// native padding and never collapse; item-setter hooks reapply after rebuilds.
 
 // Find Apollo's combined trailing button container for this nav item: a
 // custom-view UIView that holds at least one UIButton OTHER than our globe.
 static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIButton *globe) {
     for (UIBarButtonItem *item in navItem.rightBarButtonItems) {
-        UIView *cv = item.customView;
+        UIView *cv = ApolloNavigationActionsContentView(item);
         if (![cv isKindOfClass:[UIView class]]) continue;
         BOOL hasOtherButton = NO;
         for (UIView *sub in cv.subviews) {
@@ -7071,6 +7065,34 @@ static void ApolloDetachGlobeFromContainer(UIButton *globe) {
 
 static BOOL ApolloButtonGlyphPads(UIButton *btn, CGFloat *outLeft, CGFloat *outRight);
 
+// Match the live neighboring slot, not a stale standalone frame left by UIKit
+// after search or moderator-button updates.
+static void ApolloAlignGlobeInMergedContainer(UIButton *globe, UIView *container) {
+    UIButton *nextButton = nil;
+    for (UIView *sub in container.subviews) {
+        if (sub == globe || ![sub isKindOfClass:UIButton.class] ||
+            CGRectGetWidth(sub.frame) <= 1.0 || CGRectGetHeight(sub.frame) <= 1.0) continue;
+        if (!nextButton || CGRectGetMinX(sub.frame) < CGRectGetMinX(nextButton.frame)) {
+            nextButton = (UIButton *)sub;
+        }
+    }
+    if (!nextButton) return;
+    CGRect slot = nextButton.frame;
+    CGRect frame = CGRectMake(CGRectGetMinX(slot) - kApolloGlobeMergeSlotWidth,
+                              CGRectGetMinY(slot), kApolloGlobeMergeSlotWidth, CGRectGetHeight(slot));
+    if (!CGRectEqualToRect(globe.frame, frame)) globe.frame = frame;
+}
+
+// Freeze both source and destination during native menu morphs. Merge/removal
+// share a key so only the latest requested state replays.
+static BOOL ApolloDeferGlobeGeometry(UIButton *globe, UIView *container, dispatch_block_t update) {
+    UIView *currentSurface = ApolloNavigationActionsMenuSourceView(globe);
+    UIView *destinationSurface = ApolloNavigationActionsMenuSourceView(container);
+    if (ApolloNativeActionMenuDeferNavigationUpdate(currentSurface, @"translation-globe", update)) return YES;
+    return destinationSurface != currentSurface &&
+        ApolloNativeActionMenuDeferNavigationUpdate(destinationSurface, @"translation-globe", update);
+}
+
 // Place the globe correctly for this nav item (idempotent). If Apollo has a
 // multi-button trailing container, inject the globe as its leading button so
 // every icon is one evenly-spaced group (issue #393). Otherwise fall back to a
@@ -7079,15 +7101,23 @@ static BOOL ApolloButtonGlyphPads(UIButton *btn, CGFloat *outLeft, CGFloat *outR
 // setRightBarButtonItem(s) hook.
 static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (!navItem) return;
+    if ([objc_getAssociatedObject(navItem, kApolloGlobeRemovalPendingKey) boolValue]) return;
     UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
     if (!globe) return;
 
     UIView *container = ApolloFindTrailingButtonContainer(navItem, globe);
+    __weak UINavigationItem *weakItem = navItem;
+    if (ApolloDeferGlobeGeometry(globe, container, ^{
+        ApolloApplyGlobeMergeForNavItem(weakItem);
+    })) return;
     UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
 
     if (container) {
         // Prefer the merged layout — drop any standalone fallback we added.
         if (standalone) {
+            // Clear the retained adaptor before reparenting, or its delayed
+            // layout can resize the merged globe to the old standalone frame.
+            if (standalone.customView == globe) standalone.customView = nil;
             NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy];
             if ([its containsObject:standalone]) {
                 [its removeObject:standalone];
@@ -7099,9 +7129,8 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
         }
 
         if (globe.superview == container) {
-            // The visual pill may have been rebuilt around the same custom
-            // view. Keep the title invalidation alive even though the button
-            // geometry itself is already merged.
+            ApolloAlignGlobeInMergedContainer(globe, container);
+            // The pill may have rebuilt around unchanged slots; refresh the title.
             ApolloSubredditRequestTitleRelayout(navItem);
             return;  // already merged — don't double-shift
         }
@@ -7156,10 +7185,12 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
         // the no-globe normalization below applies — by starting the globe
         // slot at the difference. Falls back to bare symmetric insets if
         // either glyph can't be measured.
-        CGFloat globeX = trailInset;
+        // Preserve standard-build insets; only glass needs capsule-edge padding.
+        BOOL liquidGlass = IsLiquidGlass();
+        CGFloat globeX = liquidGlass ? trailInset : leadingX;
         globe.frame = CGRectMake(0.0, 0.0, gw, h);  // size it so glyph pads resolve
         CGFloat gGlyphL = 0.0, gGlyphR = 0.0, lastGlyphL = 0.0, lastGlyphR = 0.0;
-        if (lastBtn &&
+        if (liquidGlass && lastBtn &&
             ApolloButtonGlyphPads(globe, &gGlyphL, &gGlyphR) &&
             ApolloButtonGlyphPads(lastBtn, &lastGlyphL, &lastGlyphR)) {
             CGFloat glyphAware = trailInset + lastGlyphR - gGlyphL;
@@ -7175,6 +7206,7 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
         }
         globe.frame = CGRectMake(globeX, 0.0, gw, h);
         [container insertSubview:globe atIndex:0];
+        ApolloAlignGlobeInMergedContainer(globe, container);
 
         // Resize so the bar item re-measures: content spans [globeX, rightEdge+
         // shift] with a matching trailing inset. Remember the shift for removal.
@@ -7246,7 +7278,15 @@ static void ApolloNormalizeTrailingPillPaddingForNavItem(UINavigationItem *navIt
 // drop any standalone item, and clear tracking.
 static void ApolloRemoveGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (!navItem) return;
+    objc_setAssociatedObject(navItem, kApolloGlobeRemovalPendingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
+    __weak UINavigationItem *weakItem = navItem;
+    if (ApolloDeferGlobeGeometry(globe, ApolloFindTrailingButtonContainer(navItem, globe), ^{
+        UINavigationItem *item = weakItem;
+        if ([objc_getAssociatedObject(item, kApolloGlobeRemovalPendingKey) boolValue]) {
+            ApolloRemoveGlobeMergeForNavItem(item);
+        }
+    })) return;
     ApolloDetachGlobeFromContainer(globe);
     UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
     if (standalone) {
@@ -7263,6 +7303,7 @@ static void ApolloRemoveGlobeMergeForNavItem(UINavigationItem *navItem) {
     [globe removeFromSuperview];
     objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(navItem, kApolloGlobeMergeButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(navItem, kApolloGlobeRemovalPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     // The stock container is asymmetric inside the glass capsule; with the
     // globe gone, give it the same symmetric padding treatment.
     if (IsLiquidGlass()) ApolloNormalizeTrailingPillPaddingForNavItem(navItem);
@@ -7317,9 +7358,16 @@ static const void *kApolloTrailingPadNormalizedKey = &kApolloTrailingPadNormaliz
 
 static void ApolloNormalizeTrailingPillPaddingForNavItem(UINavigationItem *navItem) {
     if (!navItem) return;
+    // A late no-globe request must not overwrite merged-globe padding.
+    if (objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey)) return;
     UIView *container = ApolloFindTrailingButtonContainer(navItem, nil);
     if (!container) return;
     if (objc_getAssociatedObject(container, kApolloTrailingPadNormalizedKey)) return;
+    __weak UINavigationItem *weakItem = navItem;
+    if (ApolloNativeActionMenuDeferNavigationUpdate(ApolloNavigationActionsMenuSourceView(container),
+            @"translation-padding", ^{
+        ApolloNormalizeTrailingPillPaddingForNavItem(weakItem);
+    })) return;
 
     // Locate the first and last button by geometry (Apollo chains slots with
     // CGRectGetMaxX, so subview order matches, but don't rely on it).
@@ -7373,8 +7421,6 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     if (!sEnableBulkTranslation) return;
 
     BOOL isFeedVC = [objc_getAssociatedObject(controller, kApolloFeedTranslationVCKey) boolValue];
-    UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
-    NSMutableArray<UIBarButtonItem *> *items = [vc.navigationItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
     // Comments VCs require sEnableBulkTranslation.
     // Feed VCs additionally require sTranslatePostTitles — the only thing
     // they translate is post titles, so when titles are disabled the globe
@@ -7391,12 +7437,6 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-        if (translationItem) {
-            [items removeObject:translationItem];
-            vc.navigationItem.rightBarButtonItems = items;
-            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        }
-        // Liquid Glass: also pull the globe back out of Apollo's merged container.
         ApolloRemoveGlobeMergeForNavItem(vc.navigationItem);
         ApolloHideAllPostInfoMarkers();
         return;
@@ -7406,25 +7446,14 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     BOOL visibleTranslationApplied = [objc_getAssociatedObject(vc, kApolloVisibleTranslationAppliedKey) boolValue];
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
-    // Globe icon — a UIButton hosted either inside Apollo's trailing container
-    // (Liquid Glass, so it groups evenly with mod/sort/more — issue #393) or as
-    // our own separate bar button item (pre-26, where that's the tuned layout).
-    BOOL liquidGlass = IsLiquidGlass();
-
     UIImage *globeImage = [[UIImage systemImageNamed:@"globe"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 
-    UIButton *globeButton = nil;
-    if (liquidGlass) {
-        globeButton = objc_getAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey);
-    }
-    if (!globeButton && translationItem && [translationItem.customView isKindOfClass:[UIButton class]]) {
-        globeButton = (UIButton *)translationItem.customView;
-    }
+    UIButton *globeButton = objc_getAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey);
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
         globeButton.frame = CGRectMake(0.0, 0.0, 36.0, 32.0);
-        // Pre-26: right-align so the glyph tucks against Apollo's adjacent pill.
-        // Liquid Glass: ApolloApplyGlobeMergeForNavItem re-centers it in the slot.
+        // The standalone fallback right-aligns; a native action container
+        // supplies the final globe slot and centering when one is available.
         globeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
@@ -7437,36 +7466,10 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
 
-    if (liquidGlass) {
-        // Merge the globe into Apollo's combined trailing container so all icons
-        // share one evenly-spaced group. Track the button on the nav item so the
-        // setRightBarButtonItem(s) hook re-injects it after Apollo rebuilds.
-        objc_setAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey, globeButton, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        // Drop any separate bar item from a prior pre-26 run (migration safety).
-        if (translationItem && [items containsObject:translationItem]) {
-            [items removeObject:translationItem];
-            vc.navigationItem.rightBarButtonItems = items;
-            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        }
-        ApolloApplyGlobeMergeForNavItem(vc.navigationItem);
-    } else {
-        if (!translationItem) {
-            translationItem = [[UIBarButtonItem alloc] initWithCustomView:globeButton];
-            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        } else if (translationItem.customView != globeButton) {
-            translationItem.customView = globeButton;
-        }
-        translationItem.menu = nil;
-        translationItem.tintColor = resolvedTint;
-        translationItem.accessibilityLabel = globeButton.accessibilityLabel;
-        if (![items containsObject:translationItem]) {
-            // Apollo's rightBarButtonItems are laid out right-to-left. Adding to
-            // the end places the globe just to the left of Apollo's sort/3-dots
-            // pill — same bubble, tighter spacing thanks to the narrower frame.
-            [items addObject:translationItem];
-        }
-        vc.navigationItem.rightBarButtonItems = items;
-    }
+    // Both builds share this layout; only Liquid Glass collapses the actions.
+    objc_setAssociatedObject(vc.navigationItem, kApolloGlobeRemovalPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey, globeButton, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloApplyGlobeMergeForNavItem(vc.navigationItem);
 }
 
 static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
@@ -9946,7 +9949,7 @@ static void ApolloReapplyTranslationOnAppResume(void) {
     }
 }
 
-// Liquid Glass trailing-container upkeep. Apollo rebuilds its combined trailing
+// Trailing-container upkeep in both builds. Apollo rebuilds its combined trailing
 // button container on various events (mod-status load, trait changes, etc.) and
 // re-sets it via setRightBarButtonItem(s):. When a nav item is flagged for the
 // globe merge, re-inject the globe into the freshly-built container after each
@@ -9961,10 +9964,9 @@ static void ApolloReapplyTranslationOnAppResume(void) {
     // cluster. The owner association makes this a small, local invalidation.
     if (sShowSubredditHeaders && !sApplyingGlobeMerge) ApolloSubredditRequestTitleRelayout(self);
     if (sApplyingGlobeMerge) return;
-    if (!IsLiquidGlass()) return;
     if (objc_getAssociatedObject(self, kApolloGlobeMergeButtonKey)) {
         ApolloApplyGlobeMergeForNavItem(self);
-    } else {
+    } else if (IsLiquidGlass()) {
         // No globe on this nav item — still make the stock container sit
         // symmetrically in its glass capsule.
         ApolloNormalizeTrailingPillPaddingForNavItem(self);
@@ -9975,10 +9977,9 @@ static void ApolloReapplyTranslationOnAppResume(void) {
     %orig(item, animated);
     if (sShowSubredditHeaders && !sApplyingGlobeMerge) ApolloSubredditRequestTitleRelayout(self);
     if (sApplyingGlobeMerge) return;
-    if (!IsLiquidGlass()) return;
     if (objc_getAssociatedObject(self, kApolloGlobeMergeButtonKey)) {
         ApolloApplyGlobeMergeForNavItem(self);
-    } else {
+    } else if (IsLiquidGlass()) {
         ApolloNormalizeTrailingPillPaddingForNavItem(self);
     }
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3776,7 +3776,6 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
                                     UDKeyClassicTabBarScrollBehavior: @NO,
                                     UDKeyTabBarCollapseSide: @0,
                                     UDKeyKeepSearchBarInPlace: @NO,
-                                    UDKeyLGTitleGapCentering: @YES,
                                     UDKeyIPadTabBarBottom: @NO,
                                     UDKeyIconRowMagnifier: @YES,
                                     UDKeyInfoRowTapUpvote: @YES,
@@ -4049,7 +4048,6 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
     }
     sTabBarHideStyle = (ApolloTabBarHideStyle)storedTabBarHideStyle;
     sKeepSearchBarInPlace = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyKeepSearchBarInPlace];
-    sLGTitleGapCentering = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyLGTitleGapCentering];
     sIPadTabBarBottom = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIPadTabBarBottom];
     sIconRowMagnifier = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIconRowMagnifier];
     sInfoRowTapUpvote = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyInfoRowTapUpvote];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -253,12 +253,6 @@ static NSString *const UDKeyTabBarCollapseSide = @"TabBarCollapseSide";
 // "search takeover" (nav slides away + fades, field docks to the top and grows). Mutually
 // exclusive with the default nav-hide mode. Liquid Glass only. Default NO. See ApolloSearchInPlace.xm.
 static NSString *const UDKeyKeepSearchBarInPlace = @"KeepSearchBarInPlace";
-// Liquid Glass nav bar title placement. ON (default): center the title in the
-// gap between the back pill and the trailing pill so it reads balanced whatever
-// the trailing cluster holds (translation globe on or off). OFF: center it on
-// the screen itself, nudged just enough to clear a pill it would overlap.
-// See ApolloRecenterTitleControl in ApolloLiquidGlass.xm.
-static NSString *const UDKeyLGTitleGapCentering = @"LGTitleGapCentering";
 // iPad only, Liquid Glass only. When ON, forces the iOS 26 floating tab bar to
 // dock at the BOTTOM (classic tab bar) instead of the top-center pill, which on
 // iPad overlaps Apollo's search bar. Temporary stopgap for issue #387 until the

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1853,12 +1853,6 @@ typedef NS_ENUM(NSInteger, Tag) {
 
     // "Color Flairs" now rides Appearance → Flair (native injection) —
     // -flairColorsSwitchToggled: below stays as the shared toggle handler.
-    ApolloSettingsRow *titleGapCentering =
-        [ApolloSettingsRow switchRowWithID:@"gen.titleGapCentering"
-                                     title:@"Center Title Between Buttons"
-                                      isOn:^BOOL { return IsLiquidGlass() && sLGTitleGapCentering; }
-                                  onToggle:^(UISwitch *sender) { [weakSelf lgTitleGapCenteringSwitchToggled:sender]; }];
-    titleGapCentering.visible = ^BOOL { return IsLiquidGlass(); };
 
     // Overrides the top scroll-edge glass under the nav bar (iOS 26+). Liquid
     // Glass only — hidden otherwise rather than shown-disabled, since the row
@@ -1874,8 +1868,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     scrollEdgeEffect.visible = ^BOOL { return IsLiquidGlass(); };
 
     return [ApolloSettingsSection sectionWithTitle:@"Display & Navigation"
-                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nHeader Style: Soft is the iOS 26 default; Hard is the iOS 27 default."
-                                              rows:@[ userAvatars, titleGapCentering, scrollEdgeEffect ]];
+                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nIn Liquid Glass, navigation titles stay centered unless expanded actions need room. Tap the top-right ellipsis to reveal navigation actions; scrolling collapses them. Header Style: Soft is the iOS 26 default; Hard is the iOS 27 default."
+                                              rows:@[ userAvatars, scrollEdgeEffect ]];
 }
 
 // Display order of the Header Style picker. Raw values are NOT contiguous
@@ -4124,12 +4118,6 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     sDevvitFeedWidgets = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sDevvitFeedWidgets forKey:UDKeyDevvitFeedWidgets];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloDevvitFeedOwnershipChangedNotification object:nil];
-}
-
-- (void)lgTitleGapCenteringSwitchToggled:(UISwitch *)sender {
-    sLGTitleGapCentering = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sLGTitleGapCentering forKey:UDKeyLGTitleGapCentering];
-    ApolloLGTitleCenteringModeChanged();
 }
 
 - (void)liveCommentsFollowSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
**Note to maintainers**: This PR changes how navigation actions are displayed and accessed, departing from years of familiar Apollo behavior. My aim is a cleaner, more consistent layout across the app, but I understand this may be too large a change for some. I’m happy to adjust or close the PR if it doesn’t fit the project’s direction—I’ll leave that decision to you.

## Summary

Reworks Liquid Glass navigation to improve layout consistency across screens and reduce the recurring title and button resizing bugs encountered in feeds and subreddits. A collapsible action pill keeps titles centered, shifting them smoothly left only when expanded actions would overlap. Apollo’s original controls and menus are preserved, with coordinated icon, title, and context-menu animations.

## Preview

| Collapsed action pill | Expanded pill — subreddit title shifts left |
|---|---|
| <img width="330" alt="Collapsed action pill" src="https://github.com/user-attachments/assets/5a8d22e8-edd4-456b-9113-6c5231e29ebe" /> | <img width="330" alt="Expanded action pill with subreddit title shifted left" src="https://github.com/user-attachments/assets/61b600a7-03f9-4035-b127-632352276b11" /> |


## Changes

- Show the existing More icon when collapsed.
- Tap to reveal translation, moderator actions where applicable, sorting, and More.
- Animate the pill and icons together with a subtle spring.
- Collapse actions when scrolling or leaving the page.
- Keep titles centered unless expanded actions would overlap them; move overlapping titles smoothly left without resizing them.
- Coordinate native context-menu presentation and dismissal with the pill to prevent duplicate glass, distorted icons, and hidden controls.
- Defer button-layout changes while UIKit owns the menu animation.
- Fix comments-title flickering/fading and intermittent subreddit-search positioning.
- Fix translation-globe alignment, including standard builds with moderator buttons.
- Replace Center Title Between Buttons with the new automatic placement behavior.
- Consolidate shared helpers and limit local refreshes to the affected navigation bar.

Collapsing is Liquid Glass-only. Standard builds retain expanded navigation actions.

## Validation

Local simulator build passed. Targeted iOS 27 simulator checks passed:
- Search detection: 14 checks
- Menu sessions and interrupted springs: 145 checks
- Comments-title transitions: 47 checks
- Real context menus: 975 assertions across 32 scenarios
- Device testing passed. GitHub Actions build checks should also pass before merging.