### PR TITLE
Polish Liquid Glass navigation and Moderator UI

### DIFF
--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -143,9 +143,21 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     UIView *fromView = [ctx viewForKey:UITransitionContextFromViewKey] ?: fromVC.view;
     UIView *toView = [ctx viewForKey:UITransitionContextToViewKey] ?: toVC.view;
     BOOL push = ApolloNavAnimatorIsPresenting(animatorObject);
-    UISearchController *fromSearch = fromVC.navigationItem.searchController;
-    BOOL restoreSearchOnCancel = ApolloNativeFeedSearchEnabled() && !fromSearch.active &&
-                                 CGRectGetHeight(fromSearch.searchBar.bounds) > 1.0;
+    UINavigationItem *fromItem = fromVC.navigationItem;
+    UISearchController *fromSearch = fromItem.searchController;
+    UINavigationController *navigationController = fromVC.navigationController;
+    BOOL hadRevealedSearch = ApolloNativeFeedSearchEnabled() && interactive && !push && fromSearch && !fromSearch.active &&
+        fromItem.hidesSearchBarWhenScrolling && CGRectGetHeight(fromSearch.searchBar.bounds) > 1.0;
+    __block BOOL holdsRevealedInset = NO;
+    if (hadRevealedSearch) {
+        [fromVC.transitionCoordinator notifyWhenInteractionChangesUsingBlock:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            if (!context.isCancelled || fromItem.searchController != fromSearch || fromSearch.active) return;
+            // A cancelled pop must keep the outgoing page's existing safe-area band.
+            // Otherwise UIKit briefly removes it and reparks the entire feed upward.
+            holdsRevealedInset = YES;
+            fromItem.hidesSearchBarWhenScrolling = NO;
+        }];
+    }
     CGFloat width = CGRectGetWidth(container.bounds);
     CGFloat parallax = width / kApolloNavParallaxDivisor;
 
@@ -233,16 +245,32 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         // No cache bookkeeping here: this may synchronously start the next transition (a push or
         // pop issued from didShowViewController:), whose animator must survive untouched. The
         // per-context lookup in interruptibleAnimatorForTransition: keeps the two apart.
-        [ctx completeTransition:!cancelled];
-        // completeTransition: synchronously restores the item stack and feed
-        // geometry on cancellation. Keep the guard up through that cleanup.
-        if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
-        if (cancelled && restoreSearchOnCancel) {
-            ApolloNativeFeedSearchRestoreCancelledNavigation(fromVC);
-        }
+        void (^complete)(void) = ^{
+            [ctx completeTransition:!cancelled];
+            // Keep the guard through UIKit's synchronous item-stack restoration.
+            if (interactive && sApolloNavTransitionsInFlight > 0) sApolloNavTransitionsInFlight--;
+            if (holdsRevealedInset) {
+                holdsRevealedInset = NO;
+                // UIKit defers its final content-overlay layout until after
+                // completeTransition:. Flush it while the existing band is held;
+                // releasing the policy first lets that pass briefly remove it.
+                if (!ApolloNavTransitionInFlight() &&
+                    navigationController.topViewController == fromVC &&
+                    navigationController.visibleViewController == fromVC) {
+                    [navigationController.view setNeedsLayout];
+                    [navigationController.view layoutIfNeeded];
+                }
+                fromItem.hidesSearchBarWhenScrolling = YES;
+            }
+            if (cancelled && interactive) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);
+        };
+        // The reversed animator has already returned the page to its rest frame.
+        // Item, inset and title restoration must not start a second animation.
+        if (cancelled) [UIView performWithoutAnimation:complete];
+        else complete();
         // The bar has settled on whichever item won; give the title capsules that were held
         // back during the cross-fade their chance now (they fade in rather than pop).
-        if (interactive) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);
+        if (interactive && !cancelled) ApolloNavigationTitleGlassRefreshNavigationBar(navigationBar);
     }];
     // The animator's blocks hold ctx, the views and the dim/shadow until it finishes;
     // UIViewPropertyAnimator drops them then, so nothing here outlives the transition.

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -946,8 +946,6 @@ static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *con
 @property (nonatomic) CGRect observedJumpBarBounds;
 @property (nonatomic) NSUInteger observedJumpBarSubviewCount;
 @property (nonatomic) BOOL observedSearching;
-@property (nonatomic) CFTimeInterval searchMorphDeadline;
-@property (nonatomic, weak) UITextField *revealingSearchField;
 @property (nonatomic) BOOL actionsMotionCaptured;
 @property (nonatomic) CGPoint actionsMotionStart;
 // Read-only frame fold over the whole bar subtree: the recenter's output
@@ -989,9 +987,6 @@ static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *con
     [self.glassView removeFromSuperview];
     self.glassView = nil;
     self.glassHostView = nil;
-    self.searchMorphDeadline = 0;
-    [self.revealingSearchField.layer removeAnimationForKey:@"ApolloJumpBarSearchReveal"];
-    self.revealingSearchField = nil;
 }
 
 - (void)resetContentPlacementPreservingActionsMotion:(BOOL)preserve {
@@ -1395,58 +1390,31 @@ BOOL ApolloNavigationTitleContainsNativeSearchSurface(UIView *view) {
     }
     self.preservesNativeSearchLayout = NO;
 
-    // Search's Cancel/globe allocation settles over several frames on iOS 27.
-    // Morph from the displayed bar-space frame to avoid width jumps; exclude
-    // push/pop transitions and Reduce Motion.
-    BOOL searching = ApolloJumpBarIsSearching(jumpBar);
     BOOL navigating = ApolloOwningTopViewController(self.titleControl).transitionCoordinator.isAnimated;
-    if (navigating || UIAccessibilityIsReduceMotionEnabled()) self.searchMorphDeadline = 0;
-    if (self.observationValid && jumpBar && jumpBar == self.observedJumpBar &&
-        searching != self.observedSearching && !navigating && !UIAccessibilityIsReduceMotionEnabled()) {
-        self.searchMorphDeadline = CACurrentMediaTime() + 0.3;
-        [self.revealingSearchField.layer removeAnimationForKey:@"ApolloJumpBarSearchReveal"];
-        self.revealingSearchField = searching ? ApolloVisibleTitleSearchField(jumpBar) : nil;
-        if (self.revealingSearchField && self.glassView) {
-            // Reveal text as the narrow capsule opens, preserving model alpha.
-            CAKeyframeAnimation *reveal = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
-            reveal.values = @[@(-1.0), @(-1.0), @0.0];
-            reveal.keyTimes = @[@0.0, @0.5, @1.0];
-            reveal.duration = 0.3;
-            reveal.additive = YES;
-            [self.revealingSearchField.layer addAnimation:reveal forKey:@"ApolloJumpBarSearchReveal"];
-        }
-    }
-    UIView *bar = self.titleControl.superview;
-    while (bar && ![bar isKindOfClass:UINavigationBar.class]) bar = bar.superview;
+    BOOL animateSearch = jumpBar && jumpBar == self.observedJumpBar && self.observationValid &&
+        ApolloJumpBarIsSearching(jumpBar) != self.observedSearching &&
+        !navigating && !UIAccessibilityIsReduceMotionEnabled();
     UIVisualEffectView *oldGlass = self.glassView;
-    CGRect oldGlassFrame = CGRectNull;
-    if (bar && oldGlass.window && CACurrentMediaTime() < self.searchMorphDeadline) {
-        CALayer *presentation = oldGlass.layer.presentationLayer;
-        CALayer *barPresentation = bar.layer.presentationLayer;
-        oldGlassFrame = presentation && barPresentation
-            ? [presentation convertRect:presentation.bounds toLayer:barPresentation]
-            : [oldGlass convertRect:oldGlass.bounds toView:bar];
-    }
+    CGRect oldBounds = oldGlass.bounds;
+    CGRect displayedBounds = oldGlass.layer.presentationLayer
+        ? oldGlass.layer.presentationLayer.bounds : oldBounds;
 
     // Constrain/transform outside layoutSubviews to avoid a layout loop. Cache
     // observations only after recentering succeeds, so skipped work retries.
     BOOL recenterSettled = ApolloRecenterTitleControl(self);
     if (recenterSettled && jumpBar) ApolloLayoutJumpBarSearchContent(jumpBar);
     [self updateGlassForHostView:hostView candidateViews:[self titleContentViews]];
-    if (!CGRectIsNull(oldGlassFrame) && self.glassView == oldGlass && oldGlass.superview == hostView) {
-        CGRect target = oldGlass.frame;
-        CGRect start = [bar convertRect:oldGlassFrame toView:hostView];
-        if (!CGRectEqualToRect(start, target)) {
-            // The host itself just changed width/origin. Rebase before
-            // animating so that transform is not counted a second time.
-            [oldGlass.layer removeAnimationForKey:@"position"];
-            [oldGlass.layer removeAnimationForKey:@"bounds"];
-            [UIView performWithoutAnimation:^{ oldGlass.frame = start; }];
-            [UIView animateWithDuration:MAX(0.08, self.searchMorphDeadline - CACurrentMediaTime())
-                                  delay:0 options:UIViewAnimationOptionBeginFromCurrentState |
-                                      UIViewAnimationOptionAllowUserInteraction | UIViewAnimationOptionCurveEaseOut
-                             animations:^{ oldGlass.frame = target; } completion:nil];
-        }
+    if (animateSearch && oldGlass && self.glassView == oldGlass &&
+        !CGRectEqualToRect(oldBounds, oldGlass.bounds)) {
+        // The host already keeps the capsule centered. Animate only its size;
+        // rebasing its position adds the host's movement a second time.
+        CABasicAnimation *resize = [CABasicAnimation animationWithKeyPath:@"bounds"];
+        displayedBounds.origin = oldGlass.bounds.origin;
+        resize.fromValue = [NSValue valueWithCGRect:displayedBounds];
+        resize.toValue = [NSValue valueWithCGRect:oldGlass.bounds];
+        resize.duration = 0.25;
+        resize.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+        [oldGlass.layer addAnimation:resize forKey:@"bounds"];
     }
 
     self.observedTitleFrame = self.titleControl.frame;
@@ -1719,8 +1687,23 @@ static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *con
     // treat controls / labels / image views / visual-effect bubbles as edges.
     CGFloat leftLimit = CGRectGetMinX(bar.bounds) + bar.safeAreaInsets.left;
     CGFloat rightLimit = CGRectGetMaxX(bar.bounds) - bar.safeAreaInsets.right;
+    UIView *jumpBar = ApolloFindJumpBar(titleControl);
+    BOOL searching = jumpBar && ApolloJumpBarIsSearching(jumpBar);
+    BOOL searchActions = NO;
+    CGFloat searchActionsWidth = 0;
+    for (UIBarButtonItem *item in bar.topItem.rightBarButtonItems) {
+        searchActions |= item.action == NSSelectorFromString(@"cancelBarButtonItemTappedWithSender:");
+        CGFloat width = item.customView ? item.customView.intrinsicContentSize.width : item.width;
+        searchActionsWidth += MAX(44.0, width);
+    }
+    searchActions &= searching;
+    // Outgoing platters remain visible during the search handoff. Their moving
+    // edges are not the editor's available width; reserve the final items once.
+    if (searchActions) {
+        rightLimit -= MAX(16.0, bar.layoutMargins.right) + searchActionsWidth;
+    }
     CGRect collapsedActions = ApolloNavigationActionsCollapsedFrame(bar);
-    if (!CGRectIsNull(collapsedActions)) {
+    if (!searchActions && !CGRectIsNull(collapsedActions)) {
         if (CGRectGetMidX(collapsedActions) >= CGRectGetMidX(bar.bounds)) {
             rightLimit = MIN(rightLimit, CGRectGetMinX(collapsedActions));
         } else {
@@ -1768,15 +1751,13 @@ static BOOL ApolloRecenterTitleControl(ApolloNavigationTitleGlassController *con
             if (CGRectGetMidX(sibInBar) < CGRectGetMidX(bar.bounds)) {
                 leftLimit = MAX(leftLimit, CGRectGetMaxX(sibInBar));
             } else {
-                rightLimit = MIN(rightLimit, CGRectGetMinX(sibInBar));
+                if (!searchActions) rightLimit = MIN(rightLimit, CGRectGetMinX(sibInBar));
             }
         }
     }
 
     const CGFloat kEdgePadding = kApolloTitleButtonSpacing;
 
-    UIView *jumpBar = ApolloFindJumpBar(titleControl);
-    BOOL searching = jumpBar && ApolloJumpBarIsSearching(jumpBar);
     CGFloat capsulePadding = !searching &&
         ApolloResolvedScrollEdgeEffectStyle() != ApolloScrollEdgeEffectStyleHard
         ? kApolloTitleCapsuleHorizontalPadding : 0.0;
@@ -2151,45 +2132,20 @@ void ApolloNavigationTitlesRefresh(void) {
 
 %end
 
-static CGSize ApolloDualTitleNavigationSize(UIButton *button, CGSize size) {
-    if (!isfinite(size.height) || size.height <= 44.0 || !isfinite(size.width) || size.width <= 0) return size;
-    // UIKit may not have populated its label yet. Measure the current native
-    // attributed title without forcing lazy layout from an intrinsic-size read.
-    NSAttributedString *title = button.currentAttributedTitle;
-    if (!title.length) return size;
-    CGFloat textHeight = ceil([title boundingRectWithSize:CGSizeMake(size.width, CGFLOAT_MAX)
-        options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size.height);
-    if (isfinite(textHeight) && textHeight > 0 && textHeight <= 44.0) size.height = 44.0;
-    return size;
-}
-
-%group ApolloLGDualTitleSizing
-%hook ApolloDualLabelNavigationTitleButton
-- (CGSize)intrinsicContentSize {
-    return ApolloDualTitleNavigationSize((UIButton *)self, %orig);
-}
-- (CGSize)sizeThatFits:(CGSize)size {
-    return ApolloDualTitleNavigationSize((UIButton *)self, %orig(size));
-}
-%end
-%end
-
 %ctor {
     %init;
-    Class dualTitleButton = NSClassFromString(@"Apollo.DualLabelTitleButton");
-    if (IsLiquidGlass() && NSClassFromString(@"UIGlassEffect") && dualTitleButton) {
-        // Set the native allocation before push animation or title adoption.
-        %init(ApolloLGDualTitleSizing, ApolloDualLabelNavigationTitleButton = dualTitleButton);
-    }
-    // Also cover programmatic JumpBar entry, which doesn't pass through touch
-    // tracking. The native opening helper has set the field frame by this point.
+    // Programmatic entry also needs a refresh, but editing starts before Apollo
+    // finishes replacing the trailing buttons. Measure after that setup returns.
     [[NSNotificationCenter defaultCenter] addObserverForName:UITextFieldTextDidBeginEditingNotification
                                                      object:nil queue:nil
                                                  usingBlock:^(NSNotification *notification) {
         UIView *field = notification.object;
         if ([field isKindOfClass:UITextField.class] &&
             [NSStringFromClass(field.superview.class) isEqualToString:@"Apollo.JumpBar"]) {
-            ApolloRefreshJumpBarSearchPresentation(field.superview);
+            __weak UIView *jumpBar = field.superview;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ApolloRefreshJumpBarSearchPresentation(jumpBar);
+            });
         }
     }];
     // _UINavigationBarPlatterView only exists on iOS 26+ — register the poke

--- a/src/ApolloMedia.xm
+++ b/src/ApolloMedia.xm
@@ -144,11 +144,8 @@ static void ApolloMediaRepairRouteControlLayout(UIView *routeView, NSString *rea
     routeView.superview.clipsToBounds = NO;
     routeView.superview.layer.masksToBounds = NO;
 
-    CGRect frame = routeView.frame;
-    CGFloat minSide = 36.0;
-    if (frame.size.width > 0.0 && frame.size.width < minSide) frame.size.width = minSide;
-    if (frame.size.height > 0.0 && frame.size.height < minSide) frame.size.height = minSide;
-    routeView.frame = frame;
+    // UIKit sizes and centers this control inside the player's glass button.
+    // Enlarging it here shifts the glyph away from that center.
 
     NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:routeView];
     NSUInteger inspected = 0;

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -14,6 +14,7 @@
 static char kApolloNativeActionMenuControllerKey;
 static char kApolloNativeActionMenuInvokingActionKey;
 static char kApolloNativeActionMenuWrappedModeratorActionKey;
+static char kApolloNativeActionMenuModeratorSelectionKey;
 static char kApolloNativeActionMenuLifecycleFallbackKey;
 static char kApolloNativeActionMenuPresenterKey;
 static char kApolloNativeActionMenuSourceViewKey;
@@ -273,7 +274,7 @@ static NSString *ApolloNativeActionDefaultTitle(uint16_t actionKind) {
 }
 
 static UIColor *ApolloNativeActionMenuModeratorColor(void) {
-    return [UIColor colorWithRed:0.0 green:(148.0 / 255.0) blue:(16.0 / 255.0) alpha:1.0];
+    return ApolloModeratorColor();
 }
 
 static BOOL ApolloNativeActionKindOpensModeratorMenu(uint16_t actionKind) {
@@ -413,7 +414,7 @@ static void ApolloNativeActionMenuStyleElement(UIMenuElement *element, BOOL mode
     UIColor *moderatorTintColor = ApolloNativeActionMenuModeratorColor();
     UIColor *elementTintColor = (!destructive && (moderatorStyle || opensModeratorMenu)) ? moderatorTintColor : nil;
 
-    ApolloNativeActionMenuStyleElementTitle(element, elementTintColor);
+    ApolloNativeActionMenuStyleElementTitle(element, elementTintColor ? UIColor.labelColor : nil);
     if (elementTintColor) ApolloNativeActionMenuStyleElementImage(element, elementTintColor);
 
     if ([element isKindOfClass:[UIAction class]]) {
@@ -701,6 +702,12 @@ static void ApolloNativeActionMenuPrimeChainedSourceView(id actionController) {
 }
 
 static void ApolloNativeActionMenuSelectRow(id actionController, NSInteger row) {
+    // Finish the reverse menu morph before a moderator action changes pages.
+    // The presenter association is cleared before this deferred call runs.
+    if ([objc_getAssociatedObject(actionController, &kApolloNativeActionMenuModeratorSelectionKey) boolValue] &&
+        ApolloNativeActionMenuPerformAfterDismissal(actionController, ^{
+            ApolloNativeActionMenuSelectRow(actionController, row);
+        })) return;
     if (!actionController || ![actionController respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)]) {
         ApolloLog(@"[NativeActionMenu] Cannot invoke ActionController row %ld", (long)row);
         return;
@@ -741,7 +748,7 @@ static UIAction *ApolloNativeActionMenuAction(NSString *title, NSString *subtitl
         ApolloNativeActionMenuSelectRow(actionController, row);
     }];
 
-    ApolloNativeActionMenuStyleElementTitle(action, tintColor);
+    ApolloNativeActionMenuStyleElementTitle(action, tintColor ? UIColor.labelColor : nil);
 
     if (subtitle.length > 0 && [action respondsToSelector:@selector(setSubtitle:)]) {
         ((void (*)(id, SEL, id))objc_msgSend)(action, @selector(setSubtitle:), subtitle);
@@ -893,6 +900,8 @@ static NSArray<UIMenuElement *> *ApolloNativeActionMenuBuildModeratorReportSecti
 }
 
 static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderatorStyle) {
+    objc_setAssociatedObject(actionController, &kApolloNativeActionMenuModeratorSelectionKey,
+        @(moderatorStyle), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     void *actionsBuffer = ApolloReadRawIvar(actionController, "actions");
     void *textActionsBuffer = ApolloReadRawIvar(actionController, "textActions");
     int64_t actionCount = ApolloSwiftArrayCount(actionsBuffer);
@@ -1924,6 +1933,26 @@ static BOOL ApolloNativeActionMenuCanFallbackPresent(id presenter, id actionCont
     // The nav-bar item and bottom filter node call the same no-argument action.
     // Texture dispatches the node's target synchronously from this method, so
     // preserve the actual touched node for the nested controller hook above.
+    ApolloNativeActionMenuBeginCapture(self, self);
+    %orig;
+    ApolloNativeActionMenuEndCapture();
+}
+%end
+
+%hook _TtC6Apollo27ModeratorLogsViewController
+- (void)modLogsFilterNodeTapped {
+    id filterNode = ApolloReadObjectIvar(self, "modLogsFilterNode");
+    UIView *filterNodeView = ApolloNativeActionMenuViewForObject(filterNode);
+    BOOL fromFilterNode = sApolloNativeActionMenuCaptureDepth > 0 &&
+        sApolloNativeActionMenuSourceView == filterNodeView;
+    ApolloNativeActionMenuBeginCapture(fromFilterNode ? filterNode : ApolloReadObjectIvar(self, "filterBarButtonItem"), self);
+    %orig;
+    ApolloNativeActionMenuEndCapture();
+}
+%end
+
+%hook _TtC6Apollo17ModLogsFilterNode
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
     ApolloNativeActionMenuBeginCapture(self, self);
     %orig;
     ApolloNativeActionMenuEndCapture();

--- a/src/ApolloNavigationActions.xm
+++ b/src/ApolloNavigationActions.xm
@@ -2,6 +2,7 @@
 #import "ApolloNavigationActionsDiscovery.h"
 #import "ApolloNativeActionMenus.h"
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <QuartzCore/QuartzCore.h>
@@ -26,8 +27,75 @@ static char kActionsRefreshKey;
 static char kActionsStandardItemKey;
 static char kActionsStandardMoreKey;
 static char kActionsScrollOwnerKey;
+static char kActionsChromeKey;
+static char kActionsApprovedLayoutKey;
 static NSUInteger sActionsModelWriteDepth;
 @class ApolloNavigationActionsOwner;
+
+// Keep right-item chrome neutral before it appears, including lone actions on
+// profile feeds. Mark only the actual item content, never the whole nav bar.
+static void ApolloActionsPinChrome(id object) {
+    UIColor *chrome = ApolloNavigationChromeColor();
+    if (!objc_getAssociatedObject(object, &kActionsChromeKey) ||
+        ![[object tintColor] isEqual:chrome]) {
+        [object setTintColor:chrome];
+        objc_setAssociatedObject(object, &kActionsChromeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+static UIImage *ApolloActionsTemplateImage(UIImage *image) {
+    return image && image.renderingMode != UIImageRenderingModeAlwaysTemplate
+        ? [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] : image;
+}
+
+static BOOL ApolloActionsIsAutoModClose(UIBarButtonItem *item) {
+    return item.action == NSSelectorFromString(@"cancelBarButtonItemTappedWithSender:") &&
+        [NSStringFromClass([item.target class]) isEqualToString:@"Apollo.AutoModeratorViewController"];
+}
+
+static void ApolloActionsPrepareApprovedContent(UIView *content) {
+    if (!content || objc_getAssociatedObject(content, &kActionsApprovedLayoutKey)) return;
+    NSMutableArray<UIButton *> *buttons = [NSMutableArray array];
+    for (UIView *child in content.subviews) {
+        if ([child isKindOfClass:UIButton.class]) [buttons addObject:(UIButton *)child];
+    }
+    if (buttons.count != 2) return;
+    [buttons sortUsingComparator:^NSComparisonResult(UIButton *a, UIButton *b) {
+        return CGRectGetMinX(a.frame) < CGRectGetMinX(b.frame) ? NSOrderedAscending : NSOrderedDescending;
+    }];
+    // Apollo's compact legacy frames put the plus below its 24pt container.
+    // Keep the original controls/actions, with equal centered glass slots.
+    const CGFloat slotWidth = 36.0;
+    for (NSUInteger index = 0; index < buttons.count; index++) {
+        UIButton *button = buttons[index];
+        button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+        button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+        button.contentEdgeInsets = UIEdgeInsetsZero;
+        button.imageEdgeInsets = UIEdgeInsetsZero;
+        button.frame = CGRectMake(index * slotWidth, 0, slotWidth, 44);
+    }
+    CGRect frame = content.frame;
+    frame.size = CGSizeMake(buttons.count * slotWidth, 44);
+    content.frame = frame;
+    content.bounds = CGRectMake(0, 0, frame.size.width, 44);
+    objc_setAssociatedObject(content, &kActionsApprovedLayoutKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloActionsApplyChromeToView(UIView *view) {
+    if (!view) return;
+    ApolloActionsPinChrome(view);
+    if ([view isKindOfClass:UIButton.class]) {
+        UIButton *button = (id)view;
+        const UIControlState states[] = { UIControlStateNormal, UIControlStateSelected,
+            UIControlStateHighlighted, UIControlStateDisabled };
+        for (NSUInteger i = 0; i < sizeof(states) / sizeof(states[0]); i++) {
+            UIImage *image = [button imageForState:states[i]];
+            UIImage *templated = ApolloActionsTemplateImage(image);
+            if (templated != image) [button setImage:templated forState:states[i]];
+        }
+    }
+    for (UIView *child in view.subviews) ApolloActionsApplyChromeToView(child);
+}
 
 @interface ApolloNavigationActionsControllerBox : NSObject
 @property (nonatomic, weak) UIViewController *controller;
@@ -485,15 +553,44 @@ static NSArray<UIBarButtonItem *> *ApolloActionsInboxItems(UINavigationItem *ite
     // including late action insertion and overlapping menu sessions.
     if ([self deferGeometryUpdate]) return;
     self.preparing = YES;
+    for (UIBarButtonItem *item in items) {
+        if (item.action == NSSelectorFromString(@"cancelBarButtonItemTappedWithSender:") &&
+            [NSStringFromClass(self.controller.class) isEqualToString:@"Apollo.PostsViewController"]) {
+            // Search replaces these actions in the same update. Settle the old
+            // strip now so dismissal restores it collapsed, without a second spring.
+            [self setExpanded:NO animated:NO];
+            break;
+        }
+    }
     BOOL retargetAnimation = NO;
     NSMutableArray *strips = [NSMutableArray array];
+    ApolloNavigationActionsControllerBox *controllerBox = objc_getAssociatedObject(self.item, &kActionsControllerKey);
+    BOOL approvedSubmitters = [NSStringFromClass(controllerBox.controller.class)
+        isEqualToString:@"Apollo.ModeratorApprovedSubmittersViewController"];
     for (UIBarButtonItem *item in items) {
+        ApolloActionsPinChrome(item);
+        UIImage *image = ApolloActionsTemplateImage(item.image);
+        if (image != item.image) item.image = image;
         UIView *source = ApolloNavigationActionsContentView(item);
+        if (approvedSubmitters) ApolloActionsPrepareApprovedContent(source);
+        ApolloActionsApplyChromeToView(source);
         ApolloNavigationActionsStrip *strip = [item.customView isKindOfClass:ApolloNavigationActionsStrip.class]
             ? (id)item.customView : nil;
         UIButton *more = strip.more ?: ApolloActionsFindMore(source);
         if (!strip && more && ApolloActionsControlCount(source) > 1) {
-            strip = [[ApolloNavigationActionsStrip alloc] initWithContent:source more:more];
+            // Apollo rebuilds its container using the same buttons on return.
+            // Keep the displayed surface alive while UIKit hands off the item.
+            for (ApolloNavigationActionsStrip *existing in self.strips) {
+                if (existing.more == more) { strip = existing; break; }
+            }
+            if (strip) {
+                [strip removeIconAnimations];
+                [strip.content removeFromSuperview];
+                strip.content = source;
+                strip.originalAccessibilityHidden = source.accessibilityElementsHidden;
+            } else {
+                strip = [[ApolloNavigationActionsStrip alloc] initWithContent:source more:more];
+            }
             item.customView = strip;
             // setCustomView: detaches the old view even if reparented; adopt it afterward.
             [strip.surface.contentView addSubview:source];
@@ -676,7 +773,12 @@ static NSArray<UIBarButtonItem *> *ApolloActionsInboxItems(UINavigationItem *ite
     }
     // iOS 27's SwiftUI host caches custom-item width until the navigation model
     // changes. Reuse current identities, including any late native replacement.
-    [self.item setRightBarButtonItems:self.item.rightBarButtonItems animated:NO];
+    // During item replacement the caller is about to publish the new array.
+    // Republishing the outgoing array here lets translation upkeep pull the
+    // globe out of its new search host and merge it back into the old strip.
+    if (!self.preparing) {
+        [self.item setRightBarButtonItems:self.item.rightBarButtonItems animated:NO];
+    }
     UINavigationBar *bar = self.controller.navigationController.navigationBar;
     if (bar.topItem != self.item) return; // Never drive the page we navigated to.
     [bar setNeedsLayout];
@@ -923,9 +1025,48 @@ NSArray<UIView *> *ApolloNavigationActionsManagedRoots(UINavigationBar *bar) {
 %end
 %end
 
+// Apollo can retint existing controls without replacing their navigation item.
+// Reject those accent writes at the setter, rather than correcting a visible
+// frame later. Menu elements and unrelated content remain untouched.
+%group ApolloNavigationActionsChromeHooks
+%hook UIView
+- (void)setTintColor:(UIColor *)color {
+    if (objc_getAssociatedObject(self, &kActionsChromeKey)) {
+        color = ApolloNavigationChromeColor();
+        if ([self.tintColor isEqual:color]) return;
+    }
+    %orig(color);
+}
+%end
+
+%hook UIButton
+- (void)setImage:(UIImage *)image forState:(UIControlState)state {
+    if (objc_getAssociatedObject(self, &kActionsChromeKey)) image = ApolloActionsTemplateImage(image);
+    %orig(image, state);
+}
+%end
+
+%hook UIBarButtonItem
+- (void)setTintColor:(UIColor *)color {
+    if (objc_getAssociatedObject(self, &kActionsChromeKey) || ApolloActionsIsAutoModClose(self)) {
+        color = ApolloNavigationChromeColor();
+        if ([self.tintColor isEqual:color]) return;
+    }
+    %orig(color);
+}
+- (void)setImage:(UIImage *)image {
+    if (objc_getAssociatedObject(self, &kActionsChromeKey) || ApolloActionsIsAutoModClose(self)) image = ApolloActionsTemplateImage(image);
+    %orig(image);
+}
+%end
+%end
+
 %ctor {
     if (@available(iOS 26.0, *)) {
         %init(ApolloNavigationActionsHooks);
+        if (IsLiquidGlass()) {
+            %init(ApolloNavigationActionsChromeHooks);
+        }
         ApolloLog(@"[NavigationActions] Page-owned native strip hooks installed");
     }
 }

--- a/src/ApolloNavigationActions.xm
+++ b/src/ApolloNavigationActions.xm
@@ -53,6 +53,14 @@ static BOOL ApolloActionsIsAutoModClose(UIBarButtonItem *item) {
         [NSStringFromClass([item.target class]) isEqualToString:@"Apollo.AutoModeratorViewController"];
 }
 
+static BOOL ApolloActionsUsesPlainSubmitStyle(UIBarButtonItem *item) {
+    NSString *targetClass = NSStringFromClass([item.target class]);
+    return (item.action == NSSelectorFromString(@"submitBarButtonTapped:") &&
+            [targetClass isEqualToString:@"Apollo.ComposeViewController"]) ||
+           (item.action == NSSelectorFromString(@"updateBarButtonItemTappedWithSender:") &&
+            [targetClass isEqualToString:@"Apollo.FlairSelectorViewController"]);
+}
+
 static void ApolloActionsPrepareApprovedContent(UIView *content) {
     if (!content || objc_getAssociatedObject(content, &kActionsApprovedLayoutKey)) return;
     NSMutableArray<UIButton *> *buttons = [NSMutableArray array];
@@ -568,6 +576,23 @@ static NSArray<UIBarButtonItem *> *ApolloActionsInboxItems(UINavigationItem *ite
     BOOL approvedSubmitters = [NSStringFromClass(controllerBox.controller.class)
         isEqualToString:@"Apollo.ModeratorApprovedSubmittersViewController"];
     for (UIBarButtonItem *item in items) {
+        // Legacy Done buttons become filled/prominent on Liquid Glass.
+        if (ApolloActionsUsesPlainSubmitStyle(item) && item.style != UIBarButtonItemStylePlain) {
+            item.style = UIBarButtonItemStylePlain;
+        }
+        if (ApolloActionsUsesPlainSubmitStyle(item)) {
+            for (NSNumber *stateValue in @[@(UIControlStateNormal), @(UIControlStateDisabled)]) {
+                UIControlState state = stateValue.unsignedIntegerValue;
+                NSMutableDictionary *attributes = [[item titleTextAttributesForState:state] mutableCopy]
+                    ?: [NSMutableDictionary dictionary];
+                UIColor *color = ApolloNavigationChromeColor();
+                if (state == UIControlStateDisabled) color = [color colorWithAlphaComponent:0.45];
+                if (![attributes[NSForegroundColorAttributeName] isEqual:color]) {
+                    attributes[NSForegroundColorAttributeName] = color;
+                    [item setTitleTextAttributes:attributes forState:state];
+                }
+            }
+        }
         ApolloActionsPinChrome(item);
         UIImage *image = ApolloActionsTemplateImage(item.image);
         if (image != item.image) item.image = image;

--- a/src/ApolloNavigationActions.xm
+++ b/src/ApolloNavigationActions.xm
@@ -28,14 +28,20 @@ static char kActionsStandardItemKey;
 static char kActionsStandardMoreKey;
 static char kActionsScrollOwnerKey;
 static char kActionsChromeKey;
+static char kActionsBlueDoneKey;
 static char kActionsApprovedLayoutKey;
 static NSUInteger sActionsModelWriteDepth;
 @class ApolloNavigationActionsOwner;
 
 // Keep right-item chrome neutral before it appears, including lone actions on
 // profile feeds. Mark only the actual item content, never the whole nav bar.
+static UIColor *ApolloActionsChromeColor(id object) {
+    return [objc_getAssociatedObject(object, &kActionsBlueDoneKey) boolValue]
+        ? UIColor.systemBlueColor : ApolloNavigationChromeColor();
+}
+
 static void ApolloActionsPinChrome(id object) {
-    UIColor *chrome = ApolloNavigationChromeColor();
+    UIColor *chrome = ApolloActionsChromeColor(object);
     if (!objc_getAssociatedObject(object, &kActionsChromeKey) ||
         ![[object tintColor] isEqual:chrome]) {
         [object setTintColor:chrome];
@@ -89,8 +95,9 @@ static void ApolloActionsPrepareApprovedContent(UIView *content) {
     objc_setAssociatedObject(content, &kActionsApprovedLayoutKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-static void ApolloActionsApplyChromeToView(UIView *view) {
+static void ApolloActionsApplyChromeToView(UIView *view, BOOL blueDone) {
     if (!view) return;
+    objc_setAssociatedObject(view, &kActionsBlueDoneKey, @(blueDone), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloActionsPinChrome(view);
     if ([view isKindOfClass:UIButton.class]) {
         UIButton *button = (id)view;
@@ -102,7 +109,7 @@ static void ApolloActionsApplyChromeToView(UIView *view) {
             if (templated != image) [button setImage:templated forState:states[i]];
         }
     }
-    for (UIView *child in view.subviews) ApolloActionsApplyChromeToView(child);
+    for (UIView *child in view.subviews) ApolloActionsApplyChromeToView(child, blueDone);
 }
 
 @interface ApolloNavigationActionsControllerBox : NSObject
@@ -593,12 +600,15 @@ static NSArray<UIBarButtonItem *> *ApolloActionsInboxItems(UINavigationItem *ite
                 }
             }
         }
+        BOOL blueDone = controllerBox.controller.isEditing &&
+            [NSStringFromClass(controllerBox.controller.class) isEqualToString:@"Apollo.RedditListViewController"];
+        objc_setAssociatedObject(item, &kActionsBlueDoneKey, @(blueDone), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloActionsPinChrome(item);
         UIImage *image = ApolloActionsTemplateImage(item.image);
         if (image != item.image) item.image = image;
         UIView *source = ApolloNavigationActionsContentView(item);
         if (approvedSubmitters) ApolloActionsPrepareApprovedContent(source);
-        ApolloActionsApplyChromeToView(source);
+        ApolloActionsApplyChromeToView(source, blueDone);
         ApolloNavigationActionsStrip *strip = [item.customView isKindOfClass:ApolloNavigationActionsStrip.class]
             ? (id)item.customView : nil;
         UIButton *more = strip.more ?: ApolloActionsFindMore(source);
@@ -1057,7 +1067,7 @@ NSArray<UIView *> *ApolloNavigationActionsManagedRoots(UINavigationBar *bar) {
 %hook UIView
 - (void)setTintColor:(UIColor *)color {
     if (objc_getAssociatedObject(self, &kActionsChromeKey)) {
-        color = ApolloNavigationChromeColor();
+        color = ApolloActionsChromeColor(self);
         if ([self.tintColor isEqual:color]) return;
     }
     %orig(color);
@@ -1074,7 +1084,7 @@ NSArray<UIView *> *ApolloNavigationActionsManagedRoots(UINavigationBar *bar) {
 %hook UIBarButtonItem
 - (void)setTintColor:(UIColor *)color {
     if (objc_getAssociatedObject(self, &kActionsChromeKey) || ApolloActionsIsAutoModClose(self)) {
-        color = ApolloNavigationChromeColor();
+        color = ApolloActionsChromeColor(self);
         if ([self.tintColor isEqual:color]) return;
     }
     %orig(color);

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -27,6 +27,9 @@ BOOL ApolloThemeRuntimeIsActive(void);
 // of the custom theme's content palette.
 UIColor *ApolloNavigationChromeColor(void);
 
+// Shared moderator identity color for native Apollo surfaces and tweak menus.
+UIColor *ApolloModeratorColor(void);
+
 // Cached dynamic colour for a token, or nil if inactive / out of range.
 UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token);
 

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -836,6 +836,17 @@ UIColor *ApolloNavigationChromeColor(void) {
     return color;
 }
 
+UIColor *ApolloModeratorColor(void) {
+    return [UIColor colorWithRed:(48.0 / 255.0) green:(209.0 / 255.0) blue:(88.0 / 255.0) alpha:1.0];
+}
+
+static BOOL ApolloUsesLegacyModeratorColor(CGFloat r, CGFloat g, CGFloat b, uintptr_t caller) {
+    // Scope the exact palette replacement to Apollo, not UIKit or other libraries.
+    return r == 0.0 && fabs(g - 148.0 / 255.0) < 0.00001 &&
+        fabs(b - 15.0 / 255.0) < 0.00001 &&
+        sApolloStart && caller >= sApolloStart && caller < sApolloEnd;
+}
+
 static UIColor *NavigationTitlePrimaryColor(void) {
     if (IsLiquidGlass()) return ApolloNavigationChromeColor();
     return ApolloThemeCurrentSnapshot()->enabled
@@ -855,6 +866,28 @@ static NSAttributedString *NavigationTitleAttributedText(NSAttributedString *sou
 }
 
 static void ApplyThemeToNavigationTitleControl(UIView *titleControl);
+
+static char kApolloNeutralNavigationTitleKey;
+
+static BOOL ApolloNeutralNavigationTitle(UIView *view) {
+    for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
+        if (objc_getAssociatedObject(ancestor, &kApolloNeutralNavigationTitleKey)) return YES;
+    }
+    return NO;
+}
+
+static CGSize ApolloNavigationTitleFittingSize(UIButton *button, CGSize size) {
+    if (!IsLiquidGlass() || (!ApolloNeutralNavigationTitle(button) &&
+        ![NSStringFromClass(button.class) isEqualToString:@"Apollo.DualLabelTitleButton"])) return size;
+    if (!isfinite(size.height) || size.height <= 44.0 || !isfinite(size.width) || size.width <= 0) return size;
+    NSAttributedString *title = button.currentAttributedTitle;
+    if (!title.length) return size;
+    CGFloat textHeight = ceil([title boundingRectWithSize:CGSizeMake(size.width, CGFLOAT_MAX)
+        options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size.height);
+    // Keep larger accessibility titles intact; remove only surplus button padding.
+    if (isfinite(textHeight) && textHeight > 0 && textHeight <= 44.0) size.height = 44.0;
+    return size;
+}
 
 static void RefreshFontOnTextControl(UIView *view, ApolloThemeFont target) {
     if (FontPinned(view)) return;
@@ -1676,6 +1709,9 @@ void ApolloThemeRuntimeInvalidate(void) {
 // sink hooks below, not by this constructor path.
 
 + (UIColor *)colorWithRed:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a {
+    if (ApolloUsesLegacyModeratorColor(r, g, b, (uintptr_t)__builtin_return_address(0))) {
+        return %orig(48.0 / 255.0, 209.0 / 255.0, 88.0 / 255.0, a);
+    }
     const ApolloThemeRuntimeSnapshot *snapshot = ApolloThemeCurrentSnapshot();
     if (snapshot->enabled && !sBypassHook) {
         uint32_t rgb = ApolloThemeRGBKeyFromComponents(r, g, b);
@@ -1693,6 +1729,9 @@ void ApolloThemeRuntimeInvalidate(void) {
 // Apollo is Swift: UIColor(red:green:blue:alpha:) compiles to this instance
 // initialiser, so this is the primary donor entry point.
 - (UIColor *)initWithRed:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a {
+    if (ApolloUsesLegacyModeratorColor(r, g, b, (uintptr_t)__builtin_return_address(0))) {
+        return %orig(48.0 / 255.0, 209.0 / 255.0, 88.0 / 255.0, a);
+    }
     const ApolloThemeRuntimeSnapshot *snapshot = ApolloThemeCurrentSnapshot();
     if (snapshot->enabled && !sBypassHook) {
         uint32_t rgb = ApolloThemeRGBKeyFromComponents(r, g, b);
@@ -1979,6 +2018,10 @@ void ApolloThemeRuntimeInvalidate(void) {
 }
 
 - (void)setTextColor:(UIColor *)textColor {
+    if (ApolloNeutralNavigationTitle(self)) {
+        %orig(ApolloNavigationChromeColor());
+        return;
+    }
     if (ApolloThemeCurrentSnapshot()->enabled && NavigationTitleOwnsButtonLabel(self)) {
         %orig(textColor);
         return;
@@ -1993,6 +2036,10 @@ void ApolloThemeRuntimeInvalidate(void) {
     if (sAttributedTextAssignmentBypass ||
         (ApolloThemeCurrentSnapshot()->enabled && NavigationTitleOwnsButtonLabel(self))) {
         %orig(attributedText);
+        return;
+    }
+    if (ApolloNeutralNavigationTitle(self)) {
+        %orig(NavigationTitleAttributedText(attributedText, self, ApolloNavigationChromeColor()));
         return;
     }
     objc_setAssociatedObject(self, kApolloThemeOriginalAttributedTextKey,
@@ -2010,12 +2057,29 @@ void ApolloThemeRuntimeInvalidate(void) {
 
 %hook UIButton
 
+- (CGSize)intrinsicContentSize {
+    return ApolloNavigationTitleFittingSize(self, %orig);
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+    return ApolloNavigationTitleFittingSize(self, %orig(size));
+}
+
+- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state {
+    if (ApolloNeutralNavigationTitle(self)) color = ApolloNavigationChromeColor();
+    %orig(color, state);
+}
+
 - (void)setAttributedTitle:(NSAttributedString *)title forState:(UIControlState)state {
     if (sNavigationButtonTitleAssignmentBypass) {
         %orig(title, state);
         return;
     }
     // Capture both title lines before attachment so retheming uses the raw source.
+    if (ApolloNeutralNavigationTitle(self)) {
+        %orig(NavigationTitleAttributedText(title, self, ApolloNavigationChromeColor()), state);
+        return;
+    }
     BOOL dualTitle = [NSStringFromClass(self.class) isEqualToString:@"Apollo.DualLabelTitleButton"];
     NSMutableDictionary<NSNumber *, id> *sources = NavigationButtonTitleSources(self, dualTitle);
     if (sources) {
@@ -2103,6 +2167,52 @@ static ASImageNodeTintColorModificationBlockFn ASImageNodeTintColorModificationB
         }
     }
     %orig;
+}
+
+%end
+
+%hook UITabBar
+- (void)didMoveToWindow {
+    %orig;
+    if (IsLiquidGlass() && self.window) {
+        UIColor *accent = ApolloThemeAccentColor();
+        if (accent) self.tintColor = accent;
+    }
+}
+
+- (void)setTintColor:(UIColor *)color {
+    // Moderator pages change their navigation accent, not the selected tab's identity.
+    if (IsLiquidGlass()) color = ApolloThemeAccentColor() ?: color;
+    %orig(color);
+}
+%end
+
+%hook UINavigationItem
+
+- (void)setTitleView:(UIView *)view {
+    if (IsLiquidGlass() && view) {
+        // Prepare custom titles before UIKit snapshots the incoming page.
+        objc_setAssociatedObject(view, &kApolloNeutralNavigationTitleKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        view.tintColor = ApolloNavigationChromeColor();
+        ApplyThemeToNavigationTitleContent(view, ApolloThemeCurrentSnapshot()->enabled
+            ? ApolloThemeCurrentSnapshot()->fontChoices[CurrentRuntimeMode()] : ApolloThemeFontSystem,
+            ApolloNavigationChromeColor());
+    }
+    %orig(view);
+}
+
+%end
+
+%hook _TtC6Apollo27AutoModeratorViewController
+
+- (void)viewDidLoad {
+    %orig;
+    if (IsLiquidGlass()) {
+        UIBarButtonItem *close = ((UIViewController *)self).navigationItem.leftBarButtonItem;
+        close.tintColor = ApolloNavigationChromeColor();
+        if (close.image) close.image = [close.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        close.customView.tintColor = ApolloNavigationChromeColor();
+    }
 }
 
 %end

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -7011,14 +7011,38 @@ static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewControll
 }
 
 // MARK: - Navigation globe-merge helpers
+
+@interface ApolloTranslationGlobeHost : UIView
+@end
+@implementation ApolloTranslationGlobeHost
+- (CGSize)intrinsicContentSize { return CGSizeMake(kApolloGlobeMergeSlotWidth, 32); }
+- (CGSize)sizeThatFits:(CGSize)size { return self.intrinsicContentSize; }
+@end
+
+static BOOL ApolloStandaloneItemHostsGlobe(UIBarButtonItem *item, UIButton *globe) {
+    return globe && (item.customView == globe ||
+        ([item.customView isKindOfClass:ApolloTranslationGlobeHost.class] && globe.superview == item.customView));
+}
+
+static UIView *ApolloStandaloneGlobeView(UIButton *globe) {
+    if (!IsLiquidGlass()) return globe;
+    // UIKit may keep sizing an outgoing custom view during dismissal. Give it
+    // a host to retain, never the button that moves back into the action strip.
+    UIView *host = [[ApolloTranslationGlobeHost alloc] initWithFrame:CGRectMake(0, 0, kApolloGlobeMergeSlotWidth, 32)];
+    globe.frame = host.bounds;
+    globe.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin |
+        UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+    [host addSubview:globe];
+    return host;
+}
 //
 // Merge into Apollo's mod/sort/more row on both builds. Standard builds retain
 // native padding and never collapse; item-setter hooks reapply after rebuilds.
 
 // Find Apollo's combined trailing button container for this nav item: a
 // custom-view UIView that holds at least one UIButton OTHER than our globe.
-static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIButton *globe) {
-    for (UIBarButtonItem *item in navItem.rightBarButtonItems) {
+static UIView *ApolloFindTrailingButtonContainerInItems(NSArray<UIBarButtonItem *> *items, UIButton *globe) {
+    for (UIBarButtonItem *item in items) {
         UIView *cv = ApolloNavigationActionsContentView(item);
         if (![cv isKindOfClass:[UIView class]]) continue;
         BOOL hasOtherButton = NO;
@@ -7028,6 +7052,10 @@ static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIBu
         if (hasOtherButton) return cv;
     }
     return nil;
+}
+
+static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIButton *globe) {
+    return ApolloFindTrailingButtonContainerInItems(navItem.rightBarButtonItems, globe);
 }
 
 // Detach the globe from a container WE merged it into, restoring that
@@ -7093,12 +7121,99 @@ static BOOL ApolloDeferGlobeGeometry(UIButton *globe, UIView *container, dispatc
         ApolloNativeActionMenuDeferNavigationUpdate(destinationSurface, @"translation-globe", update);
 }
 
-// Place the globe correctly for this nav item (idempotent). If Apollo has a
-// multi-button trailing container, inject the globe as its leading button so
-// every icon is one evenly-spaced group (issue #393). Otherwise fall back to a
-// standalone trailing bar button item (pre-26 behavior) so the globe still
-// appears on single-button screens. Re-runs after each Apollo rebuild via the
-// setRightBarButtonItem(s) hook.
+// Shared geometry for initial insertion and the handoff back from inline search.
+static void ApolloMergeGlobeIntoContainer(UIButton *globe, UIView *container) {
+    if (globe.superview == container) {
+        ApolloAlignGlobeInMergedContainer(globe, container);
+        return;
+    }
+    CGFloat gw = kApolloGlobeMergeSlotWidth;
+    CGFloat h = container.bounds.size.height > 1.0 ? container.bounds.size.height : 44.0;
+    // Out of any previous host: unpack a stale merged container properly
+    // (restore its layout), then leave whatever else held it — e.g. the
+    // wrapper of the standalone item we just dropped above.
+    ApolloDetachGlobeFromContainer(globe);
+    [globe removeFromSuperview];
+    globe.autoresizingMask = UIViewAutoresizingNone;
+
+    // Measure Apollo's button cluster and the container's trailing inset so
+    // we can insert the globe and keep the whole group SYMMETRIC inside the
+    // glass capsule (equal leading/trailing padding). Apollo's container can
+    // carry an asymmetric leading inset (the subreddit nav bar starts its
+    // first button ~10pt in) — inheriting it would leave a gap before the
+    // globe, so we re-place the leading edge to match the trailing inset.
+    CGFloat leadingX = CGFLOAT_MAX, rightEdge = 0.0, firstBtnWidth = 0.0;
+    UIButton *lastBtn = nil;
+    for (UIView *sub in container.subviews) {
+        if (![sub isKindOfClass:[UIButton class]]) continue;
+        if (CGRectGetMinX(sub.frame) < leadingX) {
+            leadingX = CGRectGetMinX(sub.frame);
+            firstBtnWidth = CGRectGetWidth(sub.frame);  // the button the globe sits before
+        }
+        if (CGRectGetMaxX(sub.frame) > rightEdge) {
+            rightEdge = CGRectGetMaxX(sub.frame);
+            lastBtn = (UIButton *)sub;
+        }
+    }
+    if (leadingX == CGFLOAT_MAX) leadingX = 0.0;
+    CGFloat contW = container.frame.size.width;
+    CGFloat trailInset = (contW > rightEdge) ? (contW - rightEdge) : 0.0;
+    trailInset = MAX(0.0, MIN(trailInset, 20.0));
+
+    // Center the glyph, then nudge it toward the next icon by HALF that
+    // icon's extra slot width beyond a normal ~38pt slot. The mod badge sits
+    // in a wide 44pt slot, so its centered glyph carries extra leading
+    // padding that makes the globe→badge gap read large; a narrow first icon
+    // (e.g. the 34pt trophy on Home) gets no nudge. Keeps spacing even on
+    // every screen without a one-size-fits-all shift.
+    CGFloat nudge = (firstBtnWidth - 38.0) * 0.5;
+    nudge = MAX(0.0, MIN(nudge, kApolloGlobeMergeGlyphNudge));
+    globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+    globe.imageEdgeInsets = UIEdgeInsetsMake(0.0, nudge, 0.0, -nudge);
+
+    // Symmetric container insets alone still read lopsided: the globe's
+    // 34pt slot only carries ~5pt of glyph centering while the trailing
+    // ••• slot centers a 25pt icon in 38-44pt (~7-10pt of air). Match the
+    // GLYPH-to-capsule-edge padding on both sides instead — the same rule
+    // the no-globe normalization below applies — by starting the globe
+    // slot at the difference. Falls back to bare symmetric insets if
+    // either glyph can't be measured.
+    // Preserve standard-build insets; only glass needs capsule-edge padding.
+    BOOL liquidGlass = IsLiquidGlass();
+    CGFloat globeX = liquidGlass ? trailInset : leadingX;
+    globe.frame = CGRectMake(0.0, 0.0, gw, h);  // size it so glyph pads resolve
+    CGFloat gGlyphL = 0.0, gGlyphR = 0.0, lastGlyphL = 0.0, lastGlyphR = 0.0;
+    if (liquidGlass && lastBtn &&
+        ApolloButtonGlyphPads(globe, &gGlyphL, &gGlyphR) &&
+        ApolloButtonGlyphPads(lastBtn, &lastGlyphL, &lastGlyphR)) {
+        CGFloat glyphAware = trailInset + lastGlyphR - gGlyphL;
+        globeX = MAX(trailInset, MIN(glyphAware, trailInset + 12.0));
+    }
+    CGFloat shift = globeX + gw - leadingX;         // first Apollo button lands flush after the globe
+
+    for (UIView *sub in container.subviews) {
+        if (![sub isKindOfClass:[UIButton class]]) continue;
+        CGRect f = sub.frame;
+        f.origin.x += shift;
+        sub.frame = f;
+    }
+    globe.frame = CGRectMake(globeX, 0.0, gw, h);
+    [container insertSubview:globe atIndex:0];
+    ApolloAlignGlobeInMergedContainer(globe, container);
+
+    // Resize so the bar item re-measures: content spans [globeX, rightEdge+
+    // shift] with a matching trailing inset. Remember the shift for removal.
+    CGFloat newW = rightEdge + shift + trailInset;
+    CGRect cf = container.frame;
+    cf.size.width = newW;
+    container.frame = cf;
+    container.bounds = CGRectMake(0.0, 0.0, newW, cf.size.height > 1.0 ? cf.size.height : h);
+    objc_setAssociatedObject(container, kApolloGlobeMergeShiftKey, @(shift), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [container setNeedsLayout];
+
+}
+
+// Merge into the trailing cluster, or retain a standalone item when absent.
 static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (!navItem) return;
     if ([objc_getAssociatedObject(navItem, kApolloGlobeRemovalPendingKey) boolValue]) return;
@@ -7110,14 +7225,14 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     if (ApolloDeferGlobeGeometry(globe, container, ^{
         ApolloApplyGlobeMergeForNavItem(weakItem);
     })) return;
-    // Host changes must update tint too: standalone glass uses native chrome,
-    // while a merged globe keeps the action group's accent and translated state.
+    // Liquid Glass uses the same neutral chrome in standalone and merged slots.
+    // Classic builds keep their accent and translated-state tint.
     id target = globe.allTargets.anyObject;
     UIViewController *controller = [target isKindOfClass:UIViewController.class] ? target : nil;
     BOOL visibleTranslationApplied = [objc_getAssociatedObject(controller, kApolloVisibleTranslationAppliedKey) boolValue];
-    UIColor *normalTint = IsLiquidGlass() && !container ? ApolloNavigationChromeColor()
-        : (ApolloThemeAccentColor() ?: controller.viewIfLoaded.tintColor ?: UIColor.systemBlueColor);
-    globe.tintColor = visibleTranslationApplied ? UIColor.systemGreenColor : normalTint;
+    globe.tintColor = IsLiquidGlass() ? ApolloNavigationChromeColor()
+        : (visibleTranslationApplied ? UIColor.systemGreenColor
+            : (ApolloThemeAccentColor() ?: controller.viewIfLoaded.tintColor ?: UIColor.systemBlueColor));
     UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
 
     if (container) {
@@ -7125,7 +7240,7 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
         if (standalone) {
             // Clear the retained adaptor before reparenting, or its delayed
             // layout can resize the merged globe to the old standalone frame.
-            if (standalone.customView == globe) standalone.customView = nil;
+            if (ApolloStandaloneItemHostsGlobe(standalone, globe)) standalone.customView = nil;
             NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy];
             if ([its containsObject:standalone]) {
                 [its removeObject:standalone];
@@ -7143,88 +7258,7 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
             return;  // already merged — don't double-shift
         }
 
-        CGFloat gw = kApolloGlobeMergeSlotWidth;
-        CGFloat h = container.bounds.size.height > 1.0 ? container.bounds.size.height : 44.0;
-        // Out of any previous host: unpack a stale merged container properly
-        // (restore its layout), then leave whatever else held it — e.g. the
-        // wrapper of the standalone item we just dropped above.
-        ApolloDetachGlobeFromContainer(globe);
-        [globe removeFromSuperview];
-
-        // Measure Apollo's button cluster and the container's trailing inset so
-        // we can insert the globe and keep the whole group SYMMETRIC inside the
-        // glass capsule (equal leading/trailing padding). Apollo's container can
-        // carry an asymmetric leading inset (the subreddit nav bar starts its
-        // first button ~10pt in) — inheriting it would leave a gap before the
-        // globe, so we re-place the leading edge to match the trailing inset.
-        CGFloat leadingX = CGFLOAT_MAX, rightEdge = 0.0, firstBtnWidth = 0.0;
-        UIButton *lastBtn = nil;
-        for (UIView *sub in container.subviews) {
-            if (![sub isKindOfClass:[UIButton class]]) continue;
-            if (CGRectGetMinX(sub.frame) < leadingX) {
-                leadingX = CGRectGetMinX(sub.frame);
-                firstBtnWidth = CGRectGetWidth(sub.frame);  // the button the globe sits before
-            }
-            if (CGRectGetMaxX(sub.frame) > rightEdge) {
-                rightEdge = CGRectGetMaxX(sub.frame);
-                lastBtn = (UIButton *)sub;
-            }
-        }
-        if (leadingX == CGFLOAT_MAX) leadingX = 0.0;
-        CGFloat contW = container.frame.size.width;
-        CGFloat trailInset = (contW > rightEdge) ? (contW - rightEdge) : 0.0;
-        trailInset = MAX(0.0, MIN(trailInset, 20.0));
-
-        // Center the glyph, then nudge it toward the next icon by HALF that
-        // icon's extra slot width beyond a normal ~38pt slot. The mod badge sits
-        // in a wide 44pt slot, so its centered glyph carries extra leading
-        // padding that makes the globe→badge gap read large; a narrow first icon
-        // (e.g. the 34pt trophy on Home) gets no nudge. Keeps spacing even on
-        // every screen without a one-size-fits-all shift.
-        CGFloat nudge = (firstBtnWidth - 38.0) * 0.5;
-        nudge = MAX(0.0, MIN(nudge, kApolloGlobeMergeGlyphNudge));
-        globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
-        globe.imageEdgeInsets = UIEdgeInsetsMake(0.0, nudge, 0.0, -nudge);
-
-        // Symmetric container insets alone still read lopsided: the globe's
-        // 34pt slot only carries ~5pt of glyph centering while the trailing
-        // ••• slot centers a 25pt icon in 38-44pt (~7-10pt of air). Match the
-        // GLYPH-to-capsule-edge padding on both sides instead — the same rule
-        // the no-globe normalization below applies — by starting the globe
-        // slot at the difference. Falls back to bare symmetric insets if
-        // either glyph can't be measured.
-        // Preserve standard-build insets; only glass needs capsule-edge padding.
-        BOOL liquidGlass = IsLiquidGlass();
-        CGFloat globeX = liquidGlass ? trailInset : leadingX;
-        globe.frame = CGRectMake(0.0, 0.0, gw, h);  // size it so glyph pads resolve
-        CGFloat gGlyphL = 0.0, gGlyphR = 0.0, lastGlyphL = 0.0, lastGlyphR = 0.0;
-        if (liquidGlass && lastBtn &&
-            ApolloButtonGlyphPads(globe, &gGlyphL, &gGlyphR) &&
-            ApolloButtonGlyphPads(lastBtn, &lastGlyphL, &lastGlyphR)) {
-            CGFloat glyphAware = trailInset + lastGlyphR - gGlyphL;
-            globeX = MAX(trailInset, MIN(glyphAware, trailInset + 12.0));
-        }
-        CGFloat shift = globeX + gw - leadingX;         // first Apollo button lands flush after the globe
-
-        for (UIView *sub in container.subviews) {
-            if (![sub isKindOfClass:[UIButton class]]) continue;
-            CGRect f = sub.frame;
-            f.origin.x += shift;
-            sub.frame = f;
-        }
-        globe.frame = CGRectMake(globeX, 0.0, gw, h);
-        [container insertSubview:globe atIndex:0];
-        ApolloAlignGlobeInMergedContainer(globe, container);
-
-        // Resize so the bar item re-measures: content spans [globeX, rightEdge+
-        // shift] with a matching trailing inset. Remember the shift for removal.
-        CGFloat newW = rightEdge + shift + trailInset;
-        CGRect cf = container.frame;
-        cf.size.width = newW;
-        container.frame = cf;
-        container.bounds = CGRectMake(0.0, 0.0, newW, cf.size.height > 1.0 ? cf.size.height : h);
-        objc_setAssociatedObject(container, kApolloGlobeMergeShiftKey, @(shift), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        [container setNeedsLayout];
+        ApolloMergeGlobeIntoContainer(globe, container);
 
         // iOS 27 caches the UIBarButtonItem custom-view measurement more
         // aggressively than iOS 26. Merely widening container.frame can leave
@@ -7258,7 +7292,7 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     // only trailing button is a plain image item — PostsSearchResultsViewController
     // with its sort bullseye — live on this path permanently.
     ApolloDetachGlobeFromContainer(globe);  // only unpacks a container we merged into
-    if (standalone && standalone.customView == globe && [navItem.rightBarButtonItems containsObject:standalone]) {
+    if (standalone && ApolloStandaloneItemHostsGlobe(standalone, globe) && [navItem.rightBarButtonItems containsObject:standalone]) {
         return;  // already hosted as its own item — leave UIKit's wrapper alone
     }
     // A standalone glass item has its own circular surface, with no neighboring
@@ -7268,12 +7302,12 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
     globe.imageEdgeInsets = UIEdgeInsetsZero;
     globe.frame = CGRectMake(0.0, 0.0, kApolloGlobeMergeSlotWidth, 32.0);
     if (!standalone) {
-        standalone = [[UIBarButtonItem alloc] initWithCustomView:globe];
+        standalone = [[UIBarButtonItem alloc] initWithCustomView:ApolloStandaloneGlobeView(globe)];
         objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, standalone, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloLog(@"[Translation] Globe: no trailing container to merge into on '%@' - hosting as a standalone bar item",
                   navItem.title ?: @"(untitled)");
-    } else if (standalone.customView != globe) {
-        standalone.customView = globe;
+    } else if (!ApolloStandaloneItemHostsGlobe(standalone, globe)) {
+        standalone.customView = ApolloStandaloneGlobeView(globe);
     }
     NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
     if (![its containsObject:standalone]) {
@@ -9954,6 +9988,47 @@ static void ApolloReapplyTranslationOnAppResume(void) {
     }
 }
 
+// Return the globe before UIKit measures or snapshots the restored action pill.
+static void ApolloRestoreGlobeBeforeSearchDismissal(UINavigationItem *navItem,
+                                                   NSArray<UIBarButtonItem *> *items) {
+    if (!IsLiquidGlass() || sApplyingGlobeMerge ||
+        [objc_getAssociatedObject(navItem, kApolloGlobeRemovalPendingKey) boolValue]) return;
+    UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
+    UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
+    if (!globe || !ApolloStandaloneItemHostsGlobe(standalone, globe) ||
+        ![navItem.rightBarButtonItems containsObject:standalone]) return;
+    UIView *container = ApolloFindTrailingButtonContainerInItems(items, globe);
+    if (!container ||
+        ApolloNativeActionMenuOwnsNavigationSurface(ApolloNavigationActionsMenuSourceView(globe)) ||
+        ApolloNativeActionMenuOwnsNavigationSurface(ApolloNavigationActionsMenuSourceView(container))) return;
+    // Release UIKit's search adaptor before the restored strip adopts the globe.
+    standalone.customView = nil;
+    objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [UIView performWithoutAnimation:^{ ApolloMergeGlobeIntoContainer(globe, container); }];
+}
+
+// Supply both search actions before the editor expands into the available gap.
+static NSArray<UIBarButtonItem *> *ApolloSearchItemsWithGlobe(UINavigationItem *navItem,
+                                                            NSArray<UIBarButtonItem *> *items) {
+    if (!IsLiquidGlass() || sApplyingGlobeMerge || items.count != 1 ||
+        items.firstObject.action != NSSelectorFromString(@"cancelBarButtonItemTappedWithSender:") ||
+        [objc_getAssociatedObject(navItem, kApolloGlobeRemovalPendingKey) boolValue]) return items;
+    UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
+    if (!globe || ApolloNativeActionMenuOwnsNavigationSurface(ApolloNavigationActionsMenuSourceView(globe))) return items;
+    ApolloDetachGlobeFromContainer(globe);
+    globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+    globe.imageEdgeInsets = UIEdgeInsetsZero;
+    globe.frame = CGRectMake(0, 0, kApolloGlobeMergeSlotWidth, 32);
+    UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
+    if (!standalone) {
+        standalone = [[UIBarButtonItem alloc] initWithCustomView:ApolloStandaloneGlobeView(globe)];
+        objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, standalone, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else if (!ApolloStandaloneItemHostsGlobe(standalone, globe)) {
+        standalone.customView = ApolloStandaloneGlobeView(globe);
+    }
+    return @[items.firstObject, standalone];
+}
+
 // Trailing-container upkeep in both builds. Apollo rebuilds its combined trailing
 // button container on various events (mod-status load, trait changes, etc.) and
 // re-sets it via setRightBarButtonItem(s):. When a nav item is flagged for the
@@ -9964,6 +10039,11 @@ static void ApolloReapplyTranslationOnAppResume(void) {
 %hook UINavigationItem
 
 - (void)setRightBarButtonItems:(NSArray<UIBarButtonItem *> *)items animated:(BOOL)animated {
+    NSArray *prepared = ApolloSearchItemsWithGlobe(self, items);
+    // Settle the button allocation first; the title capsule owns its resize.
+    if (prepared != items) animated = NO;
+    items = prepared;
+    ApolloRestoreGlobeBeforeSearchDismissal(self, items);
     %orig(items, animated);
     // Subreddit headers size this nav item's title against the trailing
     // cluster. The owner association makes this a small, local invalidation.
@@ -9979,6 +10059,13 @@ static void ApolloReapplyTranslationOnAppResume(void) {
 }
 
 - (void)setRightBarButtonItem:(UIBarButtonItem *)item animated:(BOOL)animated {
+    NSArray *items = item ? @[item] : @[];
+    NSArray *prepared = ApolloSearchItemsWithGlobe(self, items);
+    if (prepared != items) {
+        [self setRightBarButtonItems:prepared animated:NO];
+        return;
+    }
+    ApolloRestoreGlobeBeforeSearchDismissal(self, items);
     %orig(item, animated);
     if (sShowSubredditHeaders && !sApplyingGlobeMerge) ApolloSubredditRequestTitleRelayout(self);
     if (sApplyingGlobeMerge) return;


### PR DESCRIPTION
## Summary

Builds on #1035 to make navigation look more consistent and fix distracting animations, misplaced icons, and flickering across the app.

## QoL improvements

- Make Liquid Glass navigation buttons match the back button and page title instead of using custom accent colors.
- Use system light/dark colors for moderator page titles and the AutoMod close button.
- Use a brighter green for moderator controls, including the Moderator Mail icon.
- Keep moderator menu icons green, with white or black text for easier reading.
- Keep the bottom tab bar’s selected color unchanged when opening moderator tools.
- Make the Approved Submitters button group smaller, with evenly centered icons.
- Automatically collapse the action pill when opening subreddit search, and leave it collapsed when search closes.

## Fixes

- Reduce jumping and stuttering when opening or closing subreddit-title search.
- Prevent long subreddit names and an expanded action pill from squeezing the search field.
- Keep the translation globe correctly positioned when switching between search and the action pill.
- Prevent navigation buttons from briefly disappearing when returning from a post.
- Prevent two-line page titles from being clipped during transitions.
- Smooth the transition from a moderator menu to its selected page.
- Make the Mod Logs filter menu open beside the button that was tapped.
- Fix the page briefly jumping when a swipe-back is cancelled by pulling partway across and letting go.
- Fix AirPlay icon alignment in in-app video player.

## Testing

- Tested on the simulator.
- Tested on device.