### PR TITLE
Widgets: Home, Popular, All, multireddits and multi-subreddit feeds

### DIFF
--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -17,6 +17,7 @@
 #import "settings/ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
 #import "ApolloAccountCredentials.h"
+#import "ApolloWebJSON.h"           // ApolloWebJSONBearerIsSynthetic() — widget setup code
 #import "ApolloPerAccountFavorites.h"
 #import "ApolloState.h"
 #import "ApolloTabBarHideStyle.h"
@@ -1540,7 +1541,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onSelect:^{ [weakSelf copyWidgetSetupCode]; }];
 
     return [ApolloSettingsSection sectionWithTitle:@"Extras"
-                                            footer:@"Copy a code to set up the Apollo home-screen widget."
+                                            footer:@"Copy a code to set up Apollo's home-screen widgets. Include your account for Home and multireddit feeds."
                                               rows:@[ widgetSetupCode ]];
 }
 
@@ -3355,6 +3356,42 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     }
 }
 
+// The signed-in account's OAuth refresh token plus the client id it was issued
+// under, for the "with account" widget setup code. Nil when nobody is signed
+// in, when the active account is a web-session (keyless) one — those carry a
+// synthetic bearer and no refresh token — or when the credential is missing.
+static NSDictionary *ApolloWidgetAccountCredentials(void) {
+    id client = ApolloActiveAccountClient();
+    if (!client) return nil;
+    NSString *username = ApolloActiveAccountUsername();
+    if (username.length > 0 && ApolloWebSessionFor(username) != nil) return nil;
+
+    id refreshToken = nil, accessToken = nil, credentialClientId = nil;
+    @try {
+        id credential = [client valueForKey:@"authorizationCredential"];
+        id token = [credential valueForKey:@"accessToken"];
+        refreshToken = [token valueForKey:@"refreshToken"];
+        accessToken = [token valueForKey:@"accessToken"];
+        credentialClientId = [credential valueForKey:@"clientIdentifier"];
+    } @catch (__unused NSException *e) {
+        return nil;
+    }
+    if (![refreshToken isKindOfClass:[NSString class]] || [refreshToken length] == 0) return nil;
+    if ([accessToken isKindOfClass:[NSString class]] && ApolloWebJSONBearerIsSynthetic(accessToken)) return nil;
+
+    // Reddit binds a refresh token to the client id that issued it, and the
+    // credential's own id is what RedditKit presents on every refresh — so
+    // that's the id the widget must present too. Fall back to the effective
+    // (per-account, then global) key only when the credential carries none.
+    NSString *clientId = ([credentialClientId isKindOfClass:[NSString class]] && [credentialClientId length] > 0)
+        ? credentialClientId : (ApolloEffectiveRedditClientId() ?: sRedditClientId);
+    if (clientId.length == 0) return nil;
+
+    NSMutableDictionary *account = [@{ @"clientID": clientId, @"refreshToken": refreshToken } mutableCopy];
+    if (username.length > 0) account[@"username"] = username;
+    return account;
+}
+
 - (void)copyWidgetSetupCode {
     NSString *clientID = sRedditClientId ?: @"";
     if (clientID.length == 0) {
@@ -3363,11 +3400,53 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
         return;
     }
 
-    // base64( JSON { v, clientID, userAgent } ) — decoded by the widget's
-    // SetupCode parser. userAgent is included so the widget's Reddit requests
-    // carry the same identity as the configured (spoofed) app.
-    NSMutableDictionary *payload = [@{ @"v": @1, @"clientID": clientID } mutableCopy];
+    // With a signed-in API-key account the code can carry its login, which is
+    // what the widgets need for Home and private multireddits — but that's the
+    // user's choice, so ask. Keyless/no account: the plain code, as before.
+    NSDictionary *account = ApolloWidgetAccountCredentials();
+    if (!account) {
+        [self copyWidgetSetupCodeWithAccount:nil];
+        return;
+    }
+    __weak typeof(self) weakSelf = self;
+    UIAlertController *sheet = [UIAlertController
+        alertControllerWithTitle:@"Widget Setup Code"
+                         message:@"Include your account so widgets can show Home and your private multireddits."
+                  preferredStyle:UIAlertControllerStyleActionSheet];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy with Account" style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        [weakSelf copyWidgetSetupCodeWithAccount:account];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy without Account" style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        [weakSelf copyWidgetSetupCodeWithAccount:nil];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UITableViewCell *cell = [self cellForRowID:@"api.widgetSetupCode"];
+    sheet.popoverPresentationController.sourceView = cell ?: self.view;
+    sheet.popoverPresentationController.sourceRect = (cell ?: self.view).bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)copyWidgetSetupCodeWithAccount:(NSDictionary *)account {
+    // base64( JSON { v, clientID, userAgent[, clientSecret][, refreshToken,
+    // username] } ) — decoded by the widget's SetupCode parser. userAgent is
+    // included so the widget's Reddit requests carry the same identity as the
+    // configured (spoofed) app. clientSecret only exists for "web app" keys,
+    // whose token endpoint refuses the empty password installed apps use.
+    // With an account the code is v2 and carries the OAuth refresh token —
+    // that is what lets the widget read Home and private multireddits. Reddit
+    // does not rotate refresh tokens on use, so the widget minting its own
+    // access tokens never invalidates the app's session.
+    NSString *clientID = account[@"clientID"] ?: (sRedditClientId ?: @"");
+    NSMutableDictionary *payload = [@{ @"v": account ? @2 : @1, @"clientID": clientID } mutableCopy];
     if (sUserAgent.length > 0) payload[@"userAgent"] = sUserAgent;
+    NSString *secret = ApolloSecretForClientId(clientID);
+    if (secret.length > 0) payload[@"clientSecret"] = secret;
+    if (account) {
+        payload[@"refreshToken"] = account[@"refreshToken"];
+        if ([account[@"username"] length] > 0) payload[@"username"] = account[@"username"];
+    }
 
     NSData *json = [NSJSONSerialization dataWithJSONObject:payload options:0 error:NULL];
     if (!json) {
@@ -3382,8 +3461,11 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     };
     [[UIPasteboard generalPasteboard] setItems:@[item] options:options];
 
+    NSString *how = @"Long-press an Apollo widget → Edit Widget and paste it into Setup Code. One paste covers every widget.";
     [self showAlertWithTitle:@"Copied"
-                     message:@"Setup code copied. On your Home Screen, add the Apollo “Showerthoughts” widget, long-press it → Edit Widget, and paste this code into Setup Code."];
+                     message:account
+                         ? [NSString stringWithFormat:@"Setup code copied. %@ It includes your account login, so don't share it.", how]
+                         : [NSString stringWithFormat:@"Setup code copied. %@", how]];
 }
 
 - (void)testNotificationBackendConnection {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -3437,9 +3437,14 @@ static NSDictionary *ApolloWidgetAccountCredentials(void) {
     // With an account the code is v2 and carries the OAuth refresh token —
     // that is what lets the widget read Home and private multireddits. Reddit
     // does not rotate refresh tokens on use, so the widget minting its own
-    // access tokens never invalidates the app's session.
+    // access tokens never invalidates the app's session. `issued` (unix
+    // seconds) lets the widgets treat the most recently copied code as the
+    // one that wins everywhere — so copying "without account" and pasting it
+    // into any widget is how account access is removed again.
     NSString *clientID = account[@"clientID"] ?: (sRedditClientId ?: @"");
-    NSMutableDictionary *payload = [@{ @"v": account ? @2 : @1, @"clientID": clientID } mutableCopy];
+    NSMutableDictionary *payload = [@{ @"v": account ? @2 : @1,
+                                       @"clientID": clientID,
+                                       @"issued": @((long long)[NSDate date].timeIntervalSince1970) } mutableCopy];
     if (sUserAgent.length > 0) payload[@"userAgent"] = sUserAgent;
     NSString *secret = ApolloSecretForClientId(clientID);
     if (secret.length > 0) payload[@"clientSecret"] = secret;
@@ -3461,11 +3466,11 @@ static NSDictionary *ApolloWidgetAccountCredentials(void) {
     };
     [[UIPasteboard generalPasteboard] setItems:@[item] options:options];
 
-    NSString *how = @"Long-press an Apollo widget → Edit Widget and paste it into Setup Code. One paste covers every widget.";
+    NSString *how = @"Long-press an Apollo widget → Edit Widget and paste it into Setup Code. One paste covers every widget";
     [self showAlertWithTitle:@"Copied"
                      message:account
-                         ? [NSString stringWithFormat:@"Setup code copied. %@ It includes your account login, so don't share it.", how]
-                         : [NSString stringWithFormat:@"Setup code copied. %@", how]];
+                         ? [NSString stringWithFormat:@"Setup code copied. %@. It includes your account login, so don't share it.", how]
+                         : [NSString stringWithFormat:@"Setup code copied. %@ and removes any account you added before.", how]];
 }
 
 - (void)testNotificationBackendConnection {

--- a/widgets/Sources/ApolloRebornWidgetBundle.swift
+++ b/widgets/Sources/ApolloRebornWidgetBundle.swift
@@ -28,7 +28,7 @@ struct HeadlineWidget: Widget {
             HeadlineWidgetView(entry: entry)
         }
         .configurationDisplayName("Headline")
-        .description("The top headline from a subreddit you choose, on your Lock Screen.")
+        .description("The top headline from a subreddit or multireddit you choose, on your Lock Screen.")
         .supportedFamilies([.accessoryRectangular, .accessoryInline])
     }
 }
@@ -114,7 +114,7 @@ struct SinglePostWidget: Widget {
             SinglePostWidgetView(entry: entry)
         }
         .configurationDisplayName("Post")
-        .description("The top post from a subreddit you choose.")
+        .description("The top post from a subreddit, multireddit, or your Home feed.")
         // Home-screen only. Lock-screen content comes from the zero-config
         // Showerthoughts widget, so the lock screen stays option-free.
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
@@ -130,7 +130,7 @@ struct FeedWidget: Widget {
             FeedWidgetView(entry: entry)
         }
         .configurationDisplayName("Feed")
-        .description("Top posts from a subreddit you choose.")
+        .description("Top posts from a subreddit, multireddit, or your Home feed.")
         .supportedFamilies([.systemMedium, .systemLarge])
     }
 }
@@ -144,7 +144,7 @@ struct PhotoWidget: Widget {
             PhotoWidgetView(entry: entry)
         }
         .configurationDisplayName("Photo")
-        .description("The top image from a subreddit you choose. Toggle the title, subreddit and stats.")
+        .description("The top image from a subreddit or multireddit you choose. Toggle the title, subreddit and stats.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }

--- a/widgets/Sources/CalendarProvider.swift
+++ b/widgets/Sources/CalendarProvider.swift
@@ -149,10 +149,10 @@ struct CalendarProvider: IntentTimelineProvider {
             e.calendarStyle = style; e.calendarShowTitle = showTitle
             completion(e); return
         }
-        let sub = resolvedSubreddit(configuration.subreddit, default: "EarthPorn")
-        let cfg = configKey(sub: sub, sort: Self.calendarSort)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let cfg = configKey(source: source, sort: Self.calendarSort)
         let today = DailyPhoto.dayString(Date())
-        if let locked = lockedPostForSnapshot(cfg: cfg, day: today, sub: sub) {
+        if let locked = lockedPostForSnapshot(cfg: cfg, day: today) {
             var e = WidgetEntry(date: Date(), state: .posts([RenderPost(post: locked, imageData: nil)]))
             e.calendarStyle = style; e.calendarShowTitle = showTitle
             completion(e)
@@ -163,31 +163,37 @@ struct CalendarProvider: IntentTimelineProvider {
         }
     }
 
+    private static func source(_ configuration: Intent, ownMultis: Set<String>) -> FeedSource {
+        widgetSource(text: configuration.subreddit, default: .subreddits(["EarthPorn"]), ownMultis: ownMultis)
+    }
+
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "EarthPorn")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         let sort = Self.calendarSort
         let style = calendarStyle(configuration.dateStyle)
         let showTitle = configuration.showTitle?.boolValue ?? false
-        let cfg = configKey(sub: sub, sort: sort)
+        let cfg = configKey(source: source, sort: sort)
 
-        runPostTimeline(
-            code: configuration.setupCode, cacheKey: "calpool.\(sub)",
-            fetch: { try await $0.topPosts(subreddit: sub, sort: sort, limit: 50).filter { $0.isImagePost } },
-            assemble: { pool in
+        runSourceTimeline(
+            code: configuration.setupCode, cacheKey: "calpool.\(source.cacheKey)",
+            resolve: { Self.source(configuration, ownMultis: $0) },
+            sort: sort, limit: 50,
+            filter: { $0.filter { $0.isImagePost } },
+            assemble: { pool, _ in
                 await assembleCalendar(pool, cfg: cfg, style: style, showTitle: showTitle,
                                        windowDays: windowDays)
             },
             completion: completion)
     }
 
-    private func configKey(sub: String, sort: WidgetSort) -> String {
-        "cal.\(sub.lowercased()).\(sort.path)\(sort.timeWindow ?? "")"
+    private func configKey(source: FeedSource, sort: WidgetSort) -> String {
+        "cal.\(source.cacheKey.lowercased()).\(sort.path)\(sort.timeWindow ?? "")"
     }
 
     /// For the snapshot we only want a previously-locked pick; never lock a new
     /// one off the snapshot path (no pool here).
-    private func lockedPostForSnapshot(cfg: String, day: String, sub: String) -> RedditPost? {
+    private func lockedPostForSnapshot(cfg: String, day: String) -> RedditPost? {
         // DailyPhoto.pick with an empty pool returns the stored pick if locked,
         // else nil — exactly the read-only behaviour we want here.
         DailyPhoto.pick(cfg: cfg, day: day, pool: [])

--- a/widgets/Sources/CalendarProvider.swift
+++ b/widgets/Sources/CalendarProvider.swift
@@ -149,8 +149,9 @@ struct CalendarProvider: IntentTimelineProvider {
             e.calendarStyle = style; e.calendarShowTitle = showTitle
             completion(e); return
         }
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
-        let cfg = configKey(source: source, sort: Self.calendarSort)
+        let account = widgetAccountKey(configuration.setupCode)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: account))
+        let cfg = configKey(source: source, account: account, sort: Self.calendarSort)
         let today = DailyPhoto.dayString(Date())
         if let locked = lockedPostForSnapshot(cfg: cfg, day: today) {
             var e = WidgetEntry(date: Date(), state: .posts([RenderPost(post: locked, imageData: nil)]))
@@ -169,26 +170,30 @@ struct CalendarProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
         let sort = Self.calendarSort
         let style = calendarStyle(configuration.dateStyle)
         let showTitle = configuration.showTitle?.boolValue ?? false
-        let cfg = configKey(source: source, sort: sort)
 
         runSourceTimeline(
-            code: configuration.setupCode, cacheKey: "calpool.\(source.cacheKey)",
+            code: configuration.setupCode,
             resolve: { Self.source(configuration, ownMultis: $0) },
+            cacheKey: { "calpool.\($0.cacheKey(account: account))" },
             sort: sort, limit: 50,
             filter: { $0.filter { $0.isImagePost } },
-            assemble: { pool, _ in
-                await assembleCalendar(pool, cfg: cfg, style: style, showTitle: showTitle,
-                                       windowDays: windowDays)
+            assemble: { pool, used, _ in
+                // The daily pick + history are keyed per source (and per
+                // account for personal sources) too, so a locked photo never
+                // carries over to another account's feed.
+                let cfg = self.configKey(source: used, account: account, sort: sort)
+                return await assembleCalendar(pool, cfg: cfg, style: style, showTitle: showTitle,
+                                              windowDays: windowDays)
             },
             completion: completion)
     }
 
-    private func configKey(source: FeedSource, sort: WidgetSort) -> String {
-        "cal.\(source.cacheKey.lowercased()).\(sort.path)\(sort.timeWindow ?? "")"
+    private func configKey(source: FeedSource, account: String?, sort: WidgetSort) -> String {
+        "cal.\(source.cacheKey(account: account).lowercased()).\(sort.path)\(sort.timeWindow ?? "")"
     }
 
     /// For the snapshot we only want a previously-locked pick; never lock a new

--- a/widgets/Sources/FeedSource.swift
+++ b/widgets/Sources/FeedSource.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+/// Where a content widget (Feed, Post, Photo, Headline, Calendar) reads its
+/// posts from. One free-text field ("Subreddit or Multireddit") accepts every
+/// form people actually paste, so the widget config stays a single box:
+///
+///   soccer · r/soccer · https://reddit.com/r/soccer          → one subreddit
+///   soccer+nba · soccer, nba · r/soccer r/nba                → several (Reddit's a+b listing)
+///   home · popular · all                                     → the built-in feeds
+///   https://reddit.com/user/foo/m/bar · u/foo/m/bar          → someone's multireddit
+///   m/bar · /me/m/bar · bar (when bar is one of yours)       → your own multireddit
+///
+/// Home and your own multireddits are read with the signed-in account — they
+/// need the setup code copied *with account* (Apollo → Settings → Apollo
+/// Reborn). Everything else is public and goes through the app-only token,
+/// exactly as before.
+enum FeedSource: Hashable {
+    case home
+    case popular
+    case all
+    case subreddits([String])
+    /// `owner == nil` means "the signed-in user's" (`/me/m/<name>`).
+    case multireddit(owner: String?, name: String)
+
+    /// Sources only a user token can read.
+    var needsAccount: Bool {
+        switch self {
+        case .home: return true
+        case .multireddit(let owner, _): return owner == nil
+        default: return false
+        }
+    }
+
+    var isMultireddit: Bool {
+        if case .multireddit = self { return true }
+        return false
+    }
+
+    /// oauth.reddit.com path the sort segment is appended to ("" for home, so
+    /// Home + Hot is `https://oauth.reddit.com/hot`).
+    var listingPath: String {
+        switch self {
+        case .home: return ""
+        case .popular: return "/r/popular"
+        case .all: return "/r/all"
+        case .subreddits(let subs): return "/r/" + subs.joined(separator: "+")
+        case .multireddit(let owner, let name):
+            if let owner { return "/user/\(owner)/m/\(name)" }
+            return "/me/m/\(name)"
+        }
+    }
+
+    /// Header label: "Home", "Popular", "All", "r/soccer", "r/soccer+nba",
+    /// "m/bar". Long subreddit lists collapse to "r/first +N" so the Feed
+    /// header keeps room for its ↻ button.
+    var label: String {
+        switch self {
+        case .home: return "Home"
+        case .popular: return "Popular"
+        case .all: return "All"
+        case .subreddits(let subs):
+            let joined = "r/" + subs.joined(separator: "+")
+            if subs.count <= 1 || joined.count <= 22 { return joined }
+            return "r/\(subs[0]) +\(subs.count - 1)"
+        case .multireddit(_, let name): return "m/\(name)"
+        }
+    }
+
+    /// Stable id for cache keys. A plain subreddit keeps its bare name so the
+    /// caches of already-configured widgets carry over unchanged.
+    var cacheKey: String {
+        switch self {
+        case .home: return "home"
+        case .popular: return "popular"
+        case .all: return "all"
+        case .subreddits(let subs): return subs.joined(separator: "+")
+        case .multireddit(let owner, let name): return "m:\(owner ?? "me")/\(name)"
+        }
+    }
+
+    /// Deep link that opens this feed in Apollo. `username` resolves "my"
+    /// multireddits (Apollo's router only knows `/user/<name>/m/<multi>`);
+    /// without it there's no link rather than a broken one.
+    func apolloURL(username: String?) -> URL? {
+        switch self {
+        case .home: return URL(string: "apollo://reborn/home")
+        case .popular: return URL(string: "apollo://reddit.com/r/popular")
+        case .all: return URL(string: "apollo://reddit.com/r/all")
+        case .subreddits(let subs): return URL(string: "apollo://reddit.com/r/\(subs.joined(separator: "+"))")
+        case .multireddit(let owner, let name):
+            guard let who = owner ?? username, !who.isEmpty else { return nil }
+            return URL(string: "apollo://reddit.com/user/\(who)/m/\(name)")
+        }
+    }
+
+    // MARK: Parsing
+
+    /// Names Reddit allows in a subreddit / multireddit / username path segment.
+    /// Everything else is dropped, which is what keeps every URL we build
+    /// non-nil (a nil URL force-unwrapped in an extension poisons WidgetKit's
+    /// enumeration of ALL the app's widgets).
+    private static let nameChars = CharacterSet(charactersIn:
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+    static func cleanName(_ raw: String) -> String {
+        String(raw.unicodeScalars.filter { nameChars.contains($0) })
+    }
+
+    private static let homeWords: Set<String> = ["home", "frontpage", "front page", "front-page", "best"]
+    private static let sortWords: Set<String> = ["hot", "new", "top", "best", "rising", "controversial", "gilded"]
+    /// List separators for several subreddits, matched per unicode scalar:
+    /// "\r\n" is ONE Character, so a Character-level check would miss both a
+    /// lone "\n" (when written next to "\r" in a literal) and a CRLF pair.
+    private static let listSeparators = CharacterSet(charactersIn: "+,; \t\r\n")
+    private static let pathMarkers: Set<String> = ["r", "u", "user", "m", "me"]
+
+    /// Parse the free-text field. `ownMultis` is the (lowercased) set of the
+    /// signed-in user's multireddit names, from `OwnMultis`; a bare name that
+    /// matches one of them resolves to that multireddit, while an explicit
+    /// "r/name" always forces the subreddit.
+    static func parse(_ raw: String?, default def: FeedSource, ownMultis: Set<String> = []) -> FeedSource {
+        guard var s = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return def }
+
+        // Drop a query string / fragment, the URL scheme, and a reddit.com host
+        // (www./old./new./np. …) so a pasted link is just its path.
+        if let cut = s.firstIndex(where: { $0 == "?" || $0 == "#" }) { s = String(s[..<cut]) }
+        for scheme in ["https://", "http://", "apollo://"] where s.lowercased().hasPrefix(scheme) {
+            s = String(s.dropFirst(scheme.count))
+            break
+        }
+        if let host = s.lowercased().range(of: "reddit.com"), !s[..<host.lowerBound].contains("/") {
+            s = String(s[host.upperBound...])
+        }
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "/ \t\r\n"))
+        let lower = s.lowercased()
+        // A bare reddit.com link, or the words people use for the front page.
+        if lower.isEmpty || homeWords.contains(lower) { return .home }
+
+        // Path segments, minus a trailing sort ("r/soccer/top", "user/a/m/b/new")
+        // — but "r/hot" is the subreddit named hot, so a two-segment path only
+        // loses its tail when the head isn't a path marker.
+        var parts = s.split(separator: "/").map(String.init)
+        if parts.count >= 2, let last = parts.last, sortWords.contains(last.lowercased()),
+           parts.count >= 3 || !pathMarkers.contains(parts[0].lowercased()) {
+            parts.removeLast()
+        }
+        let lowerParts = parts.map { $0.lowercased() }
+
+        // Multireddit forms: user/<owner>/m/<name>, u/<owner>/m/<name>,
+        // <owner>/m/<name>, me/m/<name>, m/<name>.
+        if let mi = lowerParts.firstIndex(of: "m") {
+            guard mi + 1 < parts.count else { return def }
+            let name = cleanName(parts[mi + 1])
+            guard !name.isEmpty else { return def }
+            let before = Array(lowerParts[..<mi])
+            if before.isEmpty || before == ["me"] || before == ["user", "me"] || before == ["u", "me"] {
+                return .multireddit(owner: nil, name: name)
+            }
+            if before.count == 2, before[0] == "user" || before[0] == "u" {
+                let owner = cleanName(parts[mi - 1])
+                return owner.isEmpty ? def : .multireddit(owner: owner, name: name)
+            }
+            if before.count == 1 {
+                let owner = cleanName(parts[mi - 1])
+                return owner.isEmpty ? def : .multireddit(owner: owner, name: name)
+            }
+            return def
+        }
+
+        // Subreddit forms. "r/" is a marker, not a name, and forces the
+        // subreddit reading of a bare name that also matches one of the
+        // user's multireddits.
+        let forcedSubreddit = lowerParts.first == "r"
+        var names: [String] = []
+        var seen = Set<String>()
+        for token in parts.joined(separator: "+").split(whereSeparator: { $0.unicodeScalars.allSatisfy(listSeparators.contains) }) {
+            let t = String(token)
+            if t.lowercased() == "r" { continue }           // "r/a r/b" → r, a, r, b
+            let n = cleanName(t)
+            guard !n.isEmpty else { continue }
+            if seen.insert(n.lowercased()).inserted { names.append(n) }
+        }
+        guard !names.isEmpty else { return def }
+
+        if names.count == 1 {
+            let n = names[0].lowercased()
+            if n == "popular" { return .popular }
+            if n == "all" { return .all }
+            if homeWords.contains(n) { return .home }
+            if !forcedSubreddit, ownMultis.contains(n) { return .multireddit(owner: nil, name: names[0]) }
+        }
+        return .subreddits(names)
+    }
+}
+
+/// Cache of the signed-in user's multireddit names (and their username, learned
+/// from the multireddit paths), so a bare "nintendo" in a widget can resolve to
+/// m/nintendo when it's one of theirs. Keyed by the account (a hash of client
+/// id + refresh token), refreshed at most every few hours by `RedditClient`.
+enum OwnMultis {
+    private static let defaults = UserDefaults.standard
+    private static let maxAge: TimeInterval = 6 * 3600
+
+    private static func namesKey(_ account: String) -> String { "rw.multis.\(account)" }
+    private static func stampKey(_ account: String) -> String { "rw.multisAt.\(account)" }
+    private static func ownerKey(_ account: String) -> String { "rw.multisOwner.\(account)" }
+
+    /// Lowercased multireddit names for `account` (empty when unknown).
+    static func names(for account: String?) -> Set<String> {
+        guard let account, !account.isEmpty,
+              let arr = defaults.stringArray(forKey: namesKey(account)) else { return [] }
+        return Set(arr)
+    }
+
+    /// The username those multireddits belong to, if a refresh has taught us.
+    static func owner(for account: String?) -> String? {
+        guard let account, !account.isEmpty else { return nil }
+        let v = defaults.string(forKey: ownerKey(account))
+        return (v?.isEmpty == false) ? v : nil
+    }
+
+    static func isStale(for account: String?) -> Bool {
+        guard let account, !account.isEmpty else { return false }
+        return Date().timeIntervalSince1970 - defaults.double(forKey: stampKey(account)) > maxAge
+    }
+
+    static func store(names: [String], owner: String?, for account: String) {
+        defaults.set(names.map { $0.lowercased() }, forKey: namesKey(account))
+        defaults.set(Date().timeIntervalSince1970, forKey: stampKey(account))
+        if let owner, !owner.isEmpty { defaults.set(owner, forKey: ownerKey(account)) }
+    }
+}

--- a/widgets/Sources/FeedSource.swift
+++ b/widgets/Sources/FeedSource.swift
@@ -66,6 +66,15 @@ enum FeedSource: Hashable {
         }
     }
 
+    /// Cache id scoped to the account when the source is read with one: Home
+    /// and the user's own multireddits differ per account, so their posts,
+    /// rotation offsets and Calendar picks must never be shared across an
+    /// account switch (an offline fallback or snapshot would otherwise show
+    /// the previous account's feed). Public sources keep the bare key.
+    func cacheKey(account: String?) -> String {
+        needsAccount ? "\(cacheKey)@\(account ?? "none")" : cacheKey
+    }
+
     /// Stable id for cache keys. A plain subreddit keeps its bare name so the
     /// caches of already-configured widgets carry over unchanged.
     var cacheKey: String {

--- a/widgets/Sources/Headline.swift
+++ b/widgets/Sources/Headline.swift
@@ -15,20 +15,25 @@ struct HeadlineProvider: IntentTimelineProvider {
     func getSnapshot(for configuration: Intent, in context: Context,
                      completion: @escaping (WidgetEntry) -> Void) {
         if context.isPreview { completion(.sample([WidgetSample.feed[0]])); return }
-        let sub = resolvedSubreddit(configuration.subreddit, default: "worldnews")
-        let post = PostCache.load("headline.\(sub)").first ?? WidgetSample.feed[0]
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let post = PostCache.load("headline.\(source.cacheKey)").first ?? WidgetSample.feed[0]
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)])))
+    }
+
+    private static func source(_ configuration: Intent, ownMultis: Set<String>) -> FeedSource {
+        widgetSource(text: configuration.subreddit, default: .subreddits(["worldnews"]), ownMultis: ownMultis)
     }
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "worldnews")
-        let key = "headline.\(sub)"
-        rwLog.log("getTimeline Headline r/\(sub, privacy: .public) family=\(familyName(context.family), privacy: .public)")
-        runPostTimeline(
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let key = "headline.\(source.cacheKey)"
+        rwLog.log("getTimeline Headline \(source.label, privacy: .public) family=\(familyName(context.family), privacy: .public)")
+        runSourceTimeline(
             code: configuration.setupCode, cacheKey: key,
-            fetch: { try await $0.topPosts(subreddit: sub, sort: .hot, limit: 10) },
-            assemble: { assembleText($0, key: key) },   // rotates through the top posts
+            resolve: { Self.source(configuration, ownMultis: $0) },
+            sort: .hot, limit: 10,
+            assemble: { posts, _ in assembleText(posts, key: key) },   // rotates through the top posts
             completion: completion)
     }
 }

--- a/widgets/Sources/Headline.swift
+++ b/widgets/Sources/Headline.swift
@@ -15,8 +15,9 @@ struct HeadlineProvider: IntentTimelineProvider {
     func getSnapshot(for configuration: Intent, in context: Context,
                      completion: @escaping (WidgetEntry) -> Void) {
         if context.isPreview { completion(.sample([WidgetSample.feed[0]])); return }
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
-        let post = PostCache.load("headline.\(source.cacheKey)").first ?? WidgetSample.feed[0]
+        let account = widgetAccountKey(configuration.setupCode)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: account))
+        let post = PostCache.load("headline.\(source.cacheKey(account: account))").first ?? WidgetSample.feed[0]
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)])))
     }
 
@@ -26,14 +27,14 @@ struct HeadlineProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
-        let key = "headline.\(source.cacheKey)"
-        rwLog.log("getTimeline Headline \(source.label, privacy: .public) family=\(familyName(context.family), privacy: .public)")
+        let account = widgetAccountKey(configuration.setupCode)
+        rwLog.log("getTimeline Headline family=\(familyName(context.family), privacy: .public)")
         runSourceTimeline(
-            code: configuration.setupCode, cacheKey: key,
+            code: configuration.setupCode,
             resolve: { Self.source(configuration, ownMultis: $0) },
+            cacheKey: { "headline.\($0.cacheKey(account: account))" },
             sort: .hot, limit: 10,
-            assemble: { posts, _ in assembleText(posts, key: key) },   // rotates through the top posts
+            assemble: { posts, _, key in assembleText(posts, key: key) },   // rotates through the top posts
             completion: completion)
     }
 }

--- a/widgets/Sources/MediaProviders.swift
+++ b/widgets/Sources/MediaProviders.swift
@@ -1,11 +1,28 @@
 import WidgetKit
 import Foundation
 
-// MARK: Subreddit config helpers
+// MARK: Source config helpers
 
-func resolvedSubreddit(_ raw: String?, default def: String) -> String {
-    let s = RedditPost.normalizeSubreddit(raw ?? "")
-    return s.isEmpty ? def : s
+/// The Feed/Post "Source" picker + the "Subreddit or Multireddit" text →
+/// `FeedSource`. Unset (existing widgets) and Custom read the text; an empty
+/// text falls back to the widget's default. `ownMultis` is the account's
+/// cached multireddit names (see `OwnMultis`), so a bare name can be one of
+/// them.
+func widgetSource(pick: RebornFeedSource, text: String?, default def: FeedSource,
+                  ownMultis: Set<String>) -> FeedSource {
+    switch pick {
+    case .home: return .home
+    case .popular: return .popular
+    case .all: return .all
+    default: return FeedSource.parse(text, default: def, ownMultis: ownMultis)
+    }
+}
+
+/// Text-only resolution for the widgets without a Source picker (Photo,
+/// Headline, Calendar) — the text still accepts home/popular/all, r/a+b,
+/// multireddit links and names.
+func widgetSource(text: String?, default def: FeedSource, ownMultis: Set<String>) -> FeedSource {
+    FeedSource.parse(text, default: def, ownMultis: ownMultis)
 }
 
 func widgetSort(_ sort: RebornSort, default def: WidgetSort) -> WidgetSort {
@@ -78,30 +95,36 @@ struct SinglePostProvider: IntentTimelineProvider {
                                    caption: caption))
             return
         }
-        let sub = resolvedSubreddit(configuration.subreddit, default: "popular")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         let sort = widgetSort(configuration.sort, default: .hot)
-        let post = PostCache.load("single.\(sub)\(sortSuffix(sort))").first ?? WidgetSample.post
+        let post = PostCache.load("single.\(source.cacheKey)\(sortSuffix(sort))").first ?? WidgetSample.post
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)]),
                                caption: caption))
     }
 
+    private static func source(_ configuration: Intent, ownMultis: Set<String>) -> FeedSource {
+        widgetSource(pick: configuration.feedSource, text: configuration.subreddit,
+                     default: .popular, ownMultis: ownMultis)
+    }
+
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "popular")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         let sort = widgetSort(configuration.sort, default: .hot)
         let caption = captionLevel(configuration.caption)
         // Per-sort cache buckets so a fetch failure never falls back to a
         // different sort's cached posts.
-        let key = "single.\(sub)\(sortSuffix(sort))"
+        let key = "single.\(source.cacheKey)\(sortSuffix(sort))"
         // Lock-screen (accessory) widgets are text-only — skip image downloads
         // so the timeline builds fast and never risks the tight accessory
         // reload budget (a slow build shows the redacted placeholder skeleton).
         let accessory = isAccessoryFamily(context.family)
-        rwLog.log("getTimeline Post r/\(sub, privacy: .public) family=\(familyName(context.family), privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
-        runPostTimeline(
+        rwLog.log("getTimeline Post \(source.label, privacy: .public) family=\(familyName(context.family), privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        runSourceTimeline(
             code: configuration.setupCode, cacheKey: key,
-            fetch: { try await $0.topPosts(subreddit: sub, sort: sort, limit: 50) },
-            assemble: { posts in
+            resolve: { Self.source(configuration, ownMultis: $0) },
+            sort: sort, limit: 50,
+            assemble: { posts, _ in
                 if accessory {
                     return stamped(assembleText(posts, key: key), caption: caption)
                 }
@@ -119,13 +142,18 @@ struct FeedProvider: IntentTimelineProvider {
 
     func placeholder(in context: Context) -> WidgetEntry { .sample(WidgetSample.feed, sourceLabel: "Popular") }
 
+    private static func source(_ configuration: Intent, ownMultis: Set<String>) -> FeedSource {
+        widgetSource(pick: configuration.feedSource, text: configuration.subreddit,
+                     default: .popular, ownMultis: ownMultis)
+    }
+
     func getSnapshot(for configuration: Intent, in context: Context,
                      completion: @escaping (WidgetEntry) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "popular")
-        let label = feedSourceLabel(sub)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let label = source.label
         if context.isPreview { completion(.sample(WidgetSample.feed, sourceLabel: label)); return }
         let sort = widgetSort(configuration.sort, default: .hot)
-        let cached = PostCache.load("feed.\(sub)\(sortSuffix(sort))")
+        let cached = PostCache.load("feed.\(source.cacheKey)\(sortSuffix(sort))")
         if !cached.isEmpty {
             completion(WidgetEntry(date: Date(),
                                    state: .posts(cached.map { RenderPost(post: $0, imageData: nil) }),
@@ -135,21 +163,23 @@ struct FeedProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "popular")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         let sort = widgetSort(configuration.sort, default: .hot)
-        let label = feedSourceLabel(sub)
         let compact = configuration.compact?.boolValue ?? false
-        let key = "feed.\(sub)\(sortSuffix(sort))"
-        rwLog.log("Feed r/\(sub, privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
-        runPostTimeline(
+        let username = widgetUsername(configuration.setupCode)
+        let key = "feed.\(source.cacheKey)\(sortSuffix(sort))"
+        rwLog.log("Feed \(source.label, privacy: .public) pick=\(configuration.feedSource.rawValue) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        runSourceTimeline(
             code: configuration.setupCode, cacheKey: key,
-            fetch: { try await $0.topPosts(subreddit: sub, sort: sort, limit: 12) },
-            assemble: { posts in
+            resolve: { Self.source(configuration, ownMultis: $0) },
+            sort: sort, limit: 12,
+            assemble: { posts, used in
                 // Compact rows hide thumbnails, so only download them otherwise.
                 let renders = compact
                     ? posts.prefix(8).map { RenderPost(post: $0, imageData: nil) }
                     : await downloadImages(Array(posts.prefix(8)), keyPath: { $0.thumbnailURL }, maxPixel: 160)
-                return stamped(stamped(listTimeline(renders, key: key), sourceLabel: label), compact: compact)
+                return stamped(stamped(listTimeline(renders, key: key), source: used, username: username),
+                               compact: compact)
             },
             completion: completion)
     }
@@ -172,25 +202,31 @@ struct PhotoProvider: IntentTimelineProvider {
                                    caption: caption))
             return
         }
-        let sub = resolvedSubreddit(configuration.subreddit, default: "EarthPorn")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         let sort = widgetSort(configuration.sort, default: .top)
-        let post = PostCache.load("photo.\(sub)\(sortSuffix(sort))").first ?? WidgetSample.feed[4]
+        let post = PostCache.load("photo.\(source.cacheKey)\(sortSuffix(sort))").first ?? WidgetSample.feed[4]
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)]),
                                caption: caption))
     }
 
+    private static func source(_ configuration: Intent, ownMultis: Set<String>) -> FeedSource {
+        widgetSource(text: configuration.subreddit, default: .subreddits(["EarthPorn"]), ownMultis: ownMultis)
+    }
+
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let sub = resolvedSubreddit(configuration.subreddit, default: "EarthPorn")
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
         // Photos default to Top (best images) when no sort is chosen.
         let sort = widgetSort(configuration.sort, default: .top)
         let caption = captionLevel(configuration.caption)
-        let key = "photo.\(sub)\(sortSuffix(sort))"
-        rwLog.log("Photo r/\(sub, privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
-        runPostTimeline(
+        let key = "photo.\(source.cacheKey)\(sortSuffix(sort))"
+        rwLog.log("Photo \(source.label, privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        runSourceTimeline(
             code: configuration.setupCode, cacheKey: key,
-            fetch: { try await $0.topPosts(subreddit: sub, sort: sort, limit: 25).filter { $0.isImagePost } },
-            assemble: { stamped(await assembleWithImages($0, key: key, maxPixel: 800), caption: caption) },
+            resolve: { Self.source(configuration, ownMultis: $0) },
+            sort: sort, limit: 25,
+            filter: { $0.filter { $0.isImagePost } },
+            assemble: { posts, _ in stamped(await assembleWithImages(posts, key: key, maxPixel: 800), caption: caption) },
             completion: completion)
     }
 }

--- a/widgets/Sources/MediaProviders.swift
+++ b/widgets/Sources/MediaProviders.swift
@@ -95,9 +95,10 @@ struct SinglePostProvider: IntentTimelineProvider {
                                    caption: caption))
             return
         }
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: account))
         let sort = widgetSort(configuration.sort, default: .hot)
-        let post = PostCache.load("single.\(source.cacheKey)\(sortSuffix(sort))").first ?? WidgetSample.post
+        let post = PostCache.load("single.\(source.cacheKey(account: account))\(sortSuffix(sort))").first ?? WidgetSample.post
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)]),
                                caption: caption))
     }
@@ -109,22 +110,23 @@ struct SinglePostProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
         let sort = widgetSort(configuration.sort, default: .hot)
         let caption = captionLevel(configuration.caption)
-        // Per-sort cache buckets so a fetch failure never falls back to a
-        // different sort's cached posts.
-        let key = "single.\(source.cacheKey)\(sortSuffix(sort))"
         // Lock-screen (accessory) widgets are text-only — skip image downloads
         // so the timeline builds fast and never risks the tight accessory
         // reload budget (a slow build shows the redacted placeholder skeleton).
         let accessory = isAccessoryFamily(context.family)
-        rwLog.log("getTimeline Post \(source.label, privacy: .public) family=\(familyName(context.family), privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        rwLog.log("getTimeline Post family=\(familyName(context.family), privacy: .public) pick=\(configuration.feedSource.rawValue) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
         runSourceTimeline(
-            code: configuration.setupCode, cacheKey: key,
+            code: configuration.setupCode,
             resolve: { Self.source(configuration, ownMultis: $0) },
+            // Per-sort (and, for personal sources, per-account) cache buckets
+            // so a fetch failure never falls back to another sort's or another
+            // account's cached posts.
+            cacheKey: { "single.\($0.cacheKey(account: account))\(sortSuffix(sort))" },
             sort: sort, limit: 50,
-            assemble: { posts, _ in
+            assemble: { posts, _, key in
                 if accessory {
                     return stamped(assembleText(posts, key: key), caption: caption)
                 }
@@ -149,11 +151,12 @@ struct FeedProvider: IntentTimelineProvider {
 
     func getSnapshot(for configuration: Intent, in context: Context,
                      completion: @escaping (WidgetEntry) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: account))
         let label = source.label
         if context.isPreview { completion(.sample(WidgetSample.feed, sourceLabel: label)); return }
         let sort = widgetSort(configuration.sort, default: .hot)
-        let cached = PostCache.load("feed.\(source.cacheKey)\(sortSuffix(sort))")
+        let cached = PostCache.load("feed.\(source.cacheKey(account: account))\(sortSuffix(sort))")
         if !cached.isEmpty {
             completion(WidgetEntry(date: Date(),
                                    state: .posts(cached.map { RenderPost(post: $0, imageData: nil) }),
@@ -163,17 +166,17 @@ struct FeedProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
         let sort = widgetSort(configuration.sort, default: .hot)
         let compact = configuration.compact?.boolValue ?? false
         let username = widgetUsername(configuration.setupCode)
-        let key = "feed.\(source.cacheKey)\(sortSuffix(sort))"
-        rwLog.log("Feed \(source.label, privacy: .public) pick=\(configuration.feedSource.rawValue) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        rwLog.log("Feed pick=\(configuration.feedSource.rawValue) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
         runSourceTimeline(
-            code: configuration.setupCode, cacheKey: key,
+            code: configuration.setupCode,
             resolve: { Self.source(configuration, ownMultis: $0) },
+            cacheKey: { "feed.\($0.cacheKey(account: account))\(sortSuffix(sort))" },
             sort: sort, limit: 12,
-            assemble: { posts, used in
+            assemble: { posts, used, key in
                 // Compact rows hide thumbnails, so only download them otherwise.
                 let renders = compact
                     ? posts.prefix(8).map { RenderPost(post: $0, imageData: nil) }
@@ -202,9 +205,10 @@ struct PhotoProvider: IntentTimelineProvider {
                                    caption: caption))
             return
         }
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
+        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: account))
         let sort = widgetSort(configuration.sort, default: .top)
-        let post = PostCache.load("photo.\(source.cacheKey)\(sortSuffix(sort))").first ?? WidgetSample.feed[4]
+        let post = PostCache.load("photo.\(source.cacheKey(account: account))\(sortSuffix(sort))").first ?? WidgetSample.feed[4]
         completion(WidgetEntry(date: Date(), state: .posts([RenderPost(post: post, imageData: nil)]),
                                caption: caption))
     }
@@ -215,18 +219,18 @@ struct PhotoProvider: IntentTimelineProvider {
 
     func getTimeline(for configuration: Intent, in context: Context,
                      completion: @escaping (Timeline<WidgetEntry>) -> Void) {
-        let source = Self.source(configuration, ownMultis: OwnMultis.names(for: widgetAccountKey(configuration.setupCode)))
+        let account = widgetAccountKey(configuration.setupCode)
         // Photos default to Top (best images) when no sort is chosen.
         let sort = widgetSort(configuration.sort, default: .top)
         let caption = captionLevel(configuration.caption)
-        let key = "photo.\(source.cacheKey)\(sortSuffix(sort))"
-        rwLog.log("Photo \(source.label, privacy: .public) sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
+        rwLog.log("Photo sortRaw=\(configuration.sort.rawValue) → \(sort.path, privacy: .public)")
         runSourceTimeline(
-            code: configuration.setupCode, cacheKey: key,
+            code: configuration.setupCode,
             resolve: { Self.source(configuration, ownMultis: $0) },
+            cacheKey: { "photo.\($0.cacheKey(account: account))\(sortSuffix(sort))" },
             sort: sort, limit: 25,
             filter: { $0.filter { $0.isImagePost } },
-            assemble: { posts, _ in stamped(await assembleWithImages(posts, key: key, maxPixel: 800), caption: caption) },
+            assemble: { posts, _, key in stamped(await assembleWithImages(posts, key: key, maxPixel: 800), caption: caption) },
             completion: completion)
     }
 }

--- a/widgets/Sources/MediaViews.swift
+++ b/widgets/Sources/MediaViews.swift
@@ -186,6 +186,7 @@ struct FeedWidgetView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     WidgetHeader(label: label,
                                  tint: palette.accent,
+                                 url: entry.sourceURL,
                                  trailing: AnyView(ReloadButton(kind: "FeedWidget")))
                         .padding(.bottom, 6)
                     ForEach(Array(rows.enumerated()), id: \.element.post.id) { idx, render in

--- a/widgets/Sources/RebornWidgets.intentdefinition
+++ b/widgets/Sources/RebornWidgets.intentdefinition
@@ -192,6 +192,51 @@
 				</dict>
 			</array>
 		</dict>
+		<dict>
+			<key>INEnumDisplayName</key>
+			<string>Feed Source</string>
+			<key>INEnumGeneratesHeader</key>
+			<true/>
+			<key>INEnumName</key>
+			<string>RebornFeedSource</string>
+			<key>INEnumType</key>
+			<string>Regular</string>
+			<key>INEnumValues</key>
+			<array>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Home</string>
+					<key>INEnumValueIndex</key>
+					<integer>1</integer>
+					<key>INEnumValueName</key>
+					<string>home</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Popular</string>
+					<key>INEnumValueIndex</key>
+					<integer>2</integer>
+					<key>INEnumValueName</key>
+					<string>popular</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>All</string>
+					<key>INEnumValueIndex</key>
+					<integer>3</integer>
+					<key>INEnumValueName</key>
+					<string>all</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Subreddit or Multireddit</string>
+					<key>INEnumValueIndex</key>
+					<integer>4</integer>
+					<key>INEnumValueName</key>
+					<string>custom</string>
+				</dict>
+			</array>
+		</dict>
 	</array>
 	<key>INIntentDefinitionModelVersion</key>
 	<string>1.2</string>
@@ -333,7 +378,7 @@
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>Posts from a subreddit you choose.</string>
+			<string>Posts from a subreddit, multireddit, or feed you choose.</string>
 			<key>INIntentEligibleForWidgets</key>
 			<true/>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -366,9 +411,34 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Subreddit</string>
+					<string>Source</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>RebornFeedSource</string>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<integer>4</integer>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>feedSource</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array/>
+					<key>INIntentParameterSupportsResolution</key>
+					<false/>
+					<key>INIntentParameterTag</key>
+					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Subreddit or Multireddit</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
 					<key>INIntentParameterName</key>
 					<string>subreddit</string>
 					<key>INIntentParameterPromptDialogs</key>
@@ -386,7 +456,7 @@
 					<key>INIntentParameterDisplayName</key>
 					<string>Sort</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>3</integer>
+					<integer>4</integer>
 					<key>INIntentParameterEnumType</key>
 					<string>RebornSort</string>
 					<key>INIntentParameterName</key>
@@ -406,7 +476,7 @@
 					<key>INIntentParameterDisplayName</key>
 					<string>Compact (hide thumbnails)</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>4</integer>
+					<integer>5</integer>
 					<key>INIntentParameterMetadata</key>
 					<dict>
 						<key>INIntentParameterMetadataDefaultValue</key>
@@ -455,7 +525,7 @@
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>A rotating post from a subreddit you choose.</string>
+			<string>A rotating post from a subreddit, multireddit, or feed you choose.</string>
 			<key>INIntentEligibleForWidgets</key>
 			<true/>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -488,9 +558,34 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Subreddit</string>
+					<string>Source</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>RebornFeedSource</string>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<integer>4</integer>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>feedSource</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array/>
+					<key>INIntentParameterSupportsResolution</key>
+					<false/>
+					<key>INIntentParameterTag</key>
+					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Subreddit or Multireddit</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
 					<key>INIntentParameterName</key>
 					<string>subreddit</string>
 					<key>INIntentParameterPromptDialogs</key>
@@ -508,7 +603,7 @@
 					<key>INIntentParameterDisplayName</key>
 					<string>Sort</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>3</integer>
+					<integer>4</integer>
 					<key>INIntentParameterEnumType</key>
 					<string>RebornSort</string>
 					<key>INIntentParameterName</key>
@@ -528,7 +623,7 @@
 					<key>INIntentParameterDisplayName</key>
 					<string>Caption</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>4</integer>
+					<integer>5</integer>
 					<key>INIntentParameterEnumType</key>
 					<string>RebornCaption</string>
 					<key>INIntentParameterName</key>
@@ -675,7 +770,7 @@
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>A daily photo from a subreddit with the date overlaid. One locked photo per day.</string>
+			<string>A daily photo from a subreddit or multireddit with the date overlaid. One locked photo per day.</string>
 			<key>INIntentEligibleForWidgets</key>
 			<true/>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -708,7 +803,7 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Subreddit</string>
+					<string>Subreddit or Multireddit</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
 					<key>INIntentParameterName</key>
@@ -797,7 +892,7 @@
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>The top image from a subreddit you choose, with optional caption details.</string>
+			<string>The top image from a subreddit or multireddit you choose, with optional caption details.</string>
 			<key>INIntentEligibleForWidgets</key>
 			<true/>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -830,7 +925,7 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Subreddit</string>
+					<string>Subreddit or Multireddit</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
 					<key>INIntentParameterName</key>
@@ -916,7 +1011,7 @@
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>The top post headline from a subreddit you choose, for the Lock Screen.</string>
+			<string>The top post headline from a subreddit or multireddit you choose, for the Lock Screen.</string>
 			<key>INIntentEligibleForWidgets</key>
 			<true/>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -949,7 +1044,7 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Subreddit</string>
+					<string>Subreddit or Multireddit</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
 					<key>INIntentParameterName</key>

--- a/widgets/Sources/RedditClient.swift
+++ b/widgets/Sources/RedditClient.swift
@@ -20,18 +20,66 @@ let rwSession: URLSession = {
     return URLSession(configuration: cfg)
 }()
 
-/// Minimal Reddit client using the **app-only** OAuth grant
-/// (`grant_type=...installed_client`). This requires only a client_id — no
-/// user login — and can read public subreddits like r/showerthoughts.
+/// Minimal Reddit client with two token tiers:
+///
+///   * **app-only** (`grant_type=...installed_client`) — needs only the client
+///     id and reads every public listing: subreddits, r/popular, r/all, other
+///     people's public multireddits. This is what every widget used before.
+///   * **account** (`grant_type=refresh_token`) — present only when the setup
+///     code was copied *with account*. It's what Home and the user's own
+///     (private) multireddits need; public sources keep using the app-only
+///     token so a revoked account never breaks them.
 ///
 /// Validated by hand:
-///   POST https://www.reddit.com/api/v1/access_token   (Basic clientID:"")
+///   POST https://www.reddit.com/api/v1/access_token   (Basic clientID:secret-or-empty)
 ///   GET  https://oauth.reddit.com/r/showerthoughts/top?t=day&limit=N
-struct RedditAppOnlyClient {
+///   GET  https://oauth.reddit.com/hot                   (home; user token)
+///   GET  https://oauth.reddit.com/me/m/<multi>/hot      (own multi; user token)
+///   GET  https://oauth.reddit.com/user/<u>/m/<multi>/hot (public multi; either token)
+///   GET  https://oauth.reddit.com/api/multi/mine        (user token)
+/// Reddit does NOT rotate refresh tokens on use, so the widget refreshing its
+/// own access token never invalidates the one Apollo itself holds.
+struct RedditClient {
     let clientID: String
     let userAgent: String
+    /// Client secret for "web app" (confidential) API keys; empty for the
+    /// usual "installed app" keys, matching how Apollo itself authenticates.
+    var clientSecret: String = ""
+    var refreshToken: String? = nil
+    var username: String? = nil
 
-    enum ClientError: Error { case http(Int), badResponse, noToken }
+    init(clientID: String, userAgent: String, clientSecret: String = "",
+         refreshToken: String? = nil, username: String? = nil) {
+        self.clientID = clientID
+        self.userAgent = userAgent
+        self.clientSecret = clientSecret
+        self.refreshToken = refreshToken
+        self.username = username
+    }
+
+    init(code: SetupCode) {
+        self.init(clientID: code.clientID, userAgent: code.resolvedUserAgent,
+                  clientSecret: code.clientSecret ?? "",
+                  refreshToken: code.hasAccount ? code.refreshToken : nil,
+                  username: code.username)
+    }
+
+    var hasAccount: Bool { !(refreshToken ?? "").isEmpty }
+
+    /// Stable id of the signed-in account for per-account caches (never the
+    /// raw token). Nil without an account.
+    var accountKey: String? {
+        guard let refreshToken, !refreshToken.isEmpty else { return nil }
+        return String(fnv1a("\(clientID):\(refreshToken)"), radix: 36)
+    }
+
+    enum ClientError: Error {
+        case http(Int), badResponse, noToken
+        /// The source needs a user token and the setup code has none.
+        case needsAccount
+        /// Reddit refused the refresh token (revoked / password changed).
+        case accountRejected
+    }
 
     // MARK: Token cache (per-extension UserDefaults; no cross-process sharing)
 
@@ -40,6 +88,9 @@ struct RedditAppOnlyClient {
     private static let tokenExpiryKey = "rw.appOnlyTokenExpiry"
     private static let tokenClientKey = "rw.appOnlyTokenClient"
     private static let deviceIDKey = "rw.deviceID"
+    private static let userTokenKey = "rw.userToken"
+    private static let userTokenExpiryKey = "rw.userTokenExpiry"
+    private static let userTokenAccountKey = "rw.userTokenAccount"
 
     /// Stable per-install device id required by the installed_client grant.
     private static var deviceID: String {
@@ -66,24 +117,43 @@ struct RedditAppOnlyClient {
         d.set(Date().timeIntervalSince1970 + expiresIn, forKey: Self.tokenExpiryKey)
     }
 
+    private func cachedUserToken() -> String? {
+        let d = Self.defaults
+        guard let accountKey, d.string(forKey: Self.userTokenAccountKey) == accountKey,
+              let token = d.string(forKey: Self.userTokenKey) else { return nil }
+        guard d.double(forKey: Self.userTokenExpiryKey) - 120 > Date().timeIntervalSince1970 else { return nil }
+        return token
+    }
+
+    private func storeUserToken(_ token: String, expiresIn: Double) {
+        let d = Self.defaults
+        d.set(token, forKey: Self.userTokenKey)
+        d.set(accountKey, forKey: Self.userTokenAccountKey)
+        d.set(Date().timeIntervalSince1970 + expiresIn, forKey: Self.userTokenExpiryKey)
+    }
+
     // MARK: OAuth
 
-    private func fetchToken() async throws -> String {
+    private func tokenRequest(body: String) -> URLRequest {
         var req = URLRequest(url: URL(string: "https://www.reddit.com/api/v1/access_token")!)
         req.httpMethod = "POST"
         req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-        // HTTP Basic: clientID as username, empty password.
-        let basic = Data("\(clientID):".utf8).base64EncodedString()
+        // HTTP Basic: clientID as username, the secret (empty for installed
+        // apps) as password — the same shape Apollo's own RedditKit sends.
+        let basic = Data("\(clientID):\(clientSecret)".utf8).base64EncodedString()
         req.setValue("Basic \(basic)", forHTTPHeaderField: "Authorization")
         req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        let body = "grant_type=https://oauth.reddit.com/grants/installed_client&device_id=\(Self.deviceID)"
         req.httpBody = body.data(using: .utf8)
+        return req
+    }
 
-        let (data, resp) = try await rwSession.data(for: req)
+    private struct TokenResponse: Codable { let access_token: String; let expires_in: Double }
+
+    private func fetchToken() async throws -> String {
+        let body = "grant_type=https://oauth.reddit.com/grants/installed_client&device_id=\(Self.deviceID)"
+        let (data, resp) = try await rwSession.data(for: tokenRequest(body: body))
         guard let http = resp as? HTTPURLResponse else { throw ClientError.badResponse }
         guard http.statusCode == 200 else { throw ClientError.http(http.statusCode) }
-
-        struct TokenResponse: Codable { let access_token: String; let expires_in: Double }
         guard let tr = try? JSONDecoder().decode(TokenResponse.self, from: data) else {
             throw ClientError.noToken
         }
@@ -96,17 +166,54 @@ struct RedditAppOnlyClient {
         return try await fetchToken()
     }
 
+    /// Mint a user access token from the account's refresh token.
+    private func fetchUserToken() async throws -> String {
+        guard let refreshToken, !refreshToken.isEmpty else { throw ClientError.needsAccount }
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        let encoded = refreshToken.addingPercentEncoding(withAllowedCharacters: allowed) ?? refreshToken
+        let body = "grant_type=refresh_token&refresh_token=\(encoded)"
+        let (data, resp) = try await rwSession.data(for: tokenRequest(body: body))
+        guard let http = resp as? HTTPURLResponse else { throw ClientError.badResponse }
+        // Reddit answers a revoked/foreign refresh token with 400 invalid_grant
+        // (401 for a bad client id/secret pairing); both mean "re-copy the code".
+        if http.statusCode == 400 || http.statusCode == 401 {
+            rwLog.error("user token refresh → HTTP \(http.statusCode)")
+            throw ClientError.accountRejected
+        }
+        guard http.statusCode == 200 else { throw ClientError.http(http.statusCode) }
+        guard let tr = try? JSONDecoder().decode(TokenResponse.self, from: data) else {
+            throw ClientError.noToken
+        }
+        storeUserToken(tr.access_token, expiresIn: tr.expires_in)
+        return tr.access_token
+    }
+
+    private func userToken() async throws -> String {
+        if let cached = cachedUserToken() { return cached }
+        return try await fetchUserToken()
+    }
+
+    /// The bearer for a source: account tier for personal sources, app-only for
+    /// everything public (so a dead account never takes r/aww down with it).
+    private func bearer(for source: FeedSource) async throws -> String {
+        if source.needsAccount {
+            guard hasAccount else { throw ClientError.needsAccount }
+            return try await userToken()
+        }
+        return try await token()
+    }
+
     // MARK: Data
 
-    func topPosts(subreddit: String, sort: WidgetSort, limit: Int = 25,
-                  allowNSFW: Bool = false) async throws -> [RedditPost] {
-        let bearer = try await token()
-        let sub = RedditPost.normalizeSubreddit(subreddit)
-        // Built from a sanitized sub, but never force-unwrap: a nil URL must
+    /// Posts from any `FeedSource` at the given sort.
+    func posts(source: FeedSource, sort: WidgetSort, limit: Int = 25,
+               allowNSFW: Bool = false) async throws -> [RedditPost] {
+        let bearer = try await bearer(for: source)
+        // Built from sanitized names, but never force-unwrap: a nil URL must
         // surface as an error, not a crash (a crashing extension poisons
         // WidgetKit's enumeration of every widget).
-        guard !sub.isEmpty,
-              var comps = URLComponents(string: "https://oauth.reddit.com/r/\(sub)/\(sort.path)") else {
+        guard var comps = URLComponents(string: "https://oauth.reddit.com\(source.listingPath)/\(sort.path)") else {
             throw ClientError.badResponse
         }
         var items = [
@@ -130,14 +237,58 @@ struct RedditAppOnlyClient {
         let (data, resp) = try await rwSession.data(for: req)
         guard let http = resp as? HTTPURLResponse else { throw ClientError.badResponse }
         guard http.statusCode == 200 else {
-            rwLog.error("fetch r/\(sub, privacy: .public)/\(sort.path, privacy: .public) → HTTP \(http.statusCode)")
+            rwLog.error("fetch \(source.listingPath, privacy: .public)/\(sort.path, privacy: .public) → HTTP \(http.statusCode)")
             throw ClientError.http(http.statusCode)
         }
         let posts = Self.parseListing(data, allowNSFW: allowNSFW)
         let firstIDs = posts.prefix(3).map { $0.id }.joined(separator: ",")
         let window = sort.timeWindow ?? "-"
-        rwLog.log("fetched r/\(sub, privacy: .public) sort=\(sort.path, privacy: .public) t=\(window, privacy: .public) → \(posts.count) posts [\(firstIDs, privacy: .public)]")
+        rwLog.log("fetched \(source.label, privacy: .public) sort=\(sort.path, privacy: .public) t=\(window, privacy: .public) → \(posts.count) posts [\(firstIDs, privacy: .public)]")
         return posts
+    }
+
+    /// Posts from one subreddit (the fixed-subreddit widgets: Jokes, Showerthoughts).
+    func topPosts(subreddit: String, sort: WidgetSort, limit: Int = 25,
+                  allowNSFW: Bool = false) async throws -> [RedditPost] {
+        let sub = RedditPost.normalizeSubreddit(subreddit)
+        guard !sub.isEmpty else { throw ClientError.badResponse }
+        return try await posts(source: .subreddits([sub]), sort: sort, limit: limit, allowNSFW: allowNSFW)
+    }
+
+    /// Learn the signed-in user's multireddits (names + owner) into `OwnMultis`
+    /// when the cache is missing or old. No-op without an account; failures
+    /// are logged and simply leave the cache as it was.
+    func refreshOwnMultisIfStale() async {
+        guard let accountKey, OwnMultis.isStale(for: accountKey) else { return }
+        do {
+            let bearer = try await userToken()
+            guard let url = URL(string: "https://oauth.reddit.com/api/multi/mine?raw_json=1") else { return }
+            var req = URLRequest(url: url)
+            req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            req.setValue("bearer \(bearer)", forHTTPHeaderField: "Authorization")
+            let (data, resp) = try await rwSession.data(for: req)
+            guard let http = resp as? HTTPURLResponse, http.statusCode == 200,
+                  let list = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                rwLog.error("multi/mine failed (\((resp as? HTTPURLResponse)?.statusCode ?? -1))")
+                return
+            }
+            var names: [String] = []
+            var owner: String? = username
+            for item in list {
+                guard let d = item["data"] as? [String: Any],
+                      let name = d["name"] as? String, !name.isEmpty else { continue }
+                names.append(name)
+                // "/user/<owner>/m/<name>/" — the owner is our username.
+                if owner == nil, let path = d["path"] as? String {
+                    let segs = path.split(separator: "/")
+                    if segs.count >= 2, segs[0] == "user" { owner = String(segs[1]) }
+                }
+            }
+            OwnMultis.store(names: names, owner: owner, for: accountKey)
+            rwLog.log("multi/mine → \(names.count) multireddit(s)")
+        } catch {
+            rwLog.error("multi/mine: \(String(describing: error), privacy: .public)")
+        }
     }
 
     /// A subreddit's icon URL + brand color hex from /about (best-effort).

--- a/widgets/Sources/RedditClient.swift
+++ b/widgets/Sources/RedditClient.swift
@@ -67,10 +67,20 @@ struct RedditClient {
     var hasAccount: Bool { !(refreshToken ?? "").isEmpty }
 
     /// Stable id of the signed-in account for per-account caches (never the
-    /// raw token). Nil without an account.
+    /// raw token; same derivation as `SetupCode.accountKey`). Nil without an
+    /// account.
     var accountKey: String? {
         guard let refreshToken, !refreshToken.isEmpty else { return nil }
         return String(fnv1a("\(clientID):\(refreshToken)"), radix: 36)
+    }
+
+    /// Drop the cached user access token if it belongs to `account`.
+    static func forgetUserToken(account: String) {
+        let d = defaults
+        guard d.string(forKey: userTokenAccountKey) == account else { return }
+        d.removeObject(forKey: userTokenKey)
+        d.removeObject(forKey: userTokenExpiryKey)
+        d.removeObject(forKey: userTokenAccountKey)
     }
 
     enum ClientError: Error {

--- a/widgets/Sources/SetupCode.swift
+++ b/widgets/Sources/SetupCode.swift
@@ -11,14 +11,20 @@ import WidgetKit
 /// reliably claim for `group.com.christianselig.apollo`. A one-time manual
 /// paste sidesteps that entirely and works identically on every signer.
 ///
-/// Format: base64( JSON { "v": 1, "clientID": "...", "userAgent": "..." } ).
-/// `refreshToken` is reserved for a future tier-2 (personal) widget; it is
-/// optional and ignored here.
+/// Format: base64( JSON { "v", "clientID", "userAgent", … } ).
+///   v1  – clientID + userAgent: the app-only tier every widget started with.
+///   v2  – adds `refreshToken` + `username` (copied "with account"), which is
+///         what Home and the user's own multireddits need, and `clientSecret`
+///         for "web app" API keys. Older widget builds ignore the extra keys.
 struct SetupCode: Codable {
     var v: Int
     var clientID: String
     var userAgent: String?
+    var clientSecret: String?
     var refreshToken: String?
+    var username: String?
+
+    var hasAccount: Bool { !(refreshToken ?? "").isEmpty }
 
     /// Decode a pasted code. Accepts either the base64 setup code OR, as a
     /// forgiving fallback, a bare Reddit client_id string (in which case a
@@ -27,17 +33,23 @@ struct SetupCode: Codable {
         guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
               !raw.isEmpty else { return nil }
 
-        // Primary path: base64-encoded JSON.
-        if let data = Data(base64Encoded: raw),
-           let decoded = try? JSONDecoder().decode(SetupCode.self, from: data),
-           !decoded.clientID.isEmpty {
-            return decoded
+        // Primary path: base64-encoded JSON. Every code starts with "eyJ"
+        // (base64 of `{"`); a keyboard's auto-capitalization turns a typed one
+        // into "EyJ", which is different base64 — undo that one mangling.
+        var candidates = [raw]
+        if raw.hasPrefix("EyJ") { candidates.append("eyJ" + raw.dropFirst(3)) }
+        for candidate in candidates {
+            if let data = Data(base64Encoded: candidate),
+               let decoded = try? JSONDecoder().decode(SetupCode.self, from: data),
+               !decoded.clientID.isEmpty {
+                return decoded
+            }
         }
 
         // Fallback: a raw client_id (Reddit ids are short, no spaces).
         if raw.count >= 8, raw.count <= 40,
            raw.rangeOfCharacter(from: .whitespacesAndNewlines) == nil {
-            return SetupCode(v: 1, clientID: raw, userAgent: nil, refreshToken: nil)
+            return SetupCode(v: 1, clientID: raw)
         }
 
         return nil
@@ -55,16 +67,25 @@ struct SetupCode: Codable {
     /// it; any other widget whose own field is blank falls back to that stash.
     /// Net effect: paste the code once into ANY widget and the rest pick it up
     /// on their next refresh — no per-widget pasting, no App Group needed.
+    ///
+    /// A code copied *with account* outranks a plain one for the same API key:
+    /// pasting it into ONE widget upgrades every widget, and the plain codes
+    /// still sitting in the other widgets' fields don't downgrade the stash
+    /// back. Only the first stash and that upgrade reload every widget —
+    /// two widgets holding different codes would otherwise ping-pong
+    /// `reloadAllTimelines` at each other (each rebuild re-stashing its own).
     static func resolve(_ raw: String?) -> SetupCode? {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmed.isEmpty, let parsed = parse(trimmed) {
-            SharedSetup.store(trimmed)          // remember for the other widgets
-            return parsed
+        let shared = SharedSetup.load().flatMap(parse)
+        if !trimmed.isEmpty, let own = parse(trimmed) {
+            if let shared, shared.hasAccount, !own.hasAccount, shared.clientID == own.clientID {
+                return shared
+            }
+            let upgrade = shared.map { own.hasAccount && !$0.hasAccount } ?? true
+            SharedSetup.store(trimmed, reloadOthers: upgrade)   // remember for the other widgets
+            return own
         }
-        if let shared = SharedSetup.load() {    // fall back to the shared stash
-            return parse(shared)
-        }
-        return nil
+        return shared                            // fall back to the shared stash
     }
 }
 
@@ -74,13 +95,15 @@ enum SharedSetup {
     private static let defaults = UserDefaults.standard
     private static let key = "rw.sharedSetupCode"
 
-    static func store(_ code: String) {
-        // Only act on a genuine change, then immediately reload every widget so
-        // the others re-resolve against this freshly-shared code instead of
-        // waiting for their own next WidgetKit budget window.
+    static func store(_ code: String, reloadOthers: Bool) {
+        // Only act on a genuine change. `reloadOthers` immediately reloads
+        // every widget so the ones with a blank field re-resolve against this
+        // freshly-shared code instead of waiting for their own next WidgetKit
+        // budget window — the caller limits that to the first stash and an
+        // account upgrade so differing codes can't chase each other.
         guard defaults.string(forKey: key) != code else { return }
         defaults.set(code, forKey: key)
-        WidgetCenter.shared.reloadAllTimelines()
+        if reloadOthers { WidgetCenter.shared.reloadAllTimelines() }
     }
     static func load() -> String? {
         let v = defaults.string(forKey: key)

--- a/widgets/Sources/SetupCode.swift
+++ b/widgets/Sources/SetupCode.swift
@@ -14,8 +14,10 @@ import WidgetKit
 /// Format: base64( JSON { "v", "clientID", "userAgent", … } ).
 ///   v1  – clientID + userAgent: the app-only tier every widget started with.
 ///   v2  – adds `refreshToken` + `username` (copied "with account"), which is
-///         what Home and the user's own multireddits need, and `clientSecret`
-///         for "web app" API keys. Older widget builds ignore the extra keys.
+///         what Home and the user's own multireddits need, `clientSecret`
+///         for "web app" API keys, and `issued` (unix seconds the code was
+///         copied) so the most recently copied code can win — see `resolve`.
+///         Older widget builds ignore the extra keys.
 struct SetupCode: Codable {
     var v: Int
     var clientID: String
@@ -23,8 +25,18 @@ struct SetupCode: Codable {
     var clientSecret: String?
     var refreshToken: String?
     var username: String?
+    var issued: Double?
 
     var hasAccount: Bool { !(refreshToken ?? "").isEmpty }
+
+    /// Stable, non-secret id of the signed-in account (a hash of client id +
+    /// refresh token). Scopes every per-account cache — see `FeedSource
+    /// .cacheKey(account:)` — so switching accounts can never surface the
+    /// previous account's Home/multireddit posts. Nil without an account.
+    var accountKey: String? {
+        guard hasAccount, let refreshToken else { return nil }
+        return String(fnv1a("\(clientID):\(refreshToken)"), radix: 36)
+    }
 
     /// Decode a pasted code. Accepts either the base64 setup code OR, as a
     /// forgiving fallback, a bare Reddit client_id string (in which case a
@@ -68,24 +80,31 @@ struct SetupCode: Codable {
     /// Net effect: paste the code once into ANY widget and the rest pick it up
     /// on their next refresh — no per-widget pasting, no App Group needed.
     ///
-    /// A code copied *with account* outranks a plain one for the same API key:
-    /// pasting it into ONE widget upgrades every widget, and the plain codes
-    /// still sitting in the other widgets' fields don't downgrade the stash
-    /// back. Only the first stash and that upgrade reload every widget —
-    /// two widgets holding different codes would otherwise ping-pong
-    /// `reloadAllTimelines` at each other (each rebuild re-stashing its own).
+    /// **The most recently copied code wins everywhere.** Codes carry the time
+    /// they were copied (`issued`), so pasting a newer code into ANY widget —
+    /// with account, without account, or for another account — replaces the
+    /// stash for every widget, while the older codes still sitting in other
+    /// widgets' fields never drag it back (no reload ping-pong, and "Copy
+    /// without Account" pasted once is how account access gets removed).
+    /// Codes from older tweak builds have no timestamp: they're honoured in
+    /// their own widget but never replace a timestamped stash.
     static func resolve(_ raw: String?) -> SetupCode? {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let shared = SharedSetup.load().flatMap(parse)
-        if !trimmed.isEmpty, let own = parse(trimmed) {
-            if let shared, shared.hasAccount, !own.hasAccount, shared.clientID == own.clientID {
-                return shared
-            }
-            let upgrade = shared.map { own.hasAccount && !$0.hasAccount } ?? true
-            SharedSetup.store(trimmed, reloadOthers: upgrade)   // remember for the other widgets
+        let sharedRaw = SharedSetup.load()
+        let shared = sharedRaw.flatMap(parse)
+        guard !trimmed.isEmpty, let own = parse(trimmed) else { return shared }
+        guard let shared, trimmed != sharedRaw else {
+            if shared == nil { SharedSetup.store(trimmed, replacing: nil) }
             return own
         }
-        return shared                            // fall back to the shared stash
+        if (own.issued ?? 0) > (shared.issued ?? 0) {
+            SharedSetup.store(trimmed, replacing: shared)
+            return own
+        }
+        if let sharedIssued = shared.issued, (own.issued ?? 0) < sharedIssued {
+            return shared                        // a deliberately later paste elsewhere
+        }
+        return own                               // neither dated: each widget keeps its own
     }
 }
 
@@ -95,15 +114,18 @@ enum SharedSetup {
     private static let defaults = UserDefaults.standard
     private static let key = "rw.sharedSetupCode"
 
-    static func store(_ code: String, reloadOthers: Bool) {
-        // Only act on a genuine change. `reloadOthers` immediately reloads
-        // every widget so the ones with a blank field re-resolve against this
-        // freshly-shared code instead of waiting for their own next WidgetKit
-        // budget window — the caller limits that to the first stash and an
-        // account upgrade so differing codes can't chase each other.
+    /// Replace the stash with a newer code. When the account it carried is
+    /// gone (a plain code, or a different account), everything cached for
+    /// that account — posts, rotation offsets, Calendar picks, multireddit
+    /// names, the user token — is dropped so nothing of it can resurface.
+    /// Then every widget reloads so blank-field widgets re-resolve at once.
+    static func store(_ code: String, replacing previous: SetupCode?) {
         guard defaults.string(forKey: key) != code else { return }
         defaults.set(code, forKey: key)
-        if reloadOthers { WidgetCenter.shared.reloadAllTimelines() }
+        if let old = previous?.accountKey, old != SetupCode.parse(code)?.accountKey {
+            WidgetCaches.forget(account: old)
+        }
+        WidgetCenter.shared.reloadAllTimelines()
     }
     static func load() -> String? {
         let v = defaults.string(forKey: key)

--- a/widgets/Sources/ShortcutsProvider.swift
+++ b/widgets/Sources/ShortcutsProvider.swift
@@ -57,8 +57,7 @@ struct ShortcutsProvider: IntentTimelineProvider {
             var items = shortcuts
             // Best-effort icons via the shared setup code; letter avatars otherwise.
             if let creds = SetupCode.resolve(configuration.setupCode) {
-                let client = RedditAppOnlyClient(clientID: creds.clientID, userAgent: creds.resolvedUserAgent)
-                items = await Self.withIcons(shortcuts, client: client)
+                items = await Self.withIcons(shortcuts, client: RedditClient(code: creds))
             }
             // Refresh icons daily; subreddit icons rarely change.
             completion(Timeline(entries: [ShortcutsEntry(date: Date(), items: items, needsConfig: false)],
@@ -67,7 +66,7 @@ struct ShortcutsProvider: IntentTimelineProvider {
     }
 
     /// Concurrently fetch each subreddit's icon + brand color, preserving order.
-    private static func withIcons(_ items: [ShortcutItem], client: RedditAppOnlyClient) async -> [ShortcutItem] {
+    private static func withIcons(_ items: [ShortcutItem], client: RedditClient) async -> [ShortcutItem] {
         await withTaskGroup(of: (Int, Data?, String?).self) { group in
             for (i, item) in items.enumerated() {
                 group.addTask {

--- a/widgets/Sources/WidgetShared.swift
+++ b/widgets/Sources/WidgetShared.swift
@@ -13,6 +13,9 @@ struct WidgetEntry: TimelineEntry {
     enum State: Hashable {
         case posts([RenderPost])
         case needsSetup
+        /// The source (Home, an own multireddit) needs the account tier of the
+        /// setup code and the pasted one has none.
+        case needsAccount
         case error(String)
         case loading
     }
@@ -27,6 +30,8 @@ struct WidgetEntry: TimelineEntry {
     /// for sources like r/popular, so the header must show the configured
     /// source, not the first post's subreddit.
     var sourceLabel: String? = nil
+    /// Deep link for the Feed header (opens the configured feed in Apollo).
+    var sourceURL: URL? = nil
     /// Feed density: hide thumbnails / tighter rows (ignored by other widgets).
     var feedCompact: Bool = false
     /// Calendar widget rendering config (ignored by the other widgets). The
@@ -92,19 +97,13 @@ enum WidgetSample {
     static var post: RedditPost { feed[0] }
 }
 
-/// Human-readable label for a Feed/Post source. r/popular, r/all and the home
-/// feed are multi-subreddit, so they get a plain capitalized name; everything
-/// else is shown as "r/<sub>".
-func feedSourceLabel(_ sub: String) -> String {
-    let lower = sub.lowercased()
-    if ["popular", "all", "home"].contains(lower) { return lower.capitalized }
-    return "r/\(sub)"
-}
-
-/// Stamp a Feed source label onto every entry of a built timeline.
-func stamped(_ timeline: Timeline<WidgetEntry>, sourceLabel: String) -> Timeline<WidgetEntry> {
+/// Stamp a Feed source (header label + deep link) onto every entry of a built
+/// timeline. `username` resolves the link for the user's own multireddits.
+func stamped(_ timeline: Timeline<WidgetEntry>, source: FeedSource, username: String?) -> Timeline<WidgetEntry> {
+    let label = source.label
+    let url = source.apolloURL(username: username)
     let entries = timeline.entries.map { e -> WidgetEntry in
-        var e = e; e.sourceLabel = sourceLabel; return e
+        var e = e; e.sourceLabel = label; e.sourceURL = url; return e
     }
     return Timeline(entries: entries, policy: timeline.policy)
 }
@@ -237,17 +236,29 @@ func singleEntry(_ state: WidgetEntry.State, refreshIn: TimeInterval) -> Timelin
              policy: .after(Date().addingTimeInterval(refreshIn)))
 }
 
-func errorMessage(_ error: Error) -> String {
-    if let e = error as? RedditAppOnlyClient.ClientError {
+func errorMessage(_ error: Error, source: FeedSource? = nil) -> String {
+    if let e = error as? RedditClient.ClientError {
         switch e {
         case .http(401), .http(403): return "Reddit rejected the credentials. Re-copy the setup code."
-        case .http(404): return "Subreddit not found."
+        case .http(404):
+            // A private multireddit reads as 404 without its owner's account.
+            if let source, source.isMultireddit { return "Multireddit not found. If it's private, copy the setup code with your account." }
+            return "Subreddit not found."
         case .http(429): return "Rate limited by Reddit. Will retry shortly."
         case .http(let code): return "Reddit error \(code)."
         case .badResponse, .noToken: return "Couldn't reach Reddit."
+        case .needsAccount: return "This feed needs your account. Copy the setup code with your account."
+        case .accountRejected: return "Reddit rejected your account. Re-copy the setup code with your account."
         }
     }
     return "Couldn't load posts."
+}
+
+/// Mutable holder so the fetch step of a timeline build can hand the source it
+/// actually used (after learning the account's multireddits) to `assemble`.
+final class SourceBox {
+    var source: FeedSource
+    init(_ source: FeedSource) { self.source = source }
 }
 
 /// Shared driver: parse creds → fetch (with cache fallback) → hand posts to a
@@ -255,7 +266,8 @@ func errorMessage(_ error: Error) -> String {
 func runPostTimeline(
     code: String?,
     cacheKey: String,
-    fetch: @escaping (RedditAppOnlyClient) async throws -> [RedditPost],
+    source: SourceBox? = nil,
+    fetch: @escaping (RedditClient) async throws -> [RedditPost],
     assemble: @escaping ([RedditPost]) async -> Timeline<WidgetEntry>,
     completion: @escaping (Timeline<WidgetEntry>) -> Void
 ) {
@@ -279,7 +291,7 @@ func runPostTimeline(
         }
     }
     Task {
-        let client = RedditAppOnlyClient(clientID: creds.clientID, userAgent: creds.resolvedUserAgent)
+        let client = RedditClient(code: creds)
         do {
             var posts = try await fetch(client)
             rwLog.log("runPostTimeline[\(cacheKey, privacy: .public)]: fetched \(posts.count)")
@@ -292,11 +304,60 @@ func runPostTimeline(
             completion(await assemble(posts))
         } catch {
             rwLog.error("runPostTimeline[\(cacheKey, privacy: .public)]: \(String(describing: error), privacy: .public)")
+            // No account for a personal source: say so rather than showing
+            // stale posts — the fix is a paste, and the prompt explains it.
+            if case RedditClient.ClientError.needsAccount = error {
+                completion(singleEntry(.needsAccount, refreshIn: 60 * 60))
+                return
+            }
             let cached = PostCache.load(cacheKey)
             if !cached.isEmpty { completion(await assemble(cached)) }
-            else { completion(singleEntry(.error(errorMessage(error)), refreshIn: 15 * 60)) }
+            else { completion(singleEntry(.error(errorMessage(error, source: source?.source)), refreshIn: 15 * 60)) }
         }
     }
+}
+
+/// Source-aware driver over `runPostTimeline` for the configurable widgets.
+/// `resolve` maps the account's cached multireddit names to the source (so a
+/// bare "nintendo" can be m/nintendo when it's the user's); on the first build
+/// with an account the multireddits are fetched first and the source
+/// re-resolved. `assemble` gets the posts plus the source actually used, for
+/// the header label and deep link.
+func runSourceTimeline(
+    code: String?,
+    cacheKey: String,
+    resolve: @escaping (Set<String>) -> FeedSource,
+    sort: WidgetSort,
+    limit: Int,
+    filter: @escaping ([RedditPost]) -> [RedditPost] = { $0 },
+    assemble: @escaping ([RedditPost], FeedSource) async -> Timeline<WidgetEntry>,
+    completion: @escaping (Timeline<WidgetEntry>) -> Void
+) {
+    let box = SourceBox(resolve(OwnMultis.names(for: widgetAccountKey(code))))
+    runPostTimeline(
+        code: code, cacheKey: cacheKey, source: box,
+        fetch: { client in
+            if client.hasAccount, OwnMultis.isStale(for: client.accountKey) {
+                await client.refreshOwnMultisIfStale()
+                box.source = resolve(OwnMultis.names(for: client.accountKey))
+            }
+            return filter(try await client.posts(source: box.source, sort: sort, limit: limit))
+        },
+        assemble: { await assemble($0, box.source) },
+        completion: completion)
+}
+
+/// Per-account cache id for the resolved setup code (nil without an account).
+func widgetAccountKey(_ code: String?) -> String? {
+    SetupCode.resolve(code).flatMap { RedditClient(code: $0).accountKey }
+}
+
+/// Username behind the resolved setup code — from the code itself, else as
+/// learned from the account's multireddit paths. Nil without an account.
+func widgetUsername(_ code: String?) -> String? {
+    guard let creds = SetupCode.resolve(code), creds.hasAccount else { return nil }
+    if let u = creds.username, !u.isEmpty { return u }
+    return OwnMultis.owner(for: RedditClient(code: creds).accountKey)
 }
 
 // MARK: - assemble helpers (image downloads)

--- a/widgets/Sources/WidgetShared.swift
+++ b/widgets/Sources/WidgetShared.swift
@@ -254,11 +254,26 @@ func errorMessage(_ error: Error, source: FeedSource? = nil) -> String {
     return "Couldn't load posts."
 }
 
-/// Mutable holder so the fetch step of a timeline build can hand the source it
-/// actually used (after learning the account's multireddits) to `assemble`.
-final class SourceBox {
-    var source: FeedSource
-    init(_ source: FeedSource) { self.source = source }
+/// Everything the extension cached for one account, dropped when the shared
+/// setup code stops carrying that account (a plain code or another account
+/// was pasted later). Per-account keys all embed the account id: post caches,
+/// rotation offsets and Calendar picks as "<source>@<account>" (see
+/// `FeedSource.cacheKey(account:)`), the multireddit cache as ".<account>",
+/// plus the user access token.
+enum WidgetCaches {
+    static func forget(account: String) {
+        guard !account.isEmpty else { return }
+        let d = UserDefaults.standard
+        var dropped = 0
+        for key in d.dictionaryRepresentation().keys where key.hasPrefix("rw.") {
+            if key.contains("@\(account)") || key.hasSuffix(".\(account)") {
+                d.removeObject(forKey: key)
+                dropped += 1
+            }
+        }
+        RedditClient.forgetUserToken(account: account)
+        rwLog.log("forgot account \(account, privacy: .public): dropped \(dropped) cached value(s)")
+    }
 }
 
 /// Shared driver: parse creds → fetch (with cache fallback) → hand posts to a
@@ -266,7 +281,7 @@ final class SourceBox {
 func runPostTimeline(
     code: String?,
     cacheKey: String,
-    source: SourceBox? = nil,
+    source: FeedSource? = nil,
     fetch: @escaping (RedditClient) async throws -> [RedditPost],
     assemble: @escaping ([RedditPost]) async -> Timeline<WidgetEntry>,
     completion: @escaping (Timeline<WidgetEntry>) -> Void
@@ -312,39 +327,38 @@ func runPostTimeline(
             }
             let cached = PostCache.load(cacheKey)
             if !cached.isEmpty { completion(await assemble(cached)) }
-            else { completion(singleEntry(.error(errorMessage(error, source: source?.source)), refreshIn: 15 * 60)) }
+            else { completion(singleEntry(.error(errorMessage(error, source: source)), refreshIn: 15 * 60)) }
         }
     }
 }
 
 /// Source-aware driver over `runPostTimeline` for the configurable widgets.
-/// `resolve` maps the account's cached multireddit names to the source (so a
-/// bare "nintendo" can be m/nintendo when it's the user's); on the first build
-/// with an account the multireddits are fetched first and the source
-/// re-resolved. `assemble` gets the posts plus the source actually used, for
-/// the header label and deep link.
+/// With an account, the user's multireddit names are (re)learned first so
+/// `resolve` can map a bare "nintendo" to m/nintendo; the source is then fixed
+/// for the whole build, so `cacheKey` (which embeds the account for personal
+/// sources) always matches the posts stored under it. `assemble` gets the
+/// posts plus the source actually used, for the header label and deep link.
 func runSourceTimeline(
     code: String?,
-    cacheKey: String,
     resolve: @escaping (Set<String>) -> FeedSource,
+    cacheKey: @escaping (FeedSource) -> String,
     sort: WidgetSort,
     limit: Int,
     filter: @escaping ([RedditPost]) -> [RedditPost] = { $0 },
-    assemble: @escaping ([RedditPost], FeedSource) async -> Timeline<WidgetEntry>,
+    assemble: @escaping ([RedditPost], FeedSource, String) async -> Timeline<WidgetEntry>,
     completion: @escaping (Timeline<WidgetEntry>) -> Void
 ) {
-    let box = SourceBox(resolve(OwnMultis.names(for: widgetAccountKey(code))))
-    runPostTimeline(
-        code: code, cacheKey: cacheKey, source: box,
-        fetch: { client in
-            if client.hasAccount, OwnMultis.isStale(for: client.accountKey) {
-                await client.refreshOwnMultisIfStale()
-                box.source = resolve(OwnMultis.names(for: client.accountKey))
-            }
-            return filter(try await client.posts(source: box.source, sort: sort, limit: limit))
-        },
-        assemble: { await assemble($0, box.source) },
-        completion: completion)
+    let client = SetupCode.resolve(code).map { RedditClient(code: $0) }
+    Task {
+        if let client, client.hasAccount { await client.refreshOwnMultisIfStale() }
+        let source = resolve(OwnMultis.names(for: client?.accountKey))
+        let key = cacheKey(source)
+        runPostTimeline(
+            code: code, cacheKey: key, source: source,
+            fetch: { filter(try await $0.posts(source: source, sort: sort, limit: limit)) },
+            assemble: { await assemble($0, source, key) },
+            completion: completion)
+    }
 }
 
 /// Per-account cache id for the resolved setup code (nil without an account).

--- a/widgets/Sources/WidgetViews.swift
+++ b/widgets/Sources/WidgetViews.swift
@@ -29,6 +29,8 @@ struct WidgetShell<Content: View, Background: View>: View {
             MessageView(icon: "ellipsis", title: "Apollo", detail: "Loading…")
         case .needsSetup:
             SetupView()
+        case .needsAccount:
+            SetupView(needsAccount: true)
         case .error(let msg):
             // Transient (offline / rate-limited) — phrased as "will retry".
             MessageView(icon: "wifi.exclamationmark", title: "Can't reach Reddit", detail: msg)
@@ -73,7 +75,22 @@ struct MessageView: View {
 /// intentional welcome rather than an error.
 struct SetupView: View {
     @Environment(\.widgetFamily) private var family
+    /// The code is fine but this source (Home, an own multireddit) needs the
+    /// account tier — ask for the "with account" code instead of a first paste.
+    var needsAccount: Bool = false
     private var small: Bool { family == .systemSmall }
+
+    private var title: String { needsAccount ? "Sign in for this feed" : "Set up Apollo widgets" }
+    private var detail: String {
+        if needsAccount {
+            return small
+                ? "Paste a setup code that includes your account."
+                : "Home and your multireddits need your account. In Apollo → Settings → Apollo Reborn, copy the setup code with your account and paste it here."
+        }
+        return small
+            ? "Tap Edit and paste your Apollo setup code."
+            : "Tap Edit and paste your setup code from Apollo → Settings → Apollo Reborn. Just once — every widget shares it."
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: small ? 7 : 9) {
@@ -84,14 +101,12 @@ struct SetupView: View {
                 .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 1))
                 .shadow(color: .black.opacity(0.2), radius: 3, y: 1)
             VStack(alignment: .leading, spacing: 3) {
-                Text("Set up Apollo widgets")
+                Text(title)
                     .font(.system(size: small ? 14 : 16, weight: .bold, design: .rounded))
                     .foregroundStyle(.white)
                     .minimumScaleFactor(0.7)
                     .lineLimit(2)
-                Text(small
-                     ? "Tap Edit and paste your Apollo setup code."
-                     : "Tap Edit and paste your setup code from Apollo → Settings → Apollo Reborn. Just once — every widget shares it.")
+                Text(detail)
                     .font(.system(size: small ? 11 : 12))
                     .foregroundStyle(.white.opacity(0.9))
                     .minimumScaleFactor(0.8)
@@ -107,19 +122,32 @@ struct SetupView: View {
 
 /// Small header: a bold tinted title (Apollo uses an emoji, e.g. "Showerthoughts
 /// 🚿"), with an optional leading SF Symbol and trailing interactive button.
+/// With `url`, the title becomes a link (the Feed header opens its feed in
+/// Apollo) while the trailing button keeps its own tap.
 struct WidgetHeader: View {
     var icon: String? = nil
     let label: String
     var tint: Color = .white
+    var url: URL? = nil
     var trailing: AnyView? = nil
     var body: some View {
         HStack(spacing: 5) {
-            if let icon { Image(systemName: icon).font(.caption2) }
-            Text(label).font(.system(size: 13, weight: .heavy, design: .rounded))
+            if let url {
+                Link(destination: url) { title }
+            } else {
+                title
+            }
             Spacer(minLength: 4)
             if let trailing { trailing }
         }
         .foregroundStyle(tint)
+    }
+
+    private var title: some View {
+        HStack(spacing: 5) {
+            if let icon { Image(systemName: icon).font(.caption2) }
+            Text(label).font(.system(size: 13, weight: .heavy, design: .rounded)).lineLimit(1)
+        }
     }
 }
 
@@ -406,7 +434,7 @@ struct AccessoryPostView: View {
 
     private var accessoryNote: String {
         switch entry.state {
-        case .needsSetup: return "Set up in Apollo"
+        case .needsSetup, .needsAccount: return "Set up in Apollo"
         case .error: return "Tap to open Apollo"
         default: return "Loading…"
         }

--- a/widgets/WIDGETS.md
+++ b/widgets/WIDGETS.md
@@ -11,13 +11,13 @@ widgets live in one extension (one App ID), built with classic SiriKit
 |---|---|---|---|
 | **Showerthoughts** | S · M · L · Lock (rect, inline) | Setup code only | r/showerthoughts · Top: Week |
 | **Jokes** | S · M · L · Lock (rect, inline) | Setup code only | r/Jokes · Top: Today |
-| **Post** | S · M · L | Subreddit, Sort, Caption | r/popular · Hot |
-| **Feed** | M · L | Subreddit, Sort, Compact | r/popular · Hot |
-| **Photo** | S · M · L | Subreddit, Sort, Caption | r/EarthPorn · Top: Today |
+| **Post** | S · M · L | Source, Subreddit or Multireddit, Sort, Caption | Popular · Hot |
+| **Feed** | M · L | Source, Subreddit or Multireddit, Sort, Compact | Popular · Hot |
+| **Photo** | S · M · L | Subreddit or Multireddit, Sort, Caption | r/EarthPorn · Top: Today |
 | **Shortcuts** | S · M · L | Source, Subreddits | curated / your list |
 | **Apollo Actions** | M | — (static) | fixed actions |
-| **Calendar** | S · M · L | Subreddit, Date Style, Show Title | r/EarthPorn · Top: Week (fixed) |
-| **Headline** | Lock (rect, inline) | Subreddit | r/worldnews · Hot |
+| **Calendar** | S · M · L | Subreddit or Multireddit, Date Style, Show Title | r/EarthPorn · Top: Week (fixed) |
+| **Headline** | Lock (rect, inline) | Subreddit or Multireddit | r/worldnews · Hot |
 
 Sizes: **S** = small (2×2), **M** = medium (4×2), **L** = large (4×4), **Lock**
 = Lock Screen / StandBy accessory slots. Any widget that supports **S** also
@@ -38,6 +38,35 @@ Paste it into **one** widget and the rest pick it up automatically — they all
 share the same stash and reload immediately. The field also accepts a bare
 Reddit client ID (your API key) instead of the full code. *Apollo Actions* and
 *Shortcuts* (with letter avatars) need no setup code at all.
+
+When an API-key account is signed in, the button asks whether to **include
+your account**. That code additionally carries the account's OAuth refresh
+token, which is what lets the widgets read **Home** and your **private
+multireddits** (the app-only key can only see public listings). It's the same
+paste-once flow — a with-account code pasted into any widget upgrades every
+widget, and the plain codes still sitting in other widgets' fields don't
+downgrade it. Public sources keep using the app-only token, so a revoked
+account never breaks r/aww. The code includes your login — don't share it.
+Keyless (web-session) accounts have no refresh token, so they get the plain code.
+
+### Feed sources (Feed, Post, Photo, Headline, Calendar)
+The **Subreddit or Multireddit** field accepts everything people actually type
+or paste; Feed and Post also have a **Source** picker (Home / Popular / All /
+Subreddit or Multireddit) for the built-in feeds.
+
+| You type | You get |
+|---|---|
+| `soccer`, `r/soccer`, `https://reddit.com/r/soccer/top` | r/soccer |
+| `soccer+nba`, `soccer, nba`, `r/soccer r/nba` | the combined r/soccer+nba listing |
+| `home`, `popular`, `all` (or the Source picker) | the built-in feeds |
+| `https://reddit.com/user/foo/m/bar`, `u/foo/m/bar` | foo's multireddit (public, or yours) |
+| `m/bar`, `/me/m/bar` | your own multireddit |
+| `bar` — when it's the name of one of your multireddits | your own multireddit (`r/bar` forces the subreddit) |
+
+Home and your own multireddits need the with-account setup code; the widget
+says so ("Sign in for this feed") instead of failing quietly. The Feed header
+shows the source ("Home", "r/soccer+nba", "m/bar") and tapping it opens that
+feed in Apollo.
 
 ### Sort options
 Where a widget exposes **Sort**: **Hot**, **New**, **Top: Today**, **Top: This
@@ -95,31 +124,35 @@ purple gradient.
   tap to open Apollo for the punchline.
 
 ### Post
-The top post from a subreddit you choose. Adapts to content: image posts get a
-full-bleed photo with a title scrim; text/self posts render title + body on the
-gradient.
+The top post from a subreddit, multireddit, or feed you choose. Adapts to
+content: image posts get a full-bleed photo with a title scrim; text/self posts
+render title + body on the gradient.
 - **Sizes:** Small, Medium, Large.
-- **Config:** Setup Code · **Subreddit** (default `popular`) · **Sort** (default
-  Hot) · **Caption** (default Title + Stats).
+- **Config:** Setup Code · **Source** (Home / Popular / All / Subreddit or
+  Multireddit) · **Subreddit or Multireddit** (default `popular`) · **Sort**
+  (default Hot) · **Caption** (default Title + Stats).
 - **How it works:** fetches the top ~50, rotates through them, ↻ for the next,
   tap opens the post in Apollo.
 
 ### Feed
-A scrolling-style list of a subreddit's top posts, each row linking to its post.
+A scrolling-style list of a feed's top posts — a subreddit, several subreddits,
+a multireddit, or your Home feed — each row linking to its post.
 - **Sizes:** Medium, Large.
-- **Config:** Setup Code · **Subreddit** (default `popular`) · **Sort** (default
-  Hot) · **Compact** (default off — hides thumbnails and fits more rows).
+- **Config:** Setup Code · **Source** (Home / Popular / All / Subreddit or
+  Multireddit) · **Subreddit or Multireddit** (default `popular`) · **Sort**
+  (default Hot) · **Compact** (default off — hides thumbnails and fits more rows).
 - **How it works:** fetches the top ~12; the row count fits the widget height
   (a Medium shows ~2–3, a Large fills by device size). ↻ reloads. Thumbnails on
-  the trailing edge unless Compact is on.
+  the trailing edge unless Compact is on. The header names the source and
+  opens it in Apollo.
 
 ### Photo
 A full-bleed top image from a subreddit, minimal chrome — great as a rotating
 art/photography frame.
 - **Sizes:** Small, Medium, Large.
-- **Config:** Setup Code · **Subreddit** (default `EarthPorn`) · **Sort**
-  (default Top: Today) · **Caption** (default Title; choose **None** for a clean
-  image).
+- **Config:** Setup Code · **Subreddit or Multireddit** (default `EarthPorn`) ·
+  **Sort** (default Top: Today) · **Caption** (default Title; choose **None** for
+  a clean image).
 - **How it works:** image posts only, top ~25, rotates, ↻ for the next, subtle
   vignette, StandBy night dim, tap opens the post.
 
@@ -147,8 +180,9 @@ mascot) plus four tiles — **Home** (front-page feed), **Popular**, **All**,
 One **locked photo of the day** from a subreddit with the date overlaid — a
 photo by day, a clean date display by night.
 - **Sizes:** Small, Medium, Large.
-- **Config:** Setup Code · **Subreddit** (default `EarthPorn`) · **Date Style**
-  · **Show Title** (default off). Sort is fixed to Top: This Week (best image).
+- **Config:** Setup Code · **Subreddit or Multireddit** (default `EarthPorn`) ·
+  **Date Style** · **Show Title** (default off). Sort is fixed to Top: This Week
+  (best image).
 - **Date styles** (each a distinct system font):
   - **Rounded** – SF Pro Rounded, big friendly day number.
   - **Serif** – New York, editorial masthead with a hairline rule.
@@ -165,7 +199,7 @@ photo by day, a clean date display by night.
 The top headline from a subreddit, on your Lock Screen — a rotating ticker of
 what's hot.
 - **Sizes:** Lock Screen only (Rectangular, Inline).
-- **Config:** Setup Code · **Subreddit** (default `worldnews`).
+- **Config:** Setup Code · **Subreddit or Multireddit** (default `worldnews`).
 - **How it works:** fetches the current top ~10 (Hot) and rotates through their
   titles; tap opens the post in Apollo. Text-only, like all Lock-Screen widgets.
 

--- a/widgets/WIDGETS.md
+++ b/widgets/WIDGETS.md
@@ -43,11 +43,16 @@ When an API-key account is signed in, the button asks whether to **include
 your account**. That code additionally carries the account's OAuth refresh
 token, which is what lets the widgets read **Home** and your **private
 multireddits** (the app-only key can only see public listings). It's the same
-paste-once flow — a with-account code pasted into any widget upgrades every
-widget, and the plain codes still sitting in other widgets' fields don't
-downgrade it. Public sources keep using the app-only token, so a revoked
-account never breaks r/aww. The code includes your login — don't share it.
-Keyless (web-session) accounts have no refresh token, so they get the plain code.
+paste-once flow, and **the most recently copied code wins everywhere**: paste a
+with-account code into any widget and every widget gains the account; copy a
+plain code later and paste it into any widget and every widget drops the
+account again (its cached posts, rotation, Calendar picks and token are
+forgotten with it). Older codes still sitting in other widgets' fields never
+drag the shared code back. Public sources keep using the app-only token, so a
+revoked account never breaks r/aww. Home and multireddit caches are kept per
+account, so switching accounts never shows the previous account's posts. The
+code includes your login — don't share it. Keyless (web-session) accounts have
+no refresh token, so they get the plain code.
 
 ### Feed sources (Feed, Post, Photo, Headline, Calendar)
 The **Subreddit or Multireddit** field accepts everything people actually type


### PR DESCRIPTION
Closes #472

The Feed and Post widgets get a **Source** picker (Home / Popular / All / Subreddit or Multireddit), and the subreddit field on every content widget (Feed, Post, Photo, Headline, Calendar) now takes a lot more than a single sub name:

- `soccer`, `r/soccer`, or a pasted reddit link
- several subs: `soccer+nba`, `soccer, nba`, `r/soccer r/nba` (reddit's a+b listing)
- `home`, `popular`, `all` typed in also work
- multireddits: a pasted link (`reddit.com/user/foo/m/bar`), `u/foo/m/bar`, `m/bar` for your own, or just the multi's name if it's one of yours (`r/name` forces the sub if there's a clash)

| | |
|---|---|
| <img src="https://github.com/user-attachments/assets/291a4387-8e51-42fc-b165-2b8eb33acce1" width="330" alt="Feed widget showing the Home feed"><br>**Home feed in the Feed widget.** Source set to Home with the with-account code, so the widget shows your own subscriptions instead of r/popular. | <img src="https://github.com/user-attachments/assets/d0c6a281-c9a9-44f9-afb8-c204b1543449" width="330" alt="Copy with or without account"><br>**New setup code sheet.** Copy Widget Setup Code now asks if you want your account included. With account is what unlocks Home and your private multireddits. |
| <img src="https://github.com/user-attachments/assets/4ef9817f-4d0e-48d8-8db8-a9add45dedcc" width="330" alt="Several subreddits typed with commas"><br>**Several subreddits at once.** Type them with commas (`soccer, nba`) and the widget reads reddit's combined r/soccer+nba listing. | <img src="https://github.com/user-attachments/assets/18233530-921f-4aae-a8e7-75406992d26e" width="330" alt="Multireddit link pasted into the widget"><br>**Multireddit links.** Paste a multireddit link (or `m/name` for one of your own) and the widget reads that multi. |


Home and your own multireddits need the account since the app-only token can't see them. So **Copy Widget Setup Code** now asks "with account" or "without" when an api key account is signed in. The with-account code carries the account's oauth refresh token (v2 code, older widget builds just ignore the extra keys) and the widget mints its own user token from it. I checked that reddit doesn't rotate refresh tokens on use, so the widget never logs the app out. Public stuff keeps using the app-only token like before, so a revoked account doesn't take r/aww down with it. Keyless (web session) accounts have no refresh token so they get the plain code as before.

Paste-once still works, and **the most recently copied code wins everywhere**: every code now carries the time it was copied, so pasting a newer code into any widget (with account, without, or for another account) replaces the shared code for all of them, and the older codes still sitting in the other widgets' fields never drag it back. That's also how you remove the account again: copy "without account" and paste it into any widget, and the widgets drop that account's cached posts, rotation, calendar picks, multi names and token along with it. Codes from older tweak builds have no timestamp, they still work in their own widget but never replace a dated one.

Home and own-multireddit caches are kept per account (`feed.home@<account>` style keys, same for the rotation offsets and the Calendar's daily picks), so switching accounts can never surface the previous account's posts from an offline fallback or snapshot.

Other bits:
- the Feed header shows the source (Home / r/soccer+nba / m/bar) and tapping it opens that feed in apollo
- a "Sign in for this feed" state when a source needs the account and the code doesn't have it
- web app (confidential) api keys: the code now includes the client secret so the widget's token requests don't 401
- an auto-capitalized code ("EyJ...") is tolerated if someone types one in instead of pasting
- docs updated in widgets/WIDGETS.md

Tested in the sim (iOS 26.5) with the api key account: Home, own private multi by bare name (`nintendo` → m/Nintendo), `r/nintendo` forcing the sub, `soccer, nba` → r/Soccer+nba, a pasted public multi link, `m/apolloreborn` on a Post widget with a blank setup code (shared stash), the no-account prompt, and the header link opening Home in apollo. Widget Release build and the device tweak build both pass. Device test still pending.


