### PR TITLE
Markdown bodies: drop the empty paragraph a stripped `&#x200B;` leaves behind (fixes #482)

### DIFF
--- a/src/ApolloMarkdownBodyCleanup.xm
+++ b/src/ApolloMarkdownBodyCleanup.xm
@@ -22,7 +22,10 @@
 //    HTML entity "&#x200B;" (U+200B ZERO WIDTH SPACE) to force blank lines.
 //    Apollo never decodes it, so users see the literal text "&#x200B;" in the
 //    middle (or anywhere) of a comment body. We strip the entity (hex/decimal
-//    forms and the raw character) wherever it appears.
+//    forms and the raw character) wherever it appears. When the entity was
+//    the whole paragraph (the common "blank line" use), the now-empty
+//    paragraph is dropped too — otherwise its two "\n\n" separators stack up
+//    into a three-blank-line gap (#482).
 //
 // Both passes preserve all surrounding glyphs and attributes (links, fonts,
 // colors); only the unwanted characters are removed, so link ranges and
@@ -37,8 +40,65 @@ static Class ApolloMarkdownNodeClass(void) {
     return cls;
 }
 
+// After a zero-width entity has been deleted at `loc`, drop the paragraph it
+// leaves behind when nothing else is on that line.
+//
+// Reddit's fancy-pants editor encodes an intentionally blank line as a
+// paragraph containing only "&#x200B;". Apollo renders block elements
+// separated by a bare "\n\n" (no paragraphSpacing), so once the entity is
+// gone the body reads "...text\n\n\n\ntext..." — an empty paragraph plus two
+// separators, i.e. three blank lines where the site shows one. Removing the
+// empty line together with one "\n\n" restores the regular paragraph gap.
+//
+// Only paragraph-level blanks are collapsed: a zero-width space sitting on a
+// hard-line-break line ("A\nZWSP\nB") just loses the character, so the blank
+// line the author forced there survives as "A\n\nB". (#482)
+static void ApolloMarkdownCollapseEmptyParagraphAt(NSMutableAttributedString *result, NSUInteger loc) {
+    NSString *s = result.string;
+    NSUInteger length = s.length;
+    if (loc > length) return;
+
+    // Bounds of the line that held the entity (exclusive of its newlines).
+    NSUInteger start = loc;
+    while (start > 0 && [s characterAtIndex:start - 1] != '\n') start--;
+    NSUInteger end = loc;
+    while (end < length && [s characterAtIndex:end] != '\n') end++;
+
+    // The line must now be blank (spaces/tabs only).
+    for (NSUInteger i = start; i < end; i++) {
+        unichar c = [s characterAtIndex:i];
+        if (c != ' ' && c != '\t') return;
+    }
+
+    BOOL atStart = (start == 0);
+    BOOL atEnd = (end == length);
+    BOOL separatorBefore = (start >= 2 &&
+                            [s characterAtIndex:start - 1] == '\n' &&
+                            [s characterAtIndex:start - 2] == '\n');
+    BOOL separatorAfter = (end + 1 < length &&
+                           [s characterAtIndex:end] == '\n' &&
+                           [s characterAtIndex:end + 1] == '\n');
+
+    NSRange deletion;
+    if (separatorAfter && (separatorBefore || atStart)) {
+        // "A\n\n<blank>\n\nB" -> "A\n\nB"   /   "<blank>\n\nB" -> "B"
+        deletion = NSMakeRange(start, (end + 2) - start);
+    } else if (separatorBefore && atEnd) {
+        // "A\n\n<blank>" -> "A"
+        deletion = NSMakeRange(start - 2, end - (start - 2));
+    } else if (atStart && atEnd) {
+        // The whole body was just the entity.
+        deletion = NSMakeRange(0, length);
+    } else {
+        // Bounded by single newlines (hard line breaks): keep the blank line.
+        return;
+    }
+    [result deleteCharactersInRange:deletion];
+}
+
 // Removes every occurrence of `needle` from `result`, using `options`
-// (e.g. NSCaseInsensitiveSearch). Operates in place.
+// (e.g. NSCaseInsensitiveSearch), collapsing any paragraph a deletion leaves
+// empty. Operates in place.
 static void ApolloMarkdownDeleteAllOccurrences(NSMutableAttributedString *result,
                                                NSString *needle,
                                                NSStringCompareOptions options) {
@@ -48,14 +108,17 @@ static void ApolloMarkdownDeleteAllOccurrences(NSMutableAttributedString *result
         NSRange found = [result.string rangeOfString:needle options:options range:searchRange];
         if (found.location == NSNotFound) break;
         [result deleteCharactersInRange:found];
-        NSUInteger nextLocation = found.location;
+        ApolloMarkdownCollapseEmptyParagraphAt(result, found.location);
+        // The collapse may have removed text before `found.location`; clamp.
+        NSUInteger nextLocation = MIN(found.location, result.length);
         searchRange = NSMakeRange(nextLocation, result.length - nextLocation);
     }
 }
 
 // Strips literal zero-width-space entities ("&#x200B;", "&#8203;") and the raw
-// U+200B character from anywhere in the body. Returns the original string
-// unchanged (no allocation) when none are present.
+// U+200B character from anywhere in the body, dropping any paragraph that
+// consisted of nothing else. Returns the original string unchanged (no
+// allocation) when none are present.
 static NSAttributedString *ApolloMarkdownStripZeroWidthSpaces(NSAttributedString *attributedText) {
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) {
         return attributedText;


### PR DESCRIPTION
Fixes #482

### Issue

Since #405 strips `&#x200B;` from post/comment bodies, posts written in Reddit's fancy-pants editor render with huge gaps between paragraphs (three blank lines instead of one). Uranosphaerite's read on the issue was right: the editor stores an intentionally blank line as a paragraph containing only the zero-width space, and deleting the character leaves the empty paragraph behind.

### Cause

Dumped the attributed string Apollo hands the markdown body node in the sim. Apollo's CommonMark pass separates blocks with a bare `\n\n` (no `paragraphSpacing`), and it already collapses runs of blank lines in the source, so the only thing that survives as an empty paragraph is the ZWSP one:

```
Hey everyone,⏎⏎«U+200B»⏎⏎I've been dealing…     what Apollo renders
Hey everyone,⏎⏎⏎⏎I've been dealing…             after #405 deletes the character
```

Two separators plus the empty line = three blank lines. Post bodies get the literal `&#x200B;` text, comments get the decoded U+200B (cmark decodes the numeric entity on that path); both end up the same way.

### Fix

`ApolloMarkdownBodyCleanup.xm`: after each zero-width deletion, if the line it sat on is now blank and is bounded by `\n\n` on both sides (or the start/end of the body), remove the line together with one separator, so the body reads `Hey everyone,⏎⏎I've been dealing…` and the regular paragraph gap remains. Attributes and link ranges shift with the text as before.

Kept deliberately narrow:
- a ZWSP on a hard-line-break line (`A\nZWSP\nB`) only loses the character, so a blank line the author forced that way stays
- inline ZWSPs mid-sentence are just dropped, as before
- Apollo's horizontal-rule spacing (`---` renders as an extra newline) is untouched. That's a separate 5-newline run that has nothing to do with ZWSPs

### Testing

- Host-side Foundation harness over the helper: 18 cases (hex/decimal/raw forms, leading/trailing/consecutive blanks, several entities in one paragraph, hard-break lines, inline ZWSP, next to an HR, attribute range preservation) all pass.
- Sim (Apollo-Sim, iOS 26, Liquid Glass): both threads from the issue render with normal gaps now. `1u87jct` was checked through the "original copy" bot comment since the OP is removed, `1u8dhhd` through the post body itself. Before/after below are the same post on the same sim, toggled with a launch arg on a diag build.
- Device build compiles clean (`iphone:clang:26.0:14.0`); on-device check pending.
