### PR TITLE
Adds per-account alphabetical sorting for favorites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloManualSignInViewController.m \
     $(SRC_DIR)/ApolloAccountCredentials.m \
     $(SRC_DIR)/ApolloPerAccountFavorites.m \
+    $(SRC_DIR)/ApolloFavoritesSorting.m \
     $(SRC_DIR)/ApolloAccountSwitcherViewController.xm \
     $(SRC_DIR)/ApolloSignInSplash.xm \
     $(SRC_DIR)/ApolloHideSubscribePrompt.xm \

--- a/src/ApolloFavoritesSorting.h
+++ b/src/ApolloFavoritesSorting.h
@@ -1,0 +1,32 @@
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Coalesced on the main queue after the effective scope, value, or availability
+// changes. Settings observers re-read the current state instead of a snapshot
+// captured before a quick account switch finishes.
+FOUNDATION_EXPORT NSNotificationName const ApolloFavoritesSortingStateDidChangeNotification;
+
+// The per-account favorites state machine owns the scope: "shared" while off,
+// its materialized account identity while on, and nil while identity is unknown.
+// Changing scope only loads the preference; it never sorts the outgoing list.
+void ApolloFavoritesSortingSetScope(NSString *identity);
+BOOL ApolloFavoritesSortingIsAvailable(void);
+void ApolloFavoritesSortingSetEnabled(BOOL enabled);
+
+// Account projections can sort before installing their new native list. Native
+// star mutations must instead schedule sorting after their row animation calls.
+NSArray<NSString *> *ApolloFavoritesSortingApplyToList(NSArray<NSString *> *favorites);
+void ApolloFavoritesSortingSchedule(void);
+void ApolloFavoritesSortingSuspendForPreferencesRestore(void);
+
+// A failed account-store transition retains an unowned native list. Keep that
+// list in manual order for this session until an explicit setting change or a
+// new scope is selected, without overwriting the saved shared preference.
+void ApolloFavoritesSortingPreserveNativeOrder(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloFavoritesSorting.m
+++ b/src/ApolloFavoritesSorting.m
@@ -1,0 +1,167 @@
+#import "ApolloFavoritesSorting.h"
+
+#ifdef APOLLO_PER_ACCOUNT_FAVORITES_TESTING
+#define ApolloLog(fmt, ...) NSLog((fmt), ##__VA_ARGS__)
+#else
+#import "ApolloCommon.h"
+#endif
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+NSNotificationName const ApolloFavoritesSortingStateDidChangeNotification = @"ApolloFavoritesSortingStateDidChangeNotification";
+
+// Main-thread confined, like the per-account favorites projection. Queued
+// mutations belong to a scope generation, so work from an outgoing account
+// cannot rewrite a replacement projection (including a fail-closed store).
+static NSString *sApolloFavoritesSortingScope = nil;
+static NSUInteger sApolloFavoritesSortingGeneration = 0;
+static BOOL sApolloFavoritesSortingScheduled = NO;
+static BOOL sApolloFavoritesSortingNeedsRefresh = NO;
+static BOOL sApolloFavoritesSortingSuspended = NO;
+static BOOL sApolloFavoritesSortingStateNotificationScheduled = NO;
+static BOOL sApolloFavoritesSortingPreservingNativeOrder = NO;
+
+static void ApolloFavoritesSortingNotifyStateChanged(void) {
+    if (sApolloFavoritesSortingStateNotificationScheduled) return;
+    sApolloFavoritesSortingStateNotificationScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        sApolloFavoritesSortingStateNotificationScheduled = NO;
+        // Account reconciliation may project a new list after SetScope. Defer
+        // UI work until that transition unwinds, and publish its final state.
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:ApolloFavoritesSortingStateDidChangeNotification object:nil];
+    });
+}
+
+void ApolloFavoritesSortingSetScope(NSString *identity) {
+    NSCAssert([NSThread isMainThread], @"Favorites scope must change on the main thread");
+    if (sApolloFavoritesSortingSuspended) return;
+    BOOL wasEnabled = sSortFavoritesAlphabetically;
+    BOOL scopeChanged = sApolloFavoritesSortingScope != identity && ![sApolloFavoritesSortingScope isEqualToString:identity];
+    if (scopeChanged) {
+        sApolloFavoritesSortingGeneration++;
+        sApolloFavoritesSortingScheduled = NO;
+        sApolloFavoritesSortingPreservingNativeOrder = NO;
+    }
+    sApolloFavoritesSortingScope = [identity copy];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (sApolloFavoritesSortingPreservingNativeOrder) {
+        sSortFavoritesAlphabetically = NO;
+    } else if ([identity isEqualToString:@"shared"]) {
+        sSortFavoritesAlphabetically = [defaults boolForKey:UDKeySortFavoritesAlphabetically];
+    } else {
+        id preference = identity ? [defaults dictionaryForKey:UDKeyFavoriteSortingByAccount][identity] : nil;
+        sSortFavoritesAlphabetically = [preference isKindOfClass:[NSNumber class]] && [preference boolValue];
+    }
+    if (wasEnabled != sSortFavoritesAlphabetically) sApolloFavoritesSortingNeedsRefresh = YES;
+    if (scopeChanged || wasEnabled != sSortFavoritesAlphabetically) ApolloFavoritesSortingNotifyStateChanged();
+}
+
+BOOL ApolloFavoritesSortingIsAvailable(void) {
+    return sApolloFavoritesSortingScope != nil && !sApolloFavoritesSortingSuspended;
+}
+
+NSArray<NSString *> *ApolloFavoritesSortingApplyToList(NSArray<NSString *> *favorites) {
+    if (!sSortFavoritesAlphabetically || !ApolloFavoritesSortingIsAvailable()) return favorites;
+    // Leave malformed native data untouched. Sorting must never silently drop
+    // an entry or change its spelling; the account store validates separately.
+    for (id value in favorites) {
+        if (![value isKindOfClass:[NSString class]]) return favorites;
+    }
+    return [favorites sortedArrayWithOptions:NSSortStable usingComparator:^NSComparisonResult(NSString *left, NSString *right) {
+        return [left localizedStandardCompare:right];
+    }];
+}
+
+void ApolloFavoritesSortingSchedule(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloFavoritesSortingSchedule(); });
+        return;
+    }
+    if (!ApolloFavoritesSortingIsAvailable() || sApolloFavoritesSortingScheduled ||
+        (!sSortFavoritesAlphabetically && !sApolloFavoritesSortingNeedsRefresh)) return;
+    sApolloFavoritesSortingScheduled = YES;
+    NSUInteger generation = sApolloFavoritesSortingGeneration;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (generation != sApolloFavoritesSortingGeneration) return;
+        // Keep the scheduled guard raised through our own defaults write to
+        // avoid recursive scheduling. The native handler has
+        // now finished registering its append/delete row animation, so a full
+        // native refresh can safely present the alphabetized model.
+        if (ApolloFavoritesSortingIsAvailable()) {
+            BOOL refresh = sApolloFavoritesSortingNeedsRefresh;
+            sApolloFavoritesSortingNeedsRefresh = NO;
+            NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+            NSArray<NSString *> *favorites = [defaults arrayForKey:UDKeyApolloFavoriteSubreddits];
+            NSArray<NSString *> *sorted = ApolloFavoritesSortingApplyToList(favorites);
+            if (favorites && ![favorites isEqualToArray:sorted]) {
+                [defaults setObject:sorted forKey:UDKeyApolloFavoriteSubreddits];
+                refresh = YES;
+                ApolloLog(@"[FavoritesSorting] alphabetized %lu favorites", (unsigned long)sorted.count);
+            }
+            // Also refresh when disabling, so an already editing table asks
+            // canMoveRowAtIndexPath again and restores its reorder handles.
+            sApolloFavoritesSortingScheduled = NO;
+            if (refresh) {
+                // This is a presentation refresh, not another user edit. The
+                // defaults setter already snapshots the sorted account bucket.
+                // Native observers can still make genuine writes, which must
+                // be allowed to schedule a fresh normalization pass.
+                [[NSNotificationCenter defaultCenter]
+                    postNotificationName:ApolloFavoriteSubredditsUpdatedNotification
+                                  object:nil
+                                userInfo:@{ @"ApolloPerAccountFavoritesProjectionRefresh": @YES }];
+            }
+            return;
+        }
+        sApolloFavoritesSortingScheduled = NO;
+    });
+}
+
+void ApolloFavoritesSortingSetEnabled(BOOL enabled) {
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{ ApolloFavoritesSortingSetEnabled(enabled); });
+        return;
+    }
+    if (!ApolloFavoritesSortingIsAvailable()) return;
+    if (enabled == sSortFavoritesAlphabetically && !sApolloFavoritesSortingPreservingNativeOrder) {
+        ApolloFavoritesSortingSchedule();
+        return;
+    }
+    sApolloFavoritesSortingPreservingNativeOrder = NO;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([sApolloFavoritesSortingScope isEqualToString:@"shared"]) {
+        [defaults setBool:enabled forKey:UDKeySortFavoritesAlphabetically];
+    } else {
+        NSMutableDictionary *preferences = [[defaults dictionaryForKey:UDKeyFavoriteSortingByAccount] mutableCopy] ?: [NSMutableDictionary dictionary];
+        preferences[sApolloFavoritesSortingScope] = @(enabled);
+        [defaults setObject:preferences forKey:UDKeyFavoriteSortingByAccount];
+    }
+    sSortFavoritesAlphabetically = enabled;
+    sApolloFavoritesSortingNeedsRefresh = YES;
+    ApolloFavoritesSortingNotifyStateChanged();
+    ApolloFavoritesSortingSchedule();
+    ApolloLog(@"[FavoritesSorting] %@ for %@ favorites", enabled ? @"enabled" : @"disabled",
+              [sApolloFavoritesSortingScope isEqualToString:@"shared"] ? @"shared" : @"account");
+}
+
+void ApolloFavoritesSortingSuspendForPreferencesRestore(void) {
+    BOOL wasAvailable = ApolloFavoritesSortingIsAvailable();
+    sApolloFavoritesSortingSuspended = YES;
+    sApolloFavoritesSortingNeedsRefresh = NO;
+    if (wasAvailable) ApolloFavoritesSortingNotifyStateChanged();
+}
+
+void ApolloFavoritesSortingPreserveNativeOrder(void) {
+    NSCAssert([NSThread isMainThread], @"Favorites recovery must run on the main thread");
+    if (sApolloFavoritesSortingSuspended) return;
+    sApolloFavoritesSortingPreservingNativeOrder = YES;
+    sApolloFavoritesSortingGeneration++;
+    sApolloFavoritesSortingScheduled = NO;
+    // The failing mutation's setter and native notification can both schedule
+    // another pass. Canceling existing work alone does not protect this list:
+    // its effective mode must remain manual until the user opts into sorting.
+    if (sSortFavoritesAlphabetically) sApolloFavoritesSortingNeedsRefresh = YES;
+    sSortFavoritesAlphabetically = NO;
+    ApolloFavoritesSortingNotifyStateChanged();
+}

--- a/src/ApolloFollowingSection.xm
+++ b/src/ApolloFollowingSection.xm
@@ -80,6 +80,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloFollowingSection.h"
+#import "ApolloState.h"
 #import "UserDefaultConstants.h"
 
 @interface RedditListViewController : UIViewController // Apollo.RedditListViewController
@@ -877,6 +878,10 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
+    // Resolve the native section before enforcing the account's sort policy:
+    // Favorites need not be the first visible section in a customized list.
+    NSInteger section = map.active ? ApolloFollowingNativeSectionForVisible(map, indexPath.section) : indexPath.section;
+    if (sSortFavoritesAlphabetically && section == kApolloNativeSectionFavorites) return NO;
     if (!map.active) return %orig;
     NSInteger nativeSection = ApolloFollowingNativeSectionForVisible(map, indexPath.section);
     if (nativeSection == kApolloFollowingSyntheticSection) return map.entries.count > 1;
@@ -887,6 +892,8 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (NSIndexPath *)tableView:(UITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(NSIndexPath *)sourceIndexPath toProposedIndexPath:(NSIndexPath *)proposedDestinationIndexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
+    NSInteger section = map.active ? ApolloFollowingNativeSectionForVisible(map, sourceIndexPath.section) : sourceIndexPath.section;
+    if (sSortFavoritesAlphabetically && section == kApolloNativeSectionFavorites) return sourceIndexPath;
     if (!map.active) return %orig;
     NSInteger sourceNativeSection = ApolloFollowingNativeSectionForVisible(map, sourceIndexPath.section);
     if (sourceNativeSection == kApolloFollowingSyntheticSection) {
@@ -905,7 +912,17 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
-    if (!map.active) { %orig; return; }
+    NSInteger section = map.active ? ApolloFollowingNativeSectionForVisible(map, fromIndexPath.section) : fromIndexPath.section;
+    if (sSortFavoritesAlphabetically && section == kApolloNativeSectionFavorites) {
+        // Defend a move already in flight when an account/sort setting changed.
+        // UIKit has moved the visual row; reload to restore the unchanged model.
+        [tableView reloadData];
+        return;
+    }
+    if (!map.active) {
+        %orig;
+        return;
+    }
     NSInteger fromNativeSection = ApolloFollowingNativeSectionForVisible(map, fromIndexPath.section);
     if (fromNativeSection == kApolloFollowingSyntheticSection) {
         // A reorder inside the FOLLOWING section: persist the new order and

--- a/src/ApolloPerAccountFavorites.m
+++ b/src/ApolloPerAccountFavorites.m
@@ -1,6 +1,7 @@
 #import "ApolloPerAccountFavorites.h"
 
 #import "ApolloAccountCredentials.h"
+#import "ApolloFavoritesSorting.h"
 #ifdef APOLLO_PER_ACCOUNT_FAVORITES_TESTING
 // Keep the state-machine regression harness Foundation-only on the build host.
 #define ApolloLog(fmt, ...) NSLog((fmt), ##__VA_ARGS__)
@@ -214,6 +215,15 @@ static void ApolloPerAccountFavoritesFailClosedForStoreStatus(
     sApolloPerAccountFavoritesIdentityUnknown = NO;
     sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
     ApolloPerAccountFavoritesCancelIdentityRetries();
+    // The retained native projection can still be an account's manually
+    // ordered list, not the saved shared list. Return ownership to the shared
+    // scope, but leave sorting effectively off until the user enables it.
+    // Merely canceling the outgoing sort generation is insufficient: the
+    // defaults setter / native notification that detected this failure will
+    // schedule another pass after this function returns. Keep the saved
+    // shared preference intact while preserving this recoverable order.
+    ApolloFavoritesSortingSetScope(kApolloPerAccountFavoritesSharedIdentity);
+    ApolloFavoritesSortingPreserveNativeOrder();
     ApolloLog(@"[PerAccountFavorites] disabled because the favorites store cannot be read safely");
 }
 
@@ -286,6 +296,10 @@ ApolloPerAccountFavoritesBucketsForIdentity(NSString *activeIdentity,
 
 static BOOL ApolloPerAccountFavoritesInstallNativeList(NSArray<NSString *> *favorites) {
     NSArray<NSString *> *safeFavorites = ApolloPerAccountFavoritesSanitizeNativeArray(favorites) ?: @[];
+    // Scope is selected before every projection. Unlike Apollo's star-button
+    // append/delete flow, replacing a whole account projection has no pending
+    // row animation, so its first native refresh can already show sorted rows.
+    safeFavorites = ApolloFavoritesSortingApplyToList(safeFavorites);
     if ([ApolloPerAccountFavoritesNativeList() isEqualToArray:safeFavorites]) return NO;
 
     sApolloPerAccountFavoritesInstallingProjection = YES;
@@ -328,7 +342,10 @@ static void ApolloPerAccountFavoritesSnapshotMaterializedList(void) {
         return;
     }
 
-    NSArray<NSString *> *favorites = ApolloPerAccountFavoritesNativeList();
+    // The visible native list may still be awaiting its post-animation sort.
+    // Persist this account's order now so a quick switch cannot save an append
+    // in the wrong position, without altering the in-flight native row model.
+    NSArray<NSString *> *favorites = ApolloFavoritesSortingApplyToList(ApolloPerAccountFavoritesNativeList());
     if ([buckets[sApolloPerAccountFavoritesMaterializedIdentity] isEqualToArray:favorites]) return;
     buckets[sApolloPerAccountFavoritesMaterializedIdentity] = favorites;
     ApolloPerAccountFavoritesSaveBuckets(buckets);
@@ -427,6 +444,9 @@ static void ApolloPerAccountFavoritesEnterUnknownIdentity(NSString *reason, BOOL
         sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
     }
     sApolloPerAccountFavoritesIdentityUnknown = YES;
+    // Retain the last list while identity is quarantined, but do not let a
+    // queued sorting pass or a setting edit attribute it to the wrong user.
+    ApolloFavoritesSortingSetScope(nil);
     if (mayRetry) ApolloPerAccountFavoritesScheduleIdentityRetry(reason);
     if (firstUnknownEntry) {
         ApolloLog(@"[PerAccountFavorites] account identity temporarily unavailable; projection unchanged");
@@ -458,12 +478,14 @@ static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentit
     if ([sApolloPerAccountFavoritesMaterializedIdentity isEqualToString:incomingIdentity]) {
         sApolloPerAccountFavoritesIdentityUnknown = NO;
         sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
+        ApolloFavoritesSortingSetScope(incomingIdentity);
         if (wasUnknown && nativeMutatedWhileUnknown) {
             // The authoritative resolution returned to the same account, so
             // the native write made during quarantine can now be safely saved.
             ApolloPerAccountFavoritesSnapshotMaterializedList();
         }
         ApolloPerAccountFavoritesCancelIdentityRetries();
+        ApolloFavoritesSortingSchedule();
         return;
     }
 
@@ -480,6 +502,7 @@ static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentit
             return;
         }
         sApolloPerAccountFavoritesIdentityUnknown = YES;
+        ApolloFavoritesSortingSetScope(nil);
         // Keep NativeMutationWhileUnknown intact: losing it here would let a
         // later retry cross-write an ambiguous list into the outgoing bucket.
         if (retryable && mayRetry) ApolloPerAccountFavoritesScheduleIdentityRetry(reason);
@@ -494,7 +517,7 @@ static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentit
         buckets[kApolloPerAccountFavoritesSharedIdentity] = outgoingFavorites;
         ApolloLog(@"[PerAccountFavorites] preserved an unattributed favorites edit in the shared scope");
     } else if (sApolloPerAccountFavoritesMaterializedIdentity.length > 0) {
-        buckets[sApolloPerAccountFavoritesMaterializedIdentity] = outgoingFavorites;
+        buckets[sApolloPerAccountFavoritesMaterializedIdentity] = ApolloFavoritesSortingApplyToList(outgoingFavorites);
     }
 
     NSArray<NSString *> *incomingFavorites = buckets[incomingIdentity];
@@ -510,6 +533,7 @@ static void ApolloPerAccountFavoritesReconcileIdentity(NSString *incomingIdentit
     sApolloPerAccountFavoritesIdentityUnknown = NO;
     sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
     ApolloPerAccountFavoritesCancelIdentityRetries();
+    ApolloFavoritesSortingSetScope(incomingIdentity);
     BOOL changed = ApolloPerAccountFavoritesInstallNativeList(incomingFavorites);
     ApolloPerAccountFavoritesScheduleNativeRefresh();
     ApolloLog(@"[PerAccountFavorites] switched scope (%lu -> %lu favorites, projectionChanged=%d, reason=%@%@)",
@@ -683,9 +707,10 @@ ApolloPerAccountFavoritesSetResult ApolloPerAccountFavoritesSetEnabled(BOOL enab
         sApolloPerAccountFavoritesIdentityUnknown = NO;
         sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
         ApolloPerAccountFavoritesCancelIdentityRetries();
-        if (sharedFavorites && ApolloPerAccountFavoritesInstallNativeList(sharedFavorites)) {
-            ApolloPerAccountFavoritesScheduleNativeRefresh();
-        }
+        ApolloFavoritesSortingSetScope(kApolloPerAccountFavoritesSharedIdentity);
+        if (sharedFavorites) ApolloPerAccountFavoritesInstallNativeList(sharedFavorites);
+        // Even identical lists can have different sort policies/reorder handles.
+        ApolloPerAccountFavoritesScheduleNativeRefresh();
         ApolloLog(@"[PerAccountFavorites] disabled; restored Apollo's shared favorites list");
         return ApolloPerAccountFavoritesSetResultApplied;
     }
@@ -741,6 +766,7 @@ ApolloPerAccountFavoritesSetResult ApolloPerAccountFavoritesSetEnabled(BOOL enab
     sApolloPerAccountFavoritesIdentityUnknown = NO;
     sApolloPerAccountFavoritesNativeMutationWhileUnknown = NO;
     ApolloPerAccountFavoritesCancelIdentityRetries();
+    ApolloFavoritesSortingSetScope(activeIdentity);
     ApolloPerAccountFavoritesInstallNativeList(activeFavorites);
     ApolloPerAccountFavoritesScheduleNativeRefresh();
     ApolloLog(@"[PerAccountFavorites] enabled (%@ store, %lu active favorites)",
@@ -854,6 +880,7 @@ void ApolloPerAccountFavoritesSuspendForPreferencesRestore(void) {
         return;
     }
     sApolloPerAccountFavoritesSuspendedForRestore = YES;
+    ApolloFavoritesSortingSuspendForPreferencesRestore();
     ApolloPerAccountFavoritesCancelIdentityRetries();
     ApolloLog(@"[PerAccountFavorites] suspended for preferences restore until relaunch");
 }
@@ -865,6 +892,8 @@ void ApolloPerAccountFavoritesStart(void) {
     }
     if (sApolloPerAccountFavoritesStarted) return;
     sApolloPerAccountFavoritesStarted = YES;
+    ApolloFavoritesSortingSetScope(sPerAccountFavoritesEnabled
+        ? nil : kApolloPerAccountFavoritesSharedIdentity);
 
     // The pre-post NSNotificationCenter hook handles quick switching before any
     // native observer can read the old projection. This observer remains as a
@@ -891,9 +920,13 @@ void ApolloPerAccountFavoritesStart(void) {
         // defaults write from another observer must still be captured.
         if ([note.userInfo[kApolloPerAccountFavoritesProjectionRefreshKey] isEqual:@YES]) return;
         ApolloPerAccountFavoritesNativeFavoritesDidChange();
+        ApolloFavoritesSortingSchedule();
     }];
 
-    if (!sPerAccountFavoritesEnabled) return;
+    if (!sPerAccountFavoritesEnabled) {
+        ApolloFavoritesSortingSchedule();
+        return;
+    }
 
     NSMutableDictionary<NSString *, NSArray<NSString *> *> *preflightBuckets = nil;
     ApolloPerAccountFavoritesStoreStatus preflightStatus =
@@ -935,6 +968,7 @@ void ApolloPerAccountFavoritesStart(void) {
     }
     sApolloPerAccountFavoritesMaterializedIdentity = [activeIdentity copy];
     sApolloPerAccountFavoritesIdentityUnknown = NO;
+    ApolloFavoritesSortingSetScope(activeIdentity);
     if (ApolloPerAccountFavoritesInstallNativeList(activeFavorites)) {
         ApolloPerAccountFavoritesScheduleNativeRefresh();
     }

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -309,6 +309,8 @@ extern NSInteger sSubredditFeedLayout;
 // Opt-in per-account FavoriteSubreddits projection. Defaults OFF; see
 // ApolloPerAccountFavorites.{h,m}.
 extern BOOL sPerAccountFavoritesEnabled;
+// Effective sorting preference for the materialized favorites scope.
+extern BOOL sSortFavoritesAlphabetically;
 // Hide the description subtitles under the subreddit list's built-in feed rows
 // (see UDKeyHideSubredditListDescriptions). Independent of the enhancements master.
 extern BOOL sHideSubredditListDescriptions;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -77,6 +77,7 @@ BOOL sSubredditListEnhancements = YES;
 NSInteger sSubredditFeedIconStyle = ApolloSubredditFeedIconStyleClassic;
 NSInteger sSubredditFeedLayout = ApolloSubredditFeedLayoutRows;
 BOOL sPerAccountFavoritesEnabled = NO;
+BOOL sSortFavoritesAlphabetically = NO;
 BOOL sHideSubredditListDescriptions = NO;
 BOOL sHideMultiredditDescriptions = NO;
 BOOL sEnableFlairColors = NO;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -35,6 +35,7 @@
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloAccountCredentials.h"
 #import "ApolloPerAccountFavorites.h"
+#import "ApolloFavoritesSorting.h"
 #import "crash/ApolloCrashManager.h"
 #import "crash/ApolloCrashContext.h"
 #import "crash/ApolloCrashPromptCoordinator.h"
@@ -3620,6 +3621,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
     }
     if (ApolloDefaultsKeyChangesNativeFavorites(key)) {
         ApolloPerAccountFavoritesNativeFavoritesDidChange();
+        ApolloFavoritesSortingSchedule();
     }
 }
 
@@ -3646,6 +3648,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
     }
     if (ApolloDefaultsKeyChangesNativeFavorites(key)) {
         ApolloPerAccountFavoritesNativeFavoritesDidChange();
+        ApolloFavoritesSortingSchedule();
     }
 }
 
@@ -3712,6 +3715,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
                                     UDKeySubredditFeedIconStyle: @(ApolloSubredditFeedIconStyleClassic),
                                     UDKeySubredditFeedLayout: @(ApolloSubredditFeedLayoutRows),
                                     UDKeyPerAccountFavoritesEnabled: @NO,
+                                    UDKeySortFavoritesAlphabetically: @NO,
                                     UDKeyModernSubredditDividers: @YES,
                                     UDKeyShowDeletedComments: @NO,
                                     UDKeyTapToRevealDeletedComments: @NO,
@@ -4107,6 +4111,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
         [standardDefaults setInteger:sSubredditFeedLayout forKey:UDKeySubredditFeedLayout];
     }
     sPerAccountFavoritesEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPerAccountFavoritesEnabled];
+    sSortFavoritesAlphabetically = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySortFavoritesAlphabetically];
     sHideSubredditListDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideSubredditListDescriptions];
     sHideMultiredditDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideMultiredditDescriptions];
     sEnableFlairColors = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFlairColors];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -55,6 +55,11 @@ static NSString *const ApolloFeedShortcutsChangedNotification = @"ApolloFeedShor
 // account's bucket back through Apollo's native FavoriteSubreddits key so every
 // stock reader/mutator continues to work unchanged.
 static NSString *const UDKeyPerAccountFavoritesEnabled = @"PerAccountFavoritesEnabled";
+// Alphabetize shared favorites and disable manual reordering. Default NO.
+static NSString *const UDKeySortFavoritesAlphabetically = @"SortFavoritesAlphabetically";
+// Per-account sorting preferences, keyed by the per-account favorites identity
+// (u:name / anonymous). Missing entries default OFF; shared preference is above.
+static NSString *const UDKeyFavoriteSortingByAccount = @"FavoriteSortingByAccount";
 // Versioned envelope: { "version": 1, "buckets": { "u:name": [subreddits],
 // "anonymous": [subreddits] } }. Missing bucket and explicit empty bucket are
 // intentionally distinct; accounts created after the first migration start empty.

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -18,6 +18,7 @@
 #import "ApolloWebSessionStore.h"
 #import "ApolloAccountCredentials.h"
 #import "ApolloPerAccountFavorites.h"
+#import "ApolloFavoritesSorting.h"
 #import "ApolloState.h"
 #import "ApolloTabBarHideStyle.h"
 #import "ApolloTagFilters.h"
@@ -2522,10 +2523,19 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
                                      title:@"Per-Account Favorites"
                                       isOn:^BOOL { return sPerAccountFavoritesEnabled; }
                                   onToggle:^(UISwitch *sender) { [weakSelf perAccountFavoritesSwitchToggled:sender]; }];
+    ApolloSettingsRow *sortFavoritesAlphabetically =
+        [ApolloSettingsRow switchRowWithID:@"sub.sortFavoritesAlphabetically"
+                                     title:@"Sort Favorites Alphabetically"
+                                      isOn:^BOOL { return sSortFavoritesAlphabetically; }
+                                  onToggle:^(UISwitch *sender) {
+                                      ApolloFavoritesSortingSetEnabled(sender.isOn);
+                                      [sender setOn:sSortFavoritesAlphabetically animated:YES];
+                                  }];
+    sortFavoritesAlphabetically.enabled = ^BOOL { return ApolloFavoritesSortingIsAvailable(); };
 
     return [ApolloSettingsSection sectionWithTitle:@"Favorites"
-                                            footer:@"Keeps an independent Favorites list for each account. First enable copies the current list to existing accounts; new accounts start empty. Turning it off restores Apollo's shared list."
-                                              rows:@[ perAccountFavorites ]];
+                                            footer:@"Per-Account Favorites saves a separate list and sorting preference for each account. First enable copies the current list to existing accounts; new accounts start empty. Turning it off restores the shared list.\nAlphabetical sorting keeps existing and new favorites in order. Turn it off to rearrange them manually while editing the subreddit list."
+                                              rows:@[ perAccountFavorites, sortFavoritesAlphabetically ]];
 }
 
 - (NSString *)subredditLayoutSummaryText {
@@ -3986,7 +3996,10 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
 - (void)perAccountFavoritesSwitchToggled:(UISwitch *)sender {
     ApolloPerAccountFavoritesSetResult result =
         ApolloPerAccountFavoritesSetEnabled(sender.isOn);
-    if (result == ApolloPerAccountFavoritesSetResultApplied) return;
+    if (result == ApolloPerAccountFavoritesSetResultApplied) {
+        [self reloadRowWithID:@"sub.sortFavoritesAlphabetically"];
+        return;
+    }
 
     [sender setOn:sPerAccountFavoritesEnabled animated:YES];
     if (result == ApolloPerAccountFavoritesSetResultUnsupportedStore) {
@@ -4405,6 +4418,21 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
 
 @implementation ApolloSubredditsSettingsViewController
 - (NSString *)apollo_screenTitle { return @"Subreddits"; }
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // The quick account switcher leaves this controller on screen, so it does
+    // not get another viewWillAppear. Also refresh when a loading account's
+    // identity resolves and the sorting control becomes available again.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(apollo_favoritesSortingStateDidChange:)
+                                                 name:ApolloFavoritesSortingStateDidChangeNotification
+                                               object:nil];
+}
+- (void)apollo_favoritesSortingStateDidChange:(NSNotification *)notification {
+    (void)notification;
+    [self reloadRowWithID:@"sub.perAccountFavorites"];
+    [self reloadRowWithID:@"sub.sortFavoritesAlphabetically"];
+}
 - (NSArray<ApolloSettingsSection *> *)buildForm {
     return @[ [self buildSubredditsMainSection],
               [self buildSubredditsFavoritesSection],
@@ -4415,6 +4443,8 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     // Refresh the Subreddit Sections summary after returning from that screen
     // (the order / Following toggle may have just changed).
     [self reloadRowWithID:@"sub.sections"];
+    // Account changes can select a different alphabetical-sorting preference.
+    [self reloadRowWithID:@"sub.sortFavoritesAlphabetically"];
 }
 @end
 

--- a/tests/per_account_favorites_tests.m
+++ b/tests/per_account_favorites_tests.m
@@ -2,6 +2,7 @@
 #import <objc/runtime.h>
 
 #import "ApolloAccountCredentials.h"
+#import "ApolloFavoritesSorting.h"
 #import "ApolloPerAccountFavorites.h"
 #import "UserDefaultConstants.h"
 
@@ -10,12 +11,15 @@
 // suite, so it needs neither a production reset API nor the simulator's data.
 // The three identity providers stand in for AccountManager's runtime state.
 BOOL sPerAccountFavoritesEnabled = NO;
+BOOL sSortFavoritesAlphabetically = NO;
 static ApolloPersistedAccountIdentityStatus sTestLiveStatus = ApolloPersistedAccountIdentitySignedIn;
 static ApolloPersistedAccountIdentityStatus sTestPersistedStatus = ApolloPersistedAccountIdentitySignedIn;
 static NSString *sTestLiveUsername = @"a";
 static NSString *sTestPersistedUsername = @"a";
 static NSUInteger sTestIdentityLookups = 0;
 static NSUserDefaults *sTestDefaults = nil;
+static NSUInteger sTestNativeFavoritesWrites = 0;
+static NSUInteger sTestBucketWrites = 0;
 
 ApolloPersistedAccountIdentityStatus ApolloResolveLiveActiveAccountIdentity(
     NSString **outNormalizedUsername) {
@@ -49,7 +53,20 @@ BOOL ApolloResolvePersistedAccountUsernames(NSSet<NSString *> **outUsernames) {
     // the public mutation entry point, including writes during a notification.
     // Production projection writes must suppress themselves in the real module.
     if ([key isEqualToString:UDKeyApolloFavoriteSubreddits]) {
+        sTestNativeFavoritesWrites++;
         ApolloPerAccountFavoritesNativeFavoritesDidChange();
+        ApolloFavoritesSortingSchedule();
+    } else if ([key isEqualToString:UDKeyPerAccountFavoriteSubreddits]) {
+        sTestBucketWrites++;
+    }
+}
+
+- (void)removeObjectForKey:(NSString *)key {
+    [super removeObjectForKey:key];
+    if ([key isEqualToString:UDKeyApolloFavoriteSubreddits]) {
+        sTestNativeFavoritesWrites++;
+        ApolloPerAccountFavoritesNativeFavoritesDidChange();
+        ApolloFavoritesSortingSchedule();
     }
 }
 
@@ -254,6 +271,413 @@ static void TestFirstEnableClonesSharedFavorites(void) {
     Require(sPerAccountFavoritesEnabled, @"the explicit opt-in enables the feature");
 }
 
+static void StartSortingStore(void) {
+    SeedReadyStore();
+    NSMutableDictionary *store = [[sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits] mutableCopy];
+    store[@"buckets"] = @{
+        @"anonymous": @[@"anonymousZulu", @"anonymousAlpha"],
+        @"shared": @[@"sharedZulu", @"sharedAlpha"],
+        @"u:a": @[@"Zulu", @"sub10", @"Bravo", @"Sub2", @"alpha"],
+        @"u:b": @[@"bZulu", @"bAlpha"],
+    };
+    [sTestDefaults setObject:store forKey:UDKeyPerAccountFavoriteSubreddits];
+    [sTestDefaults setObject:store[@"buckets"][@"shared"] forKey:UDKeyApolloFavoriteSubreddits];
+    ApolloPerAccountFavoritesStart();
+    DrainMainQueue();
+}
+
+static void ResolveAccountA(void) {
+    sTestLiveStatus = ApolloPersistedAccountIdentitySignedIn;
+    sTestLiveUsername = @"a";
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+}
+
+static void TestSortingToggle(void) {
+    StartSortingStore();
+    NSArray *original = @[@"Zulu", @"sub10", @"Bravo", @"Sub2", @"alpha"];
+    NSArray *ordered = @[@"alpha", @"Bravo", @"Sub2", @"sub10", @"Zulu"];
+    Require(!sSortFavoritesAlphabetically, @"sorting is off by default for an account");
+    Require(ApolloFavoritesSortingIsAvailable(), @"sorting is available for the active account");
+    RequireList(ApolloFavoritesSortingApplyToList(original), original,
+                @"disabled sorting preserves the original manual order");
+
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    Require(sSortFavoritesAlphabetically, @"enabling updates the current sorting flag");
+    RequireList(NativeFavorites(), ordered,
+                @"enabling sorts names naturally without changing their spelling or case");
+    RequireList(Buckets()[@"u:a"], ordered, @"the sorted order persists in A's bucket");
+    RequireList(ApolloFavoritesSortingApplyToList(original), ordered,
+                @"the public ordering helper uses the current scope preference");
+    Require([sTestDefaults objectForKey:UDKeyFavoriteSortingByAccount][@"u:a"] != nil,
+            @"the account sorting preference is persisted");
+
+    ApolloFavoritesSortingSetEnabled(NO);
+    DrainMainQueue();
+    Require(!sSortFavoritesAlphabetically, @"disabling permits manual favorites order again");
+    RequireList(NativeFavorites(), ordered, @"disabling leaves the current order intact");
+    [sTestDefaults setObject:original forKey:UDKeyApolloFavoriteSubreddits];
+    DrainMainQueue();
+    RequireList(NativeFavorites(), original, @"manual reordering remains intact while off");
+    RequireList(Buckets()[@"u:a"], original, @"manual reordering persists in A's bucket");
+}
+
+static void TestSortingNativeAddAndRemove(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+
+    NSArray *added = @[@"alpha", @"Bravo", @"Sub2", @"sub10", @"Zulu", @"aardvark"];
+    NSArray *ordered = @[@"aardvark", @"alpha", @"Bravo", @"Sub2", @"sub10", @"Zulu"];
+    [sTestDefaults setObject:added forKey:UDKeyApolloFavoriteSubreddits];
+    RequireList(NativeFavorites(), added,
+                @"native additions finish their original setter before deferred reordering");
+    DrainMainQueue();
+    RequireList(NativeFavorites(), ordered, @"new favorites move into alphabetical order");
+    RequireList(Buckets()[@"u:a"], ordered, @"a new favorite persists in sorted account order");
+
+    NSArray *removed = @[@"aardvark", @"alpha", @"Sub2", @"sub10", @"Zulu"];
+    [sTestDefaults setObject:removed forKey:UDKeyApolloFavoriteSubreddits];
+    DrainMainQueue();
+    RequireList(NativeFavorites(), removed, @"removing a favorite preserves sorted survivors");
+    RequireList(Buckets()[@"u:a"], removed, @"favorite removal persists in the account bucket");
+
+    [sTestDefaults removeObjectForKey:UDKeyApolloFavoriteSubreddits];
+    DrainMainQueue();
+    Require(NativeFavorites() == nil || NativeFavorites().count == 0,
+            @"removing the native key leaves no favorites");
+    RequireList(Buckets()[@"u:a"], @[], @"removing all favorites clears the account bucket");
+}
+
+static void TestSortingAccountSwitchWithPendingWrite(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    NSArray *aAdded = @[@"alpha", @"Bravo", @"Sub2", @"sub10", @"Zulu", @"aardvark"];
+    NSArray *aOrdered = @[@"aardvark", @"alpha", @"Bravo", @"Sub2", @"sub10", @"Zulu"];
+    [sTestDefaults setObject:aAdded forKey:UDKeyApolloFavoriteSubreddits];
+    // Switch before the native setter's deferred sorting callback executes.
+    ResolveAccountB();
+    DrainMainQueue();
+    Require(!sSortFavoritesAlphabetically, @"B's missing sorting preference defaults to off");
+    RequireList(NativeFavorites(), @[@"bZulu", @"bAlpha"],
+                @"A's pending sorting work cannot reorder B's manual list");
+    RequireList(Buckets()[@"u:b"], @[@"bZulu", @"bAlpha"],
+                @"A's pending addition cannot enter B's bucket");
+    RequireList(Buckets()[@"u:a"], aOrdered,
+                @"switching away preserves A's newest favorite in sorted order");
+
+    [sTestDefaults setObject:@[@"bZulu", @"bAlpha", @"bMiddle"]
+                     forKey:UDKeyApolloFavoriteSubreddits];
+    DrainMainQueue();
+    ResolveAccountA();
+    DrainMainQueue();
+    Require(sSortFavoritesAlphabetically, @"returning to A restores its enabled preference");
+    RequireList(NativeFavorites(), aOrdered, @"returning to A restores its sorted additions");
+    RequireList(Buckets()[@"u:b"], @[@"bZulu", @"bAlpha", @"bMiddle"],
+                @"B's additions remain in manual order across account switches");
+}
+
+static void TestSortingSharedPreferenceIsSeparate(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    DisableFavorites();
+    DrainMainQueue();
+    Require(!sSortFavoritesAlphabetically, @"shared sorting has its own default-off preference");
+    RequireList(NativeFavorites(), @[@"sharedZulu", @"sharedAlpha"],
+                @"A's enabled preference cannot sort the shared list");
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    Require([sTestDefaults boolForKey:UDKeySortFavoritesAlphabetically],
+            @"shared sorting persists in the shared preference");
+    RequireList(NativeFavorites(), @[@"sharedAlpha", @"sharedZulu"], @"shared sorting is applied");
+    Require(ApolloPerAccountFavoritesSetEnabled(YES) == ApolloPerAccountFavoritesSetResultApplied,
+            @"per-account favorites can resume after shared sorting");
+    ResolveAccountB();
+    DrainMainQueue();
+    Require(!sSortFavoritesAlphabetically, @"shared sorting cannot enable B's preference");
+    RequireList(NativeFavorites(), @[@"bZulu", @"bAlpha"], @"B retains manual order");
+    DisableFavorites();
+    DrainMainQueue();
+    Require(sSortFavoritesAlphabetically, @"returning to shared favorites restores shared sorting");
+    RequireList(NativeFavorites(), @[@"sharedAlpha", @"sharedZulu"],
+                @"shared favorites retain their sorted order");
+    ResolveAccountA();
+    Require(ApolloPerAccountFavoritesSetEnabled(YES) == ApolloPerAccountFavoritesSetResultApplied,
+            @"A's account scope can resume");
+    DrainMainQueue();
+    Require(sSortFavoritesAlphabetically, @"A's preference survived shared and B transitions");
+}
+
+static void TestSortingUnknownIdentityCannotWrite(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    [sTestDefaults setObject:@[@"Zulu", @"alpha"] forKey:UDKeyApolloFavoriteSubreddits];
+    sTestLiveStatus = ApolloPersistedAccountIdentityUnknown;
+    sTestLiveUsername = nil;
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    Require(!ApolloFavoritesSortingIsAvailable(), @"sorting is unavailable while identity is unknown");
+    NSDictionary *savedPreferences = [[sTestDefaults objectForKey:UDKeyFavoriteSortingByAccount] copy];
+    NSUInteger nativeWrites = sTestNativeFavoritesWrites;
+    ApolloFavoritesSortingSetEnabled(NO);
+    ApolloFavoritesSortingSetEnabled(YES);
+    ApolloFavoritesSortingSchedule();
+    DrainMainQueue();
+    Require(sTestNativeFavoritesWrites == nativeWrites,
+            @"pending sorting cannot rewrite favorites while account identity is unknown");
+    RequireList(NativeFavorites(), @[@"Zulu", @"alpha"],
+                @"the unknown account's native list remains untouched");
+    Require([[sTestDefaults objectForKey:UDKeyFavoriteSortingByAccount] isEqual:savedPreferences],
+            @"unknown identity cannot save a sorting preference for the prior account");
+    ResolveAccountB();
+    DrainMainQueue();
+    Require(ApolloFavoritesSortingIsAvailable(), @"sorting becomes available when identity resolves");
+    Require(!sSortFavoritesAlphabetically, @"B still has sorting off after identity recovery");
+    RequireList(NativeFavorites(), @[@"bZulu", @"bAlpha"],
+                @"resolving B installs B's manual list without stale A work");
+}
+
+static void TestSortingRestoreCancelsPendingWork(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    [sTestDefaults setObject:@[@"Zulu", @"alpha"] forKey:UDKeyApolloFavoriteSubreddits];
+    ApolloPerAccountFavoritesSuspendForPreferencesRestore();
+    Require(!ApolloFavoritesSortingIsAvailable(), @"sorting is unavailable during preferences restore");
+    NSDictionary *restoredPreferences = @{@"u:a": @NO, @"u:b": @YES};
+    [sTestDefaults setObject:restoredPreferences forKey:UDKeyFavoriteSortingByAccount];
+    [sTestDefaults setObject:@[@"restoreZulu", @"restoreAlpha"] forKey:UDKeyApolloFavoriteSubreddits];
+    NSDictionary *restoredStore = @{
+        @"version": @1,
+        @"buckets": @{@"shared": @[@"restored"], @"u:b": @[@"restoreZulu", @"restoreAlpha"]},
+    };
+    [sTestDefaults setObject:restoredStore forKey:UDKeyPerAccountFavoriteSubreddits];
+    NSUInteger nativeWrites = sTestNativeFavoritesWrites;
+    NSUInteger bucketWrites = sTestBucketWrites;
+    ApolloFavoritesSortingSetEnabled(YES);
+    ApolloFavoritesSortingSchedule();
+    DrainMainQueue();
+    Require(sTestNativeFavoritesWrites == nativeWrites && sTestBucketWrites == bucketWrites,
+            @"queued sorting and projection work cannot write during restore replay");
+    RequireList(NativeFavorites(), @[@"restoreZulu", @"restoreAlpha"],
+                @"restored favorites preserve the order supplied by the backup");
+    Require([[sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits] isEqual:restoredStore],
+            @"sorting cannot write the pre-restore account into the restored bucket envelope");
+    Require([[sTestDefaults objectForKey:UDKeyFavoriteSortingByAccount] isEqual:restoredPreferences],
+            @"sorting cannot overwrite restored account preferences");
+}
+
+static void TestSortingRefreshIsIdempotent(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    DrainMainQueue();
+    NSUInteger nativeWrites = sTestNativeFavoritesWrites;
+    NSUInteger bucketWrites = sTestBucketWrites;
+    __block NSUInteger delivered = 0;
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloFavoriteSubredditsUpdatedNotification
+                    object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+        delivered++;
+    }];
+    for (NSUInteger i = 0; i < 5; i++) {
+        ApolloFavoritesSortingSetEnabled(YES);
+        ApolloFavoritesSortingSchedule();
+        ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    }
+    DrainMainQueue();
+    DrainMainQueue();
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    Require(sTestNativeFavoritesWrites == nativeWrites && sTestBucketWrites == bucketWrites,
+            @"repeated sorting and account refreshes do not rewrite an already sorted list");
+    Require(delivered == 0, @"already sorted refreshes do not emit redundant native list updates");
+}
+
+static void TestSortingUnmarkedNativeNotification(void) {
+    StartSortingStore();
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    [(ApolloFavoritesTestDefaults *)sTestDefaults
+        setNativeFavoritesWithoutSetterHook:@[@"Zulu", @"alpha", @"middle"]];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    DrainMainQueue();
+    RequireList(NativeFavorites(), @[@"alpha", @"middle", @"Zulu"],
+                @"ordinary native notifications alphabetize writes from an alternate persistence path");
+    RequireList(Buckets()[@"u:a"], @[@"alpha", @"middle", @"Zulu"],
+                @"unmarked native notifications persist the sorted account list");
+}
+
+static id ObserveSortingSettings(NSMutableArray<NSArray<NSNumber *> *> *snapshots) {
+    // Stand in for a settings screen that stays open throughout a quick account
+    // switch. Read the same public state as the row when its refresh arrives.
+    return [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloFavoritesSortingStateDidChangeNotification
+                    object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+        Require([NSThread isMainThread], @"sorting settings refresh arrives on the main thread");
+        [snapshots addObject:@[@(sSortFavoritesAlphabetically), @(ApolloFavoritesSortingIsAvailable())]];
+    }];
+}
+
+static void TestSortingSettingsFollowQuickAccountSwitch(void) {
+    [sTestDefaults setObject:@{@"u:a": @NO, @"u:b": @YES}
+                     forKey:UDKeyFavoriteSortingByAccount];
+    StartSortingStore();
+    Require(!sSortFavoritesAlphabetically, @"the settings screen initially shows A's disabled sorting");
+    NSMutableArray *snapshots = [NSMutableArray array];
+    id observer = ObserveSortingSettings(snapshots);
+
+    ResolveAccountB();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@YES, @YES]],
+                @"the open settings screen refreshes to B's enabled sorting");
+    ResolveAccountA();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@YES, @YES], @[@NO, @YES]],
+                @"the same settings observer refreshes back to A's disabled sorting");
+
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    ApolloFavoritesSortingSetEnabled(NO);
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@YES, @YES], @[@NO, @YES], @[@YES, @YES], @[@NO, @YES]],
+                @"changes to the active account's sorting preference also refresh the settings row");
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+static void TestSortingSettingsFollowIdentityAvailability(void) {
+    StartSortingStore();
+    NSMutableArray *snapshots = [NSMutableArray array];
+    id observer = ObserveSortingSettings(snapshots);
+
+    // Both accounts have sorting off, so observing only the effective on/off
+    // value would miss the control becoming unavailable and available again.
+    sTestLiveStatus = ApolloPersistedAccountIdentityUnknown;
+    sTestLiveUsername = nil;
+    ApolloPerAccountFavoritesLiveAccountStateDidChange();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@NO, @NO]],
+                @"the open settings screen disables its switch while account identity is unknown");
+    ResolveAccountB();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@NO, @NO], @[@NO, @YES]],
+                @"identity recovery re-enables the visible switch even when both sorting preferences are off");
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+static void TestSortingSettingsCoalesceQuickAccountSwitches(void) {
+    [sTestDefaults setObject:@{@"u:a": @NO, @"u:b": @YES}
+                     forKey:UDKeyFavoriteSortingByAccount];
+    StartSortingStore();
+    NSMutableArray *snapshots = [NSMutableArray array];
+    id observer = ObserveSortingSettings(snapshots);
+
+    ResolveAccountB();
+    ResolveAccountA();
+    ResolveAccountB();
+    Require(snapshots.count == 0, @"account changes defer settings refresh until the current turn completes");
+    DrainMainQueue();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@YES, @YES]],
+                @"rapid account changes deliver one refresh containing the final account's state");
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+static void TestSortingSettingsIgnoreUnchangedScope(void) {
+    [sTestDefaults setObject:@{@"u:a": @NO, @"u:b": @YES}
+                     forKey:UDKeyFavoriteSortingByAccount];
+    StartSortingStore();
+    NSMutableArray *snapshots = [NSMutableArray array];
+    id observer = ObserveSortingSettings(snapshots);
+
+    for (NSUInteger i = 0; i < 5; i++) {
+        ResolveAccountA();
+        ApolloFavoritesSortingSetScope(@"u:a");
+        ApolloFavoritesSortingSetEnabled(NO);
+    }
+    DrainMainQueue();
+    Require(snapshots.count == 0, @"repeated calls for unchanged A settings do not refresh the row");
+    ResolveAccountB();
+    DrainMainQueue();
+    for (NSUInteger i = 0; i < 5; i++) {
+        ResolveAccountB();
+        ApolloFavoritesSortingSetScope(@"u:b");
+        ApolloFavoritesSortingSetEnabled(YES);
+    }
+    DrainMainQueue();
+    DrainMainQueue();
+    RequireList(snapshots, @[@[@YES, @YES]],
+                @"repeated calls for unchanged B settings do not duplicate its account-change refresh");
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+static void TestSortingStoreFailurePreservesManualOrder(BOOL unsupportedVersion, BOOL unmarkedNotification) {
+    StartSortingStore();
+    [sTestDefaults setBool:YES forKey:UDKeySortFavoritesAlphabetically];
+    Require(!sSortFavoritesAlphabetically, @"A's sorting is off while the saved shared preference is on");
+    NSDictionary *unreadableStore = unsupportedVersion
+        ? @{@"version": @99, @"buckets": @{@"futureData": @[@"retained"]}}
+        : @{@"version": @1, @"buckets": @{@"u:a": @[@"retained"]}};
+    [sTestDefaults setObject:unreadableStore forKey:UDKeyPerAccountFavoriteSubreddits];
+    NSUInteger bucketWrites = sTestBucketWrites;
+    NSMutableArray *snapshots = [NSMutableArray array];
+    id observer = ObserveSortingSettings(snapshots);
+    NSArray *manual = @[@"Zebra", @"Apple", @"banana"];
+    if (unmarkedNotification) {
+        [(ApolloFavoritesTestDefaults *)sTestDefaults setNativeFavoritesWithoutSetterHook:manual];
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    } else {
+        [sTestDefaults setObject:manual forKey:UDKeyApolloFavoriteSubreddits];
+    }
+    Require(!sPerAccountFavoritesEnabled && ![sTestDefaults boolForKey:UDKeyPerAccountFavoritesEnabled],
+            @"an unreadable account store disables per-account favorites");
+    NSUInteger nativeWrites = sTestNativeFavoritesWrites;
+    DrainMainQueue();
+    DrainMainQueue();
+    Require(sTestNativeFavoritesWrites == nativeWrites,
+            @"the mutation detecting the unreadable store cannot schedule a shared-sort rewrite");
+    RequireList(NativeFavorites(), manual, @"store failure preserves the native list's manual order");
+    Require(!sSortFavoritesAlphabetically && ApolloFavoritesSortingIsAvailable(),
+            @"sorting remains available but effectively off after store failure");
+    Require([sTestDefaults boolForKey:UDKeySortFavoritesAlphabetically],
+            @"preserving manual order does not overwrite the saved shared sorting preference");
+    RequireList(snapshots, @[@[@NO, @YES]],
+                @"the visible settings row receives the final manual sorting state after store failure");
+
+    // The defaults setter and ordinary native notifications may both follow
+    // the failed mutation. Repeated reconciliation must also keep this order.
+    ApolloFavoritesSortingSetScope(@"shared");
+    NSArray *edited = @[@"Zebra", @"Apple", @"banana", @"aardvark"];
+    [sTestDefaults setObject:edited forKey:UDKeyApolloFavoriteSubreddits];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloFavoriteSubredditsUpdatedNotification object:nil];
+    nativeWrites = sTestNativeFavoritesWrites;
+    DrainMainQueue();
+    DrainMainQueue();
+    Require(sTestNativeFavoritesWrites == nativeWrites,
+            @"subsequent native mutations cannot bypass manual order preservation");
+    RequireList(NativeFavorites(), edited, @"favorites remain manually ordered until the user enables sorting");
+    RequireList(snapshots, @[@[@NO, @YES]],
+                @"reconciling the same shared scope keeps the effective off state without redundant refreshes");
+    Require(sTestBucketWrites == bucketWrites &&
+            [[sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits] isEqual:unreadableStore],
+            @"neither failure recovery nor later mutations overwrite the unreadable account envelope");
+
+    ApolloFavoritesSortingSetEnabled(YES);
+    DrainMainQueue();
+    Require(sSortFavoritesAlphabetically, @"an explicit user choice resumes sorting after store failure");
+    RequireList(NativeFavorites(), @[@"aardvark", @"Apple", @"banana", @"Zebra"],
+                @"explicitly enabling sorting alphabetizes the retained favorites");
+    RequireList(snapshots, @[@[@NO, @YES], @[@YES, @YES]],
+                @"the visible switch reflects the user's explicit sorting choice after recovery");
+    Require([[sTestDefaults objectForKey:UDKeyPerAccountFavoriteSubreddits] isEqual:unreadableStore],
+            @"resuming shared sorting leaves the unreadable account envelope intact");
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
 int main(int argc, const char *argv[]) {
     @autoreleasepool {
         if (argc != 2) {
@@ -285,6 +709,38 @@ int main(int argc, const char *argv[]) {
                 TestFeatureOffIsDormant();
             } else if ([scenario isEqualToString:@"first-enable"]) {
                 TestFirstEnableClonesSharedFavorites();
+            } else if ([scenario isEqualToString:@"sorting-toggle"]) {
+                TestSortingToggle();
+            } else if ([scenario isEqualToString:@"sorting-native-add-remove"]) {
+                TestSortingNativeAddAndRemove();
+            } else if ([scenario isEqualToString:@"sorting-account-switch-pending"]) {
+                TestSortingAccountSwitchWithPendingWrite();
+            } else if ([scenario isEqualToString:@"sorting-shared-preference"]) {
+                TestSortingSharedPreferenceIsSeparate();
+            } else if ([scenario isEqualToString:@"sorting-unknown-identity"]) {
+                TestSortingUnknownIdentityCannotWrite();
+            } else if ([scenario isEqualToString:@"sorting-restore-pending"]) {
+                TestSortingRestoreCancelsPendingWork();
+            } else if ([scenario isEqualToString:@"sorting-refresh-idempotent"]) {
+                TestSortingRefreshIsIdempotent();
+            } else if ([scenario isEqualToString:@"sorting-unmarked-notification"]) {
+                TestSortingUnmarkedNativeNotification();
+            } else if ([scenario isEqualToString:@"sorting-settings-account-switch"]) {
+                TestSortingSettingsFollowQuickAccountSwitch();
+            } else if ([scenario isEqualToString:@"sorting-settings-identity-availability"]) {
+                TestSortingSettingsFollowIdentityAvailability();
+            } else if ([scenario isEqualToString:@"sorting-settings-coalesced-switches"]) {
+                TestSortingSettingsCoalesceQuickAccountSwitches();
+            } else if ([scenario isEqualToString:@"sorting-settings-unchanged-scope"]) {
+                TestSortingSettingsIgnoreUnchangedScope();
+            } else if ([scenario isEqualToString:@"sorting-invalid-store-native-write"]) {
+                TestSortingStoreFailurePreservesManualOrder(NO, NO);
+            } else if ([scenario isEqualToString:@"sorting-invalid-store-native-notification"]) {
+                TestSortingStoreFailurePreservesManualOrder(NO, YES);
+            } else if ([scenario isEqualToString:@"sorting-unsupported-store-native-write"]) {
+                TestSortingStoreFailurePreservesManualOrder(YES, NO);
+            } else if ([scenario isEqualToString:@"sorting-unsupported-store-native-notification"]) {
+                TestSortingStoreFailurePreservesManualOrder(YES, YES);
             } else {
                 Require(NO, [@"unknown scenario: " stringByAppendingString:scenario]);
             }

--- a/tests/run_per_account_favorites_tests.sh
+++ b/tests/run_per_account_favorites_tests.sh
@@ -13,6 +13,7 @@ xcrun --sdk macosx clang -fobjc-arc -fblocks -Wall -Wextra -Werror \
     -framework Foundation -DAPOLLO_PER_ACCOUNT_FAVORITES_TESTING \
     -I "$test_repo_root/src" \
     "$test_repo_root/src/ApolloPerAccountFavorites.m" \
+    "$test_repo_root/src/ApolloFavoritesSorting.m" \
     "$test_repo_root/tests/per_account_favorites_tests.m" \
     -o "$test_binary"
 
@@ -25,7 +26,23 @@ for test_scenario in \
     reentrant-native-write \
     unmarked-native-notification \
     feature-off \
-    first-enable; do
+    first-enable \
+    sorting-toggle \
+    sorting-native-add-remove \
+    sorting-account-switch-pending \
+    sorting-shared-preference \
+    sorting-unknown-identity \
+    sorting-restore-pending \
+    sorting-refresh-idempotent \
+    sorting-unmarked-notification \
+    sorting-settings-account-switch \
+    sorting-settings-identity-availability \
+    sorting-settings-coalesced-switches \
+    sorting-settings-unchanged-scope \
+    sorting-invalid-store-native-write \
+    sorting-invalid-store-native-notification \
+    sorting-unsupported-store-native-write \
+    sorting-unsupported-store-native-notification; do
     if ! "$test_binary" "$test_scenario"; then
         test_failures=$((test_failures + 1))
     fi
@@ -35,4 +52,4 @@ if [ "$test_failures" -ne 0 ]; then
     printf 'per_account_favorites_tests: %s scenario(s) failed\n' "$test_failures" >&2
     exit 1
 fi
-printf 'per_account_favorites_tests: all 8 scenarios passed\n'
+printf 'per_account_favorites_tests: all 24 scenarios passed\n'


### PR DESCRIPTION
## Summary 

Adds Sort Favorites Alphabetically under Apollo Reborn → Subreddits → Favorites.
- Sorts existing favorites and automatically places new additions in order.
- Disables manual reordering while enabled; turning it off restores dragging.
- Remembers sorting separately for each account when Per-Account Favorites is enabled, with a separate shared preference.
- Updates the visible toggle after quick account switches and account-loading transitions.
- Preserves manual order if account data becomes invalid, without overwriting the saved shared sorting preference.

## Preview

<table width="100%">
  <tr>
    <th width="33%">Before: Unsorted Favorites</th>
    <th width="33%">Favorites Settings</th>
    <th width="33%">After: Sorted A–Z</th>
  </tr>
  <tr>
    <td width="33%" align="center" valign="top">
      <img width="300" alt="Unsorted favorites" src="https://github.com/user-attachments/assets/499f87ab-dcb2-4dc9-980d-47007498a229" />
    </td>
    <td width="33%" align="center" valign="top">
      <img width="300" alt="Favorites settings" src="https://github.com/user-attachments/assets/afc89bf5-328a-4a8a-94bf-c8247af8e867" />
    </td>
    <td width="33%" align="center" valign="top">
      <img width="300" alt="Alphabetically sorted favorites" src="https://github.com/user-attachments/assets/2b2f9598-3550-4433-917a-c1da30a09430" />
    </td>
  </tr>
</table>


## Validation
- All 24 regression scenarios pass on the feature and test branches.
- Simulator build, launch, and settings layout verified in the development checkout.