### PR TITLE
Fix missing subreddit header and highlights after swiping forward

### DIFF
--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -2580,6 +2580,14 @@ static void ApolloSubredditSettleBlockedTableToTop(UITableView *tableView) {
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    // Apollo retains popped controllers for swipe-forward navigation. Teardown
+    // blocks late offscreen repairs, but the same controller becomes eligible
+    // again when it reappears. Clear before %orig so nested layout callbacks
+    // can also rebuild the header (including its Community Highlights wrapper).
+    if ([objc_getAssociatedObject(self, kApolloSubredditTeardownMarkerKey) boolValue]) {
+        objc_setAssociatedObject(self, kApolloSubredditTeardownMarkerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[SubredditHeaders] reactivating retained vc=%p on appearance", self);
+    }
     %orig(animated);
     ApolloSubredditScheduleInstallIfNeeded((UIViewController *)self);
 }


### PR DESCRIPTION
## Summary 

After leaving a subreddit, swiping forward to return could leave its community header and highlights missing. Opening the subreddit again by tapping worked normally.
This fixes the swipe-forward behavior so the header and highlights appear again when you return.

Tested in the iOS Simulator.