### PR TITLE
iPad panes 1/4: opt-in containers and detail routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloListBottomInsetGuard.xm \
     $(SRC_DIR)/ApolloTabBarHideStyle.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
+    $(SRC_DIR)/ipad/ApolloPaneLayout.m \
+    $(SRC_DIR)/ipad/ApolloPaneSplitViewController.m \
+    $(SRC_DIR)/ipad/ApolloPaneInstall.xm \
+    $(SRC_DIR)/ipad/ApolloPaneRouter.xm \
     $(SRC_DIR)/ApolloScrollEdgeEffect.xm \
     $(SRC_DIR)/ApolloProgressiveBlur.xm \
     $(SRC_DIR)/settings/ApolloSettings.xm \

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -281,12 +281,11 @@ static BOOL ApolloNavWantsNativeTabBarMinimize(UINavigationController *nav) {
 static BOOL ApolloTabBarControllerWantsNativeMinimize(UITabBarController *tbc) {
     if (!tbc) return NO;
     for (UIViewController *child in tbc.viewControllers) {
-        UINavigationController *nav = nil;
-        if ([child isKindOfClass:[UINavigationController class]]) {
-            nav = (UINavigationController *)child;
-        }
-        if (nav && ApolloNavWantsNativeTabBarMinimize(nav)) {
-            return YES;
+        // Every column, not just one: with the iPad pane layout a tab holds
+        // more than one navigation controller, and any of them wanting the
+        // native minimize behavior is enough.
+        for (UINavigationController *nav in ApolloAllNavigationControllersForTabChild(child)) {
+            if (ApolloNavWantsNativeTabBarMinimize(nav)) return YES;
         }
     }
     return NO;

--- a/src/ApolloBadgeBookViewController.m
+++ b/src/ApolloBadgeBookViewController.m
@@ -1401,6 +1401,12 @@ static UIViewController *ApolloBBSimContentVC(void) {
     while (1) {
         if ([vc isKindOfClass:[UITabBarController class]]) vc = ((UITabBarController *)vc).selectedViewController;
         else if ([vc isKindOfClass:[UINavigationController class]]) vc = ((UINavigationController *)vc).topViewController;
+        // The iPad pane layout inserts a split view controller under each tab.
+        else if ([vc isKindOfClass:[UISplitViewController class]]) {
+            UIViewController *column = ApolloContentColumnForSplitViewController((UISplitViewController *)vc);
+            if (!column || column == vc) break;
+            vc = column;
+        }
         else break;
     }
     return vc;

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -169,6 +169,53 @@ BOOL ApolloNavTransitionInFlight(void);
 // UI is still coming up (e.g. cold launch from a URL) — callers should retry.
 UIViewController *ApolloMainTabBarController(void);
 
+// The navigation controller holding a tab's root stack.
+//
+// In the stock layout this is the identity function — a UITabBarController's
+// child IS the navigation controller. With the experimental iPad pane layout
+// active (src/ipad/), that child is a UISplitViewController instead, and this
+// unwraps it to the primary column's navigation controller.
+//
+// Use this anywhere you would have written `tabBarController.viewControllers[i]`
+// or `tabBarController.selectedViewController` and then cast to
+// UINavigationController. Returns nil when there is no navigation controller to
+// find. Safe on iPhone, where it can only ever take the identity path.
+UINavigationController *ApolloNavigationControllerForTabChild(UIViewController *child);
+
+// Every navigation controller inside a tab child, primary column first: one
+// element in the stock layout, up to two with the pane layout. For callers that
+// WALK stacks looking for a particular controller, rather than picking one to
+// push onto — those would otherwise miss whatever sits in the detail column.
+NSArray<UINavigationController *> *ApolloAllNavigationControllersForTabChild(UIViewController *child);
+
+// The column a "what is the user looking at" walk should descend into.
+//
+// Every recursive visible-controller finder in the tweak knows how to unwrap a
+// navigation controller and a tab bar controller; without this, a split view
+// controller falls through and the walk stops on the container itself, which is
+// never a content screen. Returns the detail column when it holds real content,
+// otherwise the primary column.
+//
+// ApolloCommon deliberately does not import src/ipad/: the pane controller
+// answers `apollo_preferredContentColumnController`, and this falls back to a
+// positional lookup for any other split view controller.
+UIViewController *ApolloContentColumnForSplitViewController(UISplitViewController *split);
+
+// YES when `ancestor` is `descendant`, or contains it anywhere in its view
+// controller containment tree.
+BOOL ApolloViewControllerContains(UIViewController *ancestor, UIViewController *descendant);
+
+// Selects the tab that contains `descendant`, and returns whether one was found.
+//
+// Use instead of assigning `tabBarController.selectedViewController` directly
+// whenever the controller you have is a navigation controller you found inside
+// a tab. In the stock layout the tab's child IS that navigation controller, so
+// the two are equivalent; under the iPad pane layout the child is a split view
+// controller and the direct assignment silently does nothing, because the
+// navigation controller is no longer in `viewControllers`.
+BOOL ApolloSelectTabContainingViewController(UITabBarController *tabBarController,
+                                             UIViewController *descendant);
+
 // Returns YES for Apple's out-of-process share/compose controllers that the
 // tweak must never traverse or mutate. Their class names end in
 // "ComposeViewController" (e.g. MFMessageComposeViewController), so loose

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1334,6 +1334,115 @@ UIViewController *ApolloMainTabBarController(void) {
     return ApolloTabBarControllerIvarOn(application.delegate);
 }
 
+// Deliberately implemented with plain UIKit rather than by asking the pane
+// module: ApolloCommon is included by nearly every file, and a dependency on
+// src/ipad/ would drag the iPad layout into translation units that must stay
+// free of it. Class-shape matching is enough — no gate check is needed, because
+// a tab child is only ever a split view controller when the layout installed.
+static UINavigationController *ApolloNavigationControllerForSplitColumn(UISplitViewController *split,
+                                                                        UISplitViewControllerColumn column) {
+    UIViewController *columnController = nil;
+    if ([split respondsToSelector:@selector(viewControllerForColumn:)]) {
+        @try {
+            columnController = [split viewControllerForColumn:column];
+        } @catch (NSException *exception) {
+            ApolloLog(@"[Common] viewControllerForColumn: threw on %@: %@", split, exception);
+        }
+    }
+    // A split controller built with the legacy `viewControllers` API answers nil
+    // for every column. Fall back to positional lookup so such a controller
+    // still resolves instead of silently returning nothing.
+    if (!columnController) {
+        NSArray<UIViewController *> *children = split.viewControllers;
+        NSUInteger index = (column == UISplitViewControllerColumnSecondary) ? 1 : 0;
+        if (index < children.count) columnController = children[index];
+    }
+    return [columnController isKindOfClass:[UINavigationController class]]
+        ? (UINavigationController *)columnController
+        : nil;
+}
+
+BOOL ApolloViewControllerContains(UIViewController *ancestor, UIViewController *descendant) {
+    if (!ancestor || !descendant) return NO;
+    for (UIViewController *node = descendant; node != nil; node = node.parentViewController) {
+        if (node == ancestor) return YES;
+    }
+    return NO;
+}
+
+BOOL ApolloSelectTabContainingViewController(UITabBarController *tabBarController,
+                                             UIViewController *descendant) {
+    if (![tabBarController isKindOfClass:[UITabBarController class]] || !descendant) return NO;
+
+    // Climb to whichever ancestor is the tab bar controller's own child: that is
+    // the navigation controller itself in the stock layout, and the enclosing
+    // split view controller under the pane layout.
+    for (UIViewController *node = descendant; node != nil; node = node.parentViewController) {
+        if (node.parentViewController == tabBarController) {
+            tabBarController.selectedViewController = node;
+            return YES;
+        }
+    }
+    ApolloLog(@"[Common] %@ is not inside any tab of %@; selection unchanged",
+              NSStringFromClass([descendant class]), NSStringFromClass([tabBarController class]));
+    return NO;
+}
+
+UIViewController *ApolloContentColumnForSplitViewController(UISplitViewController *split) {
+    if (![split isKindOfClass:[UISplitViewController class]]) return split;
+
+    SEL preferred = NSSelectorFromString(@"apollo_preferredContentColumnController");
+    if ([split respondsToSelector:preferred]) {
+        @try {
+            UIViewController *column = ((UIViewController *(*)(id, SEL))objc_msgSend)(split, preferred);
+            if (column) return column;
+        } @catch (NSException *exception) {
+            ApolloLog(@"[Common] preferred content column threw on %@: %@", split, exception);
+        }
+    }
+
+    // Any other split view controller: the trailing column is the detail one.
+    UIViewController *fallback = split.viewControllers.lastObject ?: split.viewControllers.firstObject;
+    return fallback ?: split;
+}
+
+UINavigationController *ApolloNavigationControllerForTabChild(UIViewController *child) {
+    if (!child) return nil;
+    if ([child isKindOfClass:[UINavigationController class]]) return (UINavigationController *)child;
+    if ([child isKindOfClass:[UISplitViewController class]]) {
+        return ApolloNavigationControllerForSplitColumn((UISplitViewController *)child,
+                                                        UISplitViewControllerColumnPrimary);
+    }
+    // Not a container we recognize — fall back to the controller's own
+    // navigation controller, which covers a plain view controller hosted
+    // directly in a tab.
+    return child.navigationController;
+}
+
+NSArray<UINavigationController *> *ApolloAllNavigationControllersForTabChild(UIViewController *child) {
+    if (!child) return @[];
+
+    if ([child isKindOfClass:[UISplitViewController class]]) {
+        UISplitViewController *split = (UISplitViewController *)child;
+        NSMutableArray<UINavigationController *> *navs = [NSMutableArray arrayWithCapacity:3];
+        const UISplitViewControllerColumn columns[] = {
+            UISplitViewControllerColumnPrimary,
+            UISplitViewControllerColumnSupplementary,
+            UISplitViewControllerColumnSecondary,
+        };
+        for (size_t i = 0; i < sizeof(columns) / sizeof(columns[0]); i++) {
+            UINavigationController *nav = ApolloNavigationControllerForSplitColumn(split, columns[i]);
+            // A two-column install answers the same controller for more than one
+            // column; de-duplicate so walkers do not visit a stack twice.
+            if (nav && ![navs containsObject:nav]) [navs addObject:nav];
+        }
+        return navs;
+    }
+
+    UINavigationController *nav = ApolloNavigationControllerForTabChild(child);
+    return nav ? @[ nav ] : @[];
+}
+
 #pragma mark - Color Helpers
 
 UIColor *ApolloColorFromHexString(NSString *hex) {

--- a/src/ApolloDirectChatWeb.xm
+++ b/src/ApolloDirectChatWeb.xm
@@ -904,7 +904,10 @@ static BOOL ApolloReturnToMailboxFromNavigationController(UINavigationController
 
     ApolloClearMailboxReturn(navigationController);
     [mailbox apollo_prepareForMailboxReturnAnimated:NO];
-    tabBarController.selectedViewController = mailboxNavigationController;
+    // Selects by containment: under the iPad pane layout the mailbox's
+    // navigation controller is a split view column, not a tab child, so a
+    // direct selectedViewController assignment would silently do nothing.
+    ApolloSelectTabContainingViewController(tabBarController, mailboxNavigationController);
     ApolloLog(@"[DirectChatWeb] Native Back returned to preserved %@ without mutating Inbox navigation",
               mailbox.mailboxKind == ApolloModernMailboxKindModmail ? @"Modmail" : @"Chat");
     return YES;
@@ -3166,10 +3169,11 @@ static NSTimeInterval ApolloChatStaleRefreshThreshold(void) {
         UITabBarController *tabBarController = self.tabBarController;
         UINavigationController *routingNavigationController = nil;
         for (UIViewController *candidate in tabBarController.viewControllers) {
-            if (candidate == mailboxNavigationController ||
-                ![candidate isKindOfClass:[UINavigationController class]]) continue;
-            routingNavigationController = (UINavigationController *)candidate;
-            break;
+            // Skip the tab holding this mailbox, whether the child IS its
+            // navigation controller (stock) or merely contains it (pane layout).
+            if (ApolloViewControllerContains(candidate, mailboxNavigationController)) continue;
+            routingNavigationController = ApolloNavigationControllerForTabChild(candidate);
+            if (routingNavigationController) break;
         }
 
         if (routingNavigationController) {
@@ -3178,15 +3182,14 @@ static NSTimeInterval ApolloChatStaleRefreshThreshold(void) {
             // before selecting it; returning to this mailbox reapplies the
             // current room/list state through apollo_prepareForMailboxReturn.
             [self apollo_restoreTabBarVisibility];
-            tabBarController.selectedViewController = routingNavigationController;
+            ApolloSelectTabContainingViewController(tabBarController, routingNavigationController);
         }
 
         UIViewController *routingAnchorBeforeOpen = routingNavigationController.topViewController;
         if (routingNavigationController && ApolloRouteResolvedURLViaApolloScheme(url)) {
             UINavigationController *destinationNavigationController =
-                [tabBarController.selectedViewController isKindOfClass:[UINavigationController class]]
-                    ? (UINavigationController *)tabBarController.selectedViewController
-                    : routingNavigationController;
+                ApolloNavigationControllerForTabChild(tabBarController.selectedViewController)
+                    ?: routingNavigationController;
             UIViewController *destination = destinationNavigationController.topViewController;
             if (destinationNavigationController &&
                 destinationNavigationController != mailboxNavigationController && destination &&
@@ -3204,7 +3207,7 @@ static NSTimeInterval ApolloChatStaleRefreshThreshold(void) {
         // available. Return to the still-intact mailbox before presenting
         // Apollo's browser.
         if (mailboxNavigationController && tabBarController) {
-            tabBarController.selectedViewController = mailboxNavigationController;
+            ApolloSelectTabContainingViewController(tabBarController, mailboxNavigationController);
         }
         [self apollo_prepareForMailboxReturnAnimated:NO];
         ApolloPresentWebURLFromViewController(self, url);
@@ -3910,10 +3913,15 @@ static void ApolloStandaloneChatBackPanForgetHost(ApolloDirectChatWebViewControl
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
  shouldSelectViewController:(UIViewController *)viewController {
     for (UIViewController *candidate in tabBarController.viewControllers) {
-        if (![candidate isKindOfClass:[UINavigationController class]]) continue;
-        UINavigationController *navigationController = (UINavigationController *)candidate;
-        ApolloDirectChatWebViewController *mailbox = ApolloMailboxReturnController(navigationController);
-        if (mailbox && viewController == mailbox.navigationController) {
+        // Every column: with the iPad pane layout a tab holds more than one
+        // navigation controller, and the return marker can be on any of them.
+        for (UINavigationController *navigationController in ApolloAllNavigationControllersForTabChild(candidate)) {
+            ApolloDirectChatWebViewController *mailbox = ApolloMailboxReturnController(navigationController);
+            // `viewController` is the tab CHILD being selected — the split view
+            // controller under the pane layout — so compare by containment
+            // rather than identity against the mailbox's navigation controller.
+            if (!mailbox || !ApolloViewControllerContains(viewController, mailbox.navigationController)) continue;
+
             ApolloClearMailboxReturn(navigationController);
             [mailbox apollo_prepareForMailboxReturnAnimated:NO];
             ApolloLog(@"[DirectChatWeb] Inbox tab returned directly to preserved %@",

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -197,6 +197,11 @@ static UIViewController *ApolloRedditVisibleControllerFromController(UIViewContr
         UIViewController *selected = ((UITabBarController *)current).selectedViewController;
         if (selected) return ApolloRedditVisibleControllerFromController(selected);
     }
+    // The iPad pane layout inserts a split view controller under each tab.
+    if ([current isKindOfClass:[UISplitViewController class]]) {
+        UIViewController *column = ApolloContentColumnForSplitViewController((UISplitViewController *)current);
+        if (column && column != current) return ApolloRedditVisibleControllerFromController(column);
+    }
     return current;
 }
 

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -293,8 +293,9 @@ static void OpenAccountManager(void) {
     UIViewController *profileVC = nil;
     if (tabBarController) {
         for (UIViewController *vc in tabBarController.viewControllers) {
-            if ([vc isKindOfClass:[UINavigationController class]]) {
-                UINavigationController *navController = (UINavigationController *)vc;
+            // Every column: with the iPad pane layout the profile screen can sit
+            // in either the primary or the detail stack.
+            for (UINavigationController *navController in ApolloAllNavigationControllersForTabChild(vc)) {
                 // Search through the entire navigation stack, not just topViewController
                 for (UIViewController *stackVC in navController.viewControllers) {
                     if ([stackVC isMemberOfClass:profileVCClass]) {
@@ -303,7 +304,9 @@ static void OpenAccountManager(void) {
                     }
                 }
                 if (profileVC) break;
-            } else if ([vc isMemberOfClass:profileVCClass]) {
+            }
+            if (profileVC) break;
+            if ([vc isMemberOfClass:profileVCClass]) {
                 profileVC = vc;
                 break;
             }

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -272,12 +272,14 @@ static BOOL PiPIsVideoMidpointVisible(id videoNode, id cellNode) {
         if (tab.tabBar.window) {
             bottomY -= tab.tabBar.bounds.size.height;
         }
-        UIViewController *selected = tab.selectedViewController;
-        if ([selected isKindOfClass:[UINavigationController class]]) {
-            UINavigationBar *navBar = ((UINavigationController *)selected).navigationBar;
-            if (navBar.window) {
-                topY = CGRectGetMaxY([navBar convertRect:navBar.bounds toView:nil]);
-            }
+        // Unwraps the iPad pane layout's split view controller; identity
+        // otherwise. Any column's bar gives the same top inset — they are laid
+        // out at the same y — so the primary column's is enough.
+        UINavigationController *selectedNav =
+            ApolloNavigationControllerForTabChild(tab.selectedViewController);
+        UINavigationBar *navBar = selectedNav.navigationBar;
+        if (navBar.window) {
+            topY = CGRectGetMaxY([navBar convertRect:navBar.bounds toView:nil]);
         }
     }
 

--- a/src/ApolloQuickActions.xm
+++ b/src/ApolloQuickActions.xm
@@ -93,12 +93,10 @@ static BOOL ApolloQuickActionsOpenHomeFeed(id tabBarController) {
     }
 
     UIViewController *selected = [(UITabBarController *)tabBarController selectedViewController];
-    UINavigationController *nav = nil;
-    if ([selected isKindOfClass:UINavigationController.class]) {
-        nav = (UINavigationController *)selected;
-    } else if ([selected.navigationController isKindOfClass:UINavigationController.class]) {
-        nav = selected.navigationController;
-    }
+    // Unwraps the iPad pane layout's split view controller; identity otherwise.
+    // The Home tab's root list lives in the primary column, which is what the
+    // RedditListViewController assertion below expects.
+    UINavigationController *nav = ApolloNavigationControllerForTabChild(selected);
     if (!nav) {
         ApolloLog(@"[QuickActions] Home: no navigation controller for selected tab %@", selected);
         return NO;
@@ -198,12 +196,8 @@ static BOOL ApolloQuickActionsOpenModernMailboxNow(NSDictionary<NSString *, NSSt
 
     if (![tabBarController isKindOfClass:[UITabBarController class]]) return NO;
     UIViewController *selected = [(UITabBarController *)tabBarController selectedViewController];
-    UINavigationController *navigationController = nil;
-    if ([selected isKindOfClass:[UINavigationController class]]) {
-        navigationController = (UINavigationController *)selected;
-    } else if ([selected.navigationController isKindOfClass:[UINavigationController class]]) {
-        navigationController = selected.navigationController;
-    }
+    // Unwraps the iPad pane layout's split view controller; identity otherwise.
+    UINavigationController *navigationController = ApolloNavigationControllerForTabChild(selected);
     if (!navigationController) return NO;
 
     NSString *kind = route[@"kind"];

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -188,6 +188,12 @@ void ApolloRestoreHideOnScrollPresentation(UITabBarController *tabBarController,
 // bottom (classic) instead of the top-center pill. Opt-in; default OFF via
 // registerDefaults. Temporary stopgap for issue #387. See ApolloIPadTabBarBottom.xm.
 extern BOOL sIPadTabBarBottom;
+// iPad only. When ON, each tab's navigation stack is hosted inside a
+// multi-column UISplitViewController (sidebar → content → detail) instead of a
+// single full-width stack. Opt-in; default OFF via registerDefaults
+// (UDKeyIPadPaneLayout). Read once at %ctor — installation happens at scene
+// connect, so changing it needs a relaunch. See src/ipad/ApolloPaneLayout.h.
+extern BOOL sIPadPaneLayout;
 // When ON, neutralizes Apollo's feed/subreddit search takeover (nav-hide + fade + toolbar
 // dock/grow); the field stays put and results populate the feed in place. Liquid Glass only;
 // mutually exclusive with the default nav-hide mode. See ApolloSearchInPlace.xm.

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -63,6 +63,7 @@ NSString *const ApolloTabBarScrollBehaviorChangedNotification = @"ApolloTabBarSc
 BOOL sClassicTabBarScrollBehavior = NO;
 ApolloTabBarHideStyle sTabBarHideStyle = ApolloTabBarHideStyleLeft;
 BOOL sIPadTabBarBottom = NO;   // opt-in (default OFF via registerDefaults, UDKeyIPadTabBarBottom); iPad-gated in the module
+BOOL sIPadPaneLayout = NO;     // opt-in (default OFF via registerDefaults, UDKeyIPadPaneLayout); iPad-gated, relaunch to apply
 BOOL sKeepSearchBarInPlace = NO;
 BOOL sLGTitleGapCentering = YES;   // effective default ON via registerDefaults (UDKeyLGTitleGapCentering)
 BOOL sIconRowMagnifier = YES;   // effective default ON via registerDefaults (UDKeyIconRowMagnifier)

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -3452,8 +3452,9 @@ static NSString *ApolloProfileTabUsernameForController(UITabBarController *tabBa
     if (controllers.count <= ApolloProfileTabIndex) return nil;
 
     UIViewController *profileChild = controllers[ApolloProfileTabIndex];
-    if ([profileChild isKindOfClass:[UINavigationController class]]) {
-        UINavigationController *nav = (UINavigationController *)profileChild;
+    // Every column: with the iPad pane layout a profile can be open in the
+    // primary stack, the detail stack, or both.
+    for (UINavigationController *nav in ApolloAllNavigationControllersForTabChild(profileChild)) {
         for (UIViewController *candidate in nav.viewControllers) {
             if (!ApolloViewControllerLooksProfileRelated(candidate)) continue;
             NSString *username = ApolloUsernameFromProfileViewController(candidate);

--- a/src/ApolloVisionOSMultiwindow.xm
+++ b/src/ApolloVisionOSMultiwindow.xm
@@ -289,10 +289,15 @@ static NSURL *ApolloActiveDeepLink(void) {
 // handler gates its webpageURL branch on.
 static void ApolloDeliverURLToScene(UIWindowScene *scene, NSURL *url) {
     id<UISceneDelegate> delegate = scene.delegate;
-    if (![delegate respondsToSelector:@selector(scene:continueUserActivity:)]) return;
+    if (![delegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
+        ApolloLog(@"[VisionOSMultiwindow] new scene's delegate (%@) has no continueUserActivity:; "
+                  @"window opens without the target", NSStringFromClass([delegate class]));
+        return;
+    }
     NSUserActivity *activity =
         [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
     activity.webpageURL = url;
+    ApolloLog(@"[VisionOSMultiwindow] handing %@ to the new scene", url.absoluteString);
     [delegate scene:scene continueUserActivity:activity];
 }
 
@@ -300,7 +305,11 @@ static void ApolloDeliverURLToScene(UIWindowScene *scene, NSURL *url) {
 // deliver once its UI is up. A scene-activation notification observer proved
 // unreliable; polling connectedScenes cannot miss.
 static void ApolloAwaitNewScene(NSHashTable<UIScene *> *existing, NSURL *url, int attemptsLeft) {
-    if (attemptsLeft <= 0) return;
+    if (attemptsLeft <= 0) {
+        ApolloLog(@"[VisionOSMultiwindow] no new scene appeared within 8s; %@ not delivered",
+                  url.absoluteString);
+        return;
+    }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
         for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
@@ -510,6 +519,9 @@ static void ApolloStartWindowButton(void) {
     }];
 }
 
+// visionOS ONLY. This was briefly extended to iPad as an answer to "a fourth
+// tiled column will not fit, so use separate windows instead" — reverted at the
+// user's request. iPad is a strict no-op again, exactly as before.
 %ctor {
     if (!ApolloIsRunningOnVisionOS()) return;
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3778,6 +3778,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
                                     UDKeyKeepSearchBarInPlace: @NO,
                                     UDKeyLGTitleGapCentering: @YES,
                                     UDKeyIPadTabBarBottom: @NO,
+                                    UDKeyIPadPaneLayout: @NO,
                                     UDKeyIconRowMagnifier: @YES,
                                     UDKeyInfoRowTapUpvote: @YES,
                                     UDKeyInfoRowTapComments: @YES,
@@ -4051,6 +4052,9 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
     sKeepSearchBarInPlace = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyKeepSearchBarInPlace];
     sLGTitleGapCentering = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyLGTitleGapCentering];
     sIPadTabBarBottom = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIPadTabBarBottom];
+    // Read once here: ApolloPaneInstall.xm builds the split controllers during
+    // scene connect, which happens after %ctor and never again for the process.
+    sIPadPaneLayout = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIPadPaneLayout];
     sIconRowMagnifier = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIconRowMagnifier];
     sInfoRowTapUpvote = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyInfoRowTapUpvote];
     sInfoRowTapComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyInfoRowTapComments];
@@ -4465,7 +4469,16 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
             UITabBarController *tabBarController = (UITabBarController *)mainWindow.rootViewController;
             // Navigate to Settings tab
             tabBarController.selectedViewController = [tabBarController.viewControllers lastObject];
-            UINavigationController *settingsNavController = (UINavigationController *) tabBarController.selectedViewController;
+            // The selected child is the navigation controller in the stock
+            // layout, but a UISplitViewController under the iPad pane layout —
+            // unwrap rather than casting, or this push hits the split
+            // controller and throws.
+            UINavigationController *settingsNavController =
+                ApolloNavigationControllerForTabChild(tabBarController.selectedViewController);
+            if (!settingsNavController) {
+                ApolloLog(@"[Tweak] no navigation controller for the settings tab; skipping Custom API redirect");
+                return;
+            }
 
             // Push Custom API directly
             CustomAPIViewController *vc = [[CustomAPIViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];

--- a/src/UIWindow+Apollo.m
+++ b/src/UIWindow+Apollo.m
@@ -1,4 +1,5 @@
 #import "UIWindow+Apollo.h"
+#import "ApolloCommon.h"   // ApolloContentColumnForSplitViewController
 
 // https://stackoverflow.com/a/21848247
 @implementation UIWindow (Apollo)
@@ -12,6 +13,12 @@
         return [UIWindow getVisibleViewControllerFrom:[((UINavigationController *) vc) visibleViewController]];
     } else if ([vc isKindOfClass:[UITabBarController class]]) {
         return [UIWindow getVisibleViewControllerFrom:[((UITabBarController *) vc) selectedViewController]];
+    } else if ([vc isKindOfClass:[UISplitViewController class]]) {
+        // The iPad pane layout puts a split view controller between the tab bar
+        // and the navigation stacks. Without this branch the walk stops on the
+        // container and every caller gets a shell instead of a content screen.
+        return [UIWindow getVisibleViewControllerFrom:
+                    ApolloContentColumnForSplitViewController((UISplitViewController *) vc)];
     } else {
         if (vc.presentedViewController) {
             return [UIWindow getVisibleViewControllerFrom:vc.presentedViewController];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -265,6 +265,14 @@ static NSString *const UDKeyLGTitleGapCentering = @"LGTitleGapCentering";
 // real iPad build lands. Opt-in; default OFF via registerDefaults. See ApolloIPadTabBarBottom.xm.
 static NSString *const UDKeyIPadTabBarBottom = @"IPadTabBarBottom";
 static NSString *const ApolloIPadTabBarBottomChangedNotification = @"ApolloIPadTabBarBottomChangedNotification";
+// iPad only. When ON, replaces each tab's single navigation stack with a
+// multi-column UISplitViewController: sidebar (the tab's own root list) →
+// content → detail. Opt-in; default OFF via registerDefaults. Installation
+// happens at scene connect, so a change needs a relaunch to apply — the
+// settings row confirms and restarts rather than pretending it is live.
+// Supersedes UDKeyIPadTabBarBottom while active (the floating pill is hidden).
+// See src/ipad/ and docs/ipad-pane-layout-plan.md.
+static NSString *const UDKeyIPadPaneLayout = @"IPadPaneLayout";
 // When ON, press-and-hold anywhere on a post info row (score, comments,
 // timestamp, 🌐 translation marker…) shows the glass-slider magnifier loupe: the
 // row is zoomed in a Liquid Glass card, sliding moves the selection pill

--- a/src/ipad/ApolloPaneInstall.xm
+++ b/src/ipad/ApolloPaneInstall.xm
@@ -1,0 +1,213 @@
+// ApolloPaneInstall.xm
+//
+// Installs the iPad pane layout by re-hosting each tab's navigation controller
+// inside an ApolloPaneSplitViewController.
+//
+// WHY HERE. Recovered from the binary (Hopper, Apollo 1.15.11): the scene
+// delegate's `scene:willConnectToSession:options:` is a thin shim over
+// sub_1000879c0, which builds the tab bar controller (sub_100087244, five
+// ApolloNavigationController children), assigns it to `window.rootViewController`,
+// stores it in the delegate's own `tabBarController` ivar, and calls
+// `makeKeyAndVisible`. The factory also calls `loadViewIfNeeded` and
+// `waitUntilAllUpdatesAreProcessed` on several roots, so Apollo pre-warms this
+// hierarchy synchronously — we must run strictly AFTER %orig and touch nothing
+// before it returns.
+//
+// WHAT IS PRESERVED. The tab bar controller keeps its identity, its class, its
+// index space and its position as the window's root. Only its `viewControllers`
+// array changes shape: each ApolloNavigationController becomes the primary
+// column of a pane controller instead of a direct child. That keeps the scene
+// delegate's `tabBarController` ivar valid, so ApolloMainTabBarController()
+// works untouched, and confines the hierarchy audit to one helper
+// (ApolloNavigationControllerForTabChild in ApolloCommon).
+//
+// Full design + RE notes: docs/ipad-pane-layout-plan.md
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import "../ApolloCommon.h"   // ApolloLog, ApolloMainTabBarController
+#import "../ApolloState.h"    // sIPadPaneLayout
+
+// Local alias for the Swift scene delegate; bound in %ctor via %init(...=objc_getClass).
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+@end
+
+// Wraps every navigation-controller child of `tabBarController` in a pane
+// controller. Returns YES only if at least one tab was converted — a total
+// failure leaves the stock hierarchy completely untouched, which is what makes
+// the feature fail safe rather than half-applied.
+static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarController) {
+    if (![tabBarController isKindOfClass:[UITabBarController class]]) {
+        ApolloLog(@"[PaneInstall] root is not a UITabBarController (%@); skipping",
+                  NSStringFromClass([tabBarController class]));
+        return NO;
+    }
+
+    NSArray<UIViewController *> *children = tabBarController.viewControllers;
+    if (children.count == 0) {
+        ApolloLog(@"[PaneInstall] tab bar controller has no children; skipping");
+        return NO;
+    }
+
+    NSMutableArray<UIViewController *> *converted = [NSMutableArray arrayWithCapacity:children.count];
+    NSUInteger wrapped = 0;
+
+    for (NSUInteger index = 0; index < children.count; index++) {
+        UIViewController *child = children[index];
+
+        // Anything that is not a navigation controller stays exactly as it is.
+        // Apollo ships five navigation controllers today, but an unexpected
+        // child must not be dropped from the tab bar.
+        if (![child isKindOfClass:[UINavigationController class]]) {
+            ApolloLog(@"[PaneInstall] tab %lu is %@, not a navigation controller; left as-is",
+                      (unsigned long)index, NSStringFromClass([child class]));
+            [converted addObject:child];
+            continue;
+        }
+
+        ApolloPaneSplitViewController *pane =
+            [ApolloPaneSplitViewController paneControllerWithRootNavigationController:(UINavigationController *)child
+                                                                            tabIndex:(NSInteger)index];
+        if (!pane) {
+            ApolloLog(@"[PaneInstall] tab %lu pane construction failed; left as-is", (unsigned long)index);
+            [converted addObject:child];
+            continue;
+        }
+
+        [converted addObject:pane];
+        wrapped++;
+    }
+
+    if (wrapped == 0) {
+        ApolloLog(@"[PaneInstall] no tabs converted; leaving stock hierarchy untouched");
+        return NO;
+    }
+
+    // Reassigning `viewControllers` resets the selection, so restore it. Read
+    // the index before the write: the setter clamps/zeroes it as a side effect.
+    NSUInteger selected = tabBarController.selectedIndex;
+    tabBarController.viewControllers = converted;
+    if (selected < converted.count) tabBarController.selectedIndex = selected;
+
+    // THE FIXED SIDEBAR.
+    //
+    // This one line is what makes the layout read as an iPad app rather than a
+    // stretched iPhone one. `mode = .tabSidebar` replaces the floating tab bar
+    // with UIKit's own sidebar: a single persistent list of destinations that is
+    // identical on every tab, with a system-drawn toggle back to the tab bar and
+    // the platform's own selection, hover, drag and keyboard behavior for free.
+    //
+    // It also removes a whole tier of competing chrome. Before this, the app
+    // showed a floating tab bar AND a per-tab sidebar column AND our own sidebar
+    // toggle button, three navigation surfaces stacked on one screen.
+    //
+    // VERIFIED, and worth recording because the documentation does not say so:
+    // this works with tabs that came from the LEGACY `viewControllers` array.
+    // Apollo never adopted the iOS 18 `tabs`/`UITab` API — it assigns five
+    // navigation controllers the old way — and UIKit still synthesizes the tab
+    // model and renders a full sidebar from them (confirmed on an iPad Pro 13"
+    // simulator: mode resolved to 2, a live UITabBarControllerSidebar, hidden=0,
+    // all five destinations listed with their titles, icons and inbox badge).
+    // Had this required `tabs`, the alternative would have been rebuilding
+    // Apollo's tab model by hand, which is a far larger and more fragile change.
+    //
+    // iOS 17 and earlier have no tab sidebar. Those keep the floating tab bar
+    // beside the two-column panes, which is a coherent, if less native, layout —
+    // the feature degrades rather than becoming unavailable.
+    if (@available(iOS 18.0, *)) {
+        tabBarController.mode = UITabBarControllerModeTabSidebar;
+        ApolloLog(@"[PaneInstall] tab sidebar on: mode=%ld sidebar=%@ hidden=%d",
+                  (long)tabBarController.mode,
+                  tabBarController.sidebar,
+                  tabBarController.sidebar ? tabBarController.sidebar.isHidden : -1);
+
+        // NOT ATTEMPTED AGAIN: `sidebar.preferredLayout`.
+        // -[UITabBarControllerSidebar _resolvedLayout] maps preferredLayout 0
+        // (automatic) to 1 on iPad, and 1 is the FLOATING glass card. Layout 2
+        // is what non-Solarium macOS and visionOS resolve to, so it looked like
+        // the attached-sidebar switch. Setting it is a no-op here: the sidebar
+        // stayed at (10,32,270,990) with its _UIDuoShadowView. The floating
+        // treatment on iPadOS 26 is not reachable through this property.
+    } else {
+        ApolloLog(@"[PaneInstall] iOS < 18: no tab sidebar; keeping the tab bar beside the panes");
+    }
+
+    ApolloLog(@"[PaneInstall] installed panes on %lu/%lu tabs (selected=%lu)",
+              (unsigned long)wrapped, (unsigned long)children.count, (unsigned long)selected);
+    return YES;
+}
+
+%group ApolloPaneInstallGroup
+
+%hook SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(id)session options:(id)options {
+    %orig;
+
+    // Re-check the gate here rather than trusting the %ctor decision alone: a
+    // second scene (Stage Manager, an external display) connects later, and the
+    // install must be idempotent per tab bar controller rather than per process.
+    if (!ApolloPaneLayoutEnabled()) return;
+
+    UITabBarController *tabBarController = nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable([self class], "tabBarController");
+        id value = ivar ? object_getIvar(self, ivar) : nil;
+        if ([value isKindOfClass:[UITabBarController class]]) tabBarController = value;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneInstall] reading tabBarController ivar threw: %@", exception);
+    }
+
+    // Fall back to the window's root: the ivar name is Swift-private and could
+    // be renamed by an Apollo update, but the root VC assignment is structural.
+    if (!tabBarController && [scene isKindOfClass:[UIWindowScene class]]) {
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if ([window.rootViewController isKindOfClass:[UITabBarController class]]) {
+                tabBarController = (UITabBarController *)window.rootViewController;
+                break;
+            }
+        }
+    }
+
+    if (!tabBarController) {
+        ApolloLog(@"[PaneInstall] no tab bar controller found for scene; pane layout not installed");
+        return;
+    }
+
+    // Idempotence: if this controller's children are already panes, a second
+    // pass would wrap the panes themselves.
+    if ([tabBarController.viewControllers.firstObject isKindOfClass:[ApolloPaneSplitViewController class]]) {
+        ApolloLog(@"[PaneInstall] panes already installed on this tab bar controller; skipping");
+        return;
+    }
+
+    if (ApolloPaneInstallIntoTabBarController(tabBarController)) {
+        ApolloPaneLayoutSetActive(YES);
+    }
+}
+
+%end
+
+%end
+
+%ctor {
+    // iPhone never loads any of this: the idiom check comes first, so the hook
+    // is not even installed on a device that can never run the pane layout.
+    if (!ApolloPaneLayoutSupported()) return;
+
+    if (!ApolloPaneLayoutEnabled()) {
+        ApolloLog(@"[PaneInstall] iPad detected, pane layout off (UDKeyIPadPaneLayout); hook not installed");
+        return;
+    }
+
+    Class sceneDelegateClass = objc_getClass("_TtC6Apollo13SceneDelegate");
+    if (!sceneDelegateClass) {
+        ApolloLog(@"[PaneInstall] Apollo.SceneDelegate class not found; pane layout unavailable");
+        return;
+    }
+
+    %init(ApolloPaneInstallGroup, SceneDelegate = sceneDelegateClass);
+    ApolloLog(@"[PaneInstall] scene delegate hook installed; awaiting scene connect");
+}

--- a/src/ipad/ApolloPaneLayout.h
+++ b/src/ipad/ApolloPaneLayout.h
@@ -1,0 +1,75 @@
+// ApolloPaneLayout.h
+//
+// Feature gate and shared vocabulary for the experimental iPad multi-column
+// ("pane") layout. Every other file under src/ipad/ gates on this one, and no
+// module outside src/ipad/ should read `sIPadPaneLayout` directly — see the
+// "enabled vs active" note below for why.
+//
+// Full design + RE notes: docs/ipad-pane-layout-plan.md
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+// C linkage: ApolloPaneInstall.xm is Objective-C++, so without this the
+// Objective-C definitions in the .m never match its references.
+__BEGIN_DECLS
+
+// Which column of the pane layout a view controller belongs in. The router
+// (ApolloPaneRouter) classifies pushed controllers into these; the split
+// controller maps them onto UISplitViewControllerColumn values.
+typedef NS_ENUM(NSInteger, ApolloPaneColumn) {
+    // The tab's own root list: subreddits, the search field, inbox mailboxes.
+    // In the current two-column install this is also where lists (feeds,
+    // search results) live.
+    ApolloPaneColumnPrimary = 0,
+    // Reserved for the three-column install, where feeds separate from the
+    // sidebar. Maps to `primary` until that lands so callers can be written
+    // once. See docs/ipad-pane-layout-plan.md §3.
+    ApolloPaneColumnSupplementary,
+    // Detail: comment threads, messages, subreddit sidebars.
+    ApolloPaneColumnSecondary,
+    // Not classified — push in place, exactly as the stock app does. This is
+    // the default for every controller the router does not explicitly know
+    // about, and is what keeps ~90 Apollo screens and every tweak-owned screen
+    // behaving as they do today.
+    ApolloPaneColumnInPlace,
+};
+
+// MARK: - Gate
+//
+// Three distinct questions, deliberately not collapsed into one:
+//
+//   Supported  — could this device ever run the pane layout? (iPad, immutable)
+//   Enabled    — did the user ask for it for THIS process? (read at %ctor)
+//   Active     — did installation actually succeed and is it live right now?
+//
+// Modules must gate on Active. The user default is what the user wants at the
+// NEXT launch: it changes the moment they flip the switch, while the running
+// process still has whatever layout it installed at scene connect. Gating on
+// the default would make every consumer disagree with reality for the rest of
+// the session.
+
+// iPad idiom. Cached — the idiom cannot change for the life of the process.
+BOOL ApolloPaneLayoutSupported(void);
+
+// Supported AND the user default was on when %ctor read it. This is the
+// install-time question; ApolloPaneInstall is essentially its only caller.
+BOOL ApolloPaneLayoutEnabled(void);
+
+// The pane layout is installed and live. Everything else gates on this.
+BOOL ApolloPaneLayoutActive(void);
+
+// Install-time only (ApolloPaneInstall.xm). Flipping this to NO after a failed
+// or partial install is what makes the whole feature fail safe: every consumer
+// falls back to stock behavior rather than half-applying.
+void ApolloPaneLayoutSetActive(BOOL active);
+
+// MARK: - Hierarchy
+
+// The pane split controller enclosing `viewController`, or nil when it is not
+// inside one (always nil on iPhone, and whenever the layout is off). Walks up
+// through parents, so it works from a deeply nested child.
+UISplitViewController *_Nullable ApolloPaneSplitControllerFor(UIViewController *_Nullable viewController);
+
+__END_DECLS
+NS_ASSUME_NONNULL_END

--- a/src/ipad/ApolloPaneLayout.m
+++ b/src/ipad/ApolloPaneLayout.m
@@ -1,0 +1,55 @@
+// ApolloPaneLayout.m — see ApolloPaneLayout.h
+
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import "../ApolloCommon.h"   // ApolloLog
+#import "../ApolloState.h"    // sIPadPaneLayout
+
+// Set once, from the main thread, during scene connect. Read from the main
+// thread by every consumer. No synchronization needed and none implied — if a
+// background reader ever appears, make this atomic rather than adding a lock
+// around a single BOOL.
+static BOOL sPaneLayoutActive = NO;
+
+BOOL ApolloPaneLayoutSupported(void) {
+    static BOOL supported = NO;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (@available(iOS 18.0, *)) {
+            supported = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad);
+        }
+    });
+    return supported;
+}
+
+BOOL ApolloPaneLayoutEnabled(void) {
+    return ApolloPaneLayoutSupported() && sIPadPaneLayout;
+}
+
+BOOL ApolloPaneLayoutActive(void) {
+    return sPaneLayoutActive;
+}
+
+void ApolloPaneLayoutSetActive(BOOL active) {
+    if (sPaneLayoutActive == active) return;
+    sPaneLayoutActive = active;
+    ApolloLog(@"[PaneLayout] active=%d (supported=%d enabled=%d)",
+              active, ApolloPaneLayoutSupported(), ApolloPaneLayoutEnabled());
+}
+
+UISplitViewController *ApolloPaneSplitControllerFor(UIViewController *viewController) {
+    if (!sPaneLayoutActive) return nil;
+
+    // Walk parents rather than `splitViewController`: UIKit's property only
+    // reports an ancestor split controller when the receiver is one of its
+    // direct children or inside its columns' navigation stacks, and it can
+    // also report a split controller we did NOT install (Apollo embeds none
+    // today, but a future one would silently match). Matching on our own class
+    // keeps the answer unambiguous.
+    for (UIViewController *node = viewController; node != nil; node = node.parentViewController) {
+        if ([node isKindOfClass:[ApolloPaneSplitViewController class]]) {
+            return (UISplitViewController *)node;
+        }
+    }
+    return nil;
+}

--- a/src/ipad/ApolloPaneRouter.xm
+++ b/src/ipad/ApolloPaneRouter.xm
@@ -1,0 +1,233 @@
+// ApolloPaneRouter.xm
+//
+// Decides which column a pushed view controller belongs in, and redirects it
+// there. This is the only file that changes where navigation lands.
+//
+// ALLOWLIST, NEVER BLOCKLIST. Only classes named in kPaneRoutes are moved;
+// everything else pushes in place, exactly as it does today. Apollo ships ~90
+// view controllers and the tweak adds its own, so an allowlist is the only
+// default that cannot silently break a screen nobody thought about.
+//
+// WHY HOOK THE OBJC SHIM. `-[ApolloNavigationController pushViewController:
+// animated:]` is a thin Objective-C shim over one Swift body (sub_10015c720,
+// recovered with Hopper). Logos hooks the shim, so returning early means
+// Apollo's Swift body never runs on the wrong navigation controller. That body
+// also **silently drops a push when the controller is already in the stack** —
+// which is why a reroute must never leave the controller in the source stack,
+// and why we re-home it with setViewControllers: rather than splicing arrays.
+//
+// Full design + RE notes: docs/ipad-pane-layout-plan.md
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import "../ApolloCommon.h"
+
+typedef struct {
+    const char *className;
+    ApolloPaneColumn column;
+} ApolloPaneRoute;
+
+// Matched with isKindOfClass:, so subclasses inherit their parent's column.
+//
+// The comment-LIST controllers are deliberately absent: despite their names,
+// AllSubredditComments / SavedPostsComments / UserComments are feeds whose rows
+// open a real CommentsViewController, so they belong wherever they are pushed
+// and their selections route to the detail column on their own.
+static const ApolloPaneRoute kPaneRoutes[] = {
+    // The headline case: a post's comment thread opens beside its feed.
+    { "_TtC6Apollo22CommentsViewController", ApolloPaneColumnSecondary },
+
+    // Feeds belong in the list column, which is where they are already being
+    // pushed — a subreddit list pushing to a feed is Apollo's own structure and
+    // it survives the pane layout untouched. They are listed anyway so that
+    // opening a new feed CLEARS whatever thread is sitting in the detail column:
+    // a comment thread beside an unrelated feed is worse than an empty pane.
+    { "_TtC6Apollo19PostsViewController",     ApolloPaneColumnPrimary },
+    { "_TtC6Apollo23LitePostsViewController", ApolloPaneColumnPrimary },
+};
+
+// Re-entrancy guard: our own re-homing must never be re-classified. Main thread
+// only, like every UIKit navigation call this hook sits on.
+static BOOL sPaneRouterReentrant = NO;
+
+// SOURCE-BASED ROUTING, for tabs whose root is an index rather than a feed.
+//
+// Settings is the case that needs it. Its rows do not lead to posts, so nothing
+// downstream ever needs the detail column, and drilling in place left an index
+// in a 480pt column beside an empty pane the width of the screen — while the
+// native iPad shape for exactly this content is index on the left, the selected
+// page on the right.
+//
+// This is deliberately NOT applied to Home or Search, even though their roots
+// are also lists. Their rows lead to FEEDS, whose posts then need the detail
+// column for comments; sending the feed there instead would leave comments
+// nowhere to go but on top of the feed. Those tabs keep feed-in-place, and only
+// the comment thread crosses over.
+//
+// Matched on the pushing controller's CURRENT top, not on the tab index, so a
+// settings screen reached from somewhere else does not accidentally re-home.
+static BOOL ApolloPaneIsIndexRootController(UIViewController *viewController) {
+    static const char *kIndexRoots[] = {
+        "_TtC6Apollo22SettingsViewController",
+        // Profile is an index by product decision rather than by structure. Its
+        // rows DO lead to post lists, so this knowingly costs one thing: a post
+        // opened from Saved (or Posts, Comments, Upvoted…) replaces that list in
+        // the detail column rather than opening beside it, because the list is
+        // already occupying the only column a thread could go to. Back returns
+        // to it. Bought in exchange for the profile card never leaving screen,
+        // which is what the tab is for.
+        "_TtC6Apollo21ProfileViewController",
+    };
+    for (size_t i = 0; i < sizeof(kIndexRoots) / sizeof(kIndexRoots[0]); i++) {
+        Class cls = objc_getClass(kIndexRoots[i]);
+        if (cls && [viewController isMemberOfClass:cls]) return YES;
+    }
+    return NO;
+}
+
+static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *viewController) {
+    if (!viewController) return ApolloPaneColumnInPlace;
+    for (size_t i = 0; i < sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0]); i++) {
+        Class cls = objc_getClass(kPaneRoutes[i].className);
+        if (cls && [viewController isKindOfClass:cls]) return kPaneRoutes[i].column;
+    }
+    return ApolloPaneColumnInPlace;
+}
+
+%group ApolloPaneRouterGroup
+
+%hook UINavigationController
+
+- (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    if (!ApolloPaneLayoutActive() || sPaneRouterReentrant) { %orig; return; }
+
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(self);
+
+    if (!pane) { %orig; return; }
+
+    // Collapsed (Slide Over, a narrow Stage Manager window, portrait on a small
+    // iPad) is a single merged stack and must behave exactly like today's app.
+    if (pane.isCollapsed) { %orig; return; }
+
+    // CONTENT ONLY EVER MOVES RIGHTWARD.
+    //
+    // Cross-column routing applies only to pushes that START in the list column.
+    // Anything pushed from the detail column stays there and behaves like a
+    // normal navigation stack: push, back button, pop.
+    //
+    // Without this the layout teleports content leftward and destroys your place.
+    // Tapping a subreddit link inside a comment thread pushed a
+    // PostsViewController, the table sent it to the LIST column, and re-homing
+    // there means setViewControllers: — which replaces the whole left stack. The
+    // Home tab's [subreddit list, feed] became [new feed], so the subreddit list,
+    // the feed you were reading and every back button went with it. That is why
+    // there was no way back to the home feed, and why the direction felt wrong:
+    // you tapped something on the right and watched the left half of the app get
+    // replaced.
+    //
+    // The detail column is now the browsing stack — the thing you tapped opens
+    // where you were looking, and back always returns — while the list column
+    // stays the stable context you navigated from.
+    BOOL fromListColumn = (self == [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]);
+
+    ApolloPaneColumn column = fromListColumn
+        ? ApolloPaneColumnForViewController(viewController)
+        : ApolloPaneColumnInPlace;
+
+    // An index root sends EVERYTHING it pushes to the detail column, so the index
+    // itself stays put. This deliberately overrides the destination table rather
+    // than only filling in for it: the profile's "Posts" row pushes a
+    // PostsViewController, which the table maps to the list column, so gating
+    // this on the table having no opinion left that row — and only that row —
+    // still replacing the profile card.
+    //
+    // Still limited to pushes coming FROM the list column: a settings page or a
+    // saved-posts list pushing deeper is already in the detail column and stays
+    // there rather than re-homing onto itself.
+    if (fromListColumn && ApolloPaneIsIndexRootController(self.topViewController)) {
+        column = ApolloPaneColumnSecondary;
+    }
+
+    if (column == ApolloPaneColumnInPlace) {
+        %orig;
+        // Guarantee a way back out of the detail column.
+        //
+        // Some Apollo screens are designed to be a TAB ROOT and supply their own
+        // leading bar items, so when one is pushed they render no back button at
+        // all. On iPhone that never happens — you reach them by selecting a tab,
+        // never by pushing. In the detail column it does: tapping your own
+        // username inside a comment thread pushes ProfileViewController onto the
+        // thread, and the result is a screen with the thread still underneath it
+        // and no affordance to return. That is the "stuck in a second profile"
+        // report, and it is not a routing problem — the push lands in exactly
+        // the right column.
+        //
+        // leftItemsSupplementBackButton keeps the screen's own items (the
+        // profile's hide/history buttons) rather than replacing them.
+        if (self.viewControllers.count > 1) {
+            viewController.navigationItem.hidesBackButton = NO;
+            viewController.navigationItem.leftItemsSupplementBackButton = YES;
+        }
+        return;
+    }
+
+    UINavigationController *destination = [pane apollo_navigationControllerForColumn:column];
+
+    // Already in the right column. A feed arriving here means the user moved to
+    // different content, so the stale thread beside it goes.
+    if (!destination || destination == self) {
+        if (column != ApolloPaneColumnSecondary) [pane apollo_clearDetailColumn];
+        %orig;
+        return;
+    }
+
+    // Cross-column. Re-home rather than push: this REPLACES the destination
+    // stack, so opening a second post swaps the thread instead of burying the
+    // first one under a back button, and the placeholder disappears with it.
+    //
+    // setViewControllers: is plain UIKit — Apollo overrides pushViewController:
+    // and the pop family, but not this — so the one thing Apollo's push body
+    // would have done that still matters here is applied by hand below.
+    // The rest of that body (its duplicate guard, the interactive-transition
+    // `pushing` flag, the hidden-nav-bar re-show timer loop) is specific to an
+    // animated push onto an existing stack and does not apply to replacing a
+    // column's root.
+    viewController.extendedLayoutIncludesOpaqueBars = YES;
+
+    sPaneRouterReentrant = YES;
+    @try {
+        [destination setViewControllers:@[ viewController ] animated:NO];
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneRouter] re-homing %@ threw: %@; falling back to an in-place push",
+                  NSStringFromClass([viewController class]), exception);
+        sPaneRouterReentrant = NO;
+        %orig;
+        return;
+    }
+    sPaneRouterReentrant = NO;
+
+    // The detail column just filled, so the pane can reclaim the sidebar's width
+    // for it.
+    [pane apollo_detailContentDidChange];
+
+    ApolloLog(@"[PaneRouter] routed %@ to column %ld (tab %ld)",
+              NSStringFromClass([viewController class]), (long)column, (long)pane.apollo_tabIndex);
+}
+
+%end
+
+%end
+
+%ctor {
+    // iPhone never installs this, and neither does an iPad with the layout off:
+    // ApolloPaneLayoutActive() would be NO for the whole process anyway, so the
+    // hook would be pure overhead on Apollo's hottest navigation path.
+    if (!ApolloPaneLayoutEnabled()) return;
+
+    %init(ApolloPaneRouterGroup);
+    ApolloLog(@"[PaneRouter] installed with %lu routed classes",
+              (unsigned long)(sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0])));
+}

--- a/src/ipad/ApolloPaneSplitViewController.h
+++ b/src/ipad/ApolloPaneSplitViewController.h
@@ -1,0 +1,54 @@
+// ApolloPaneSplitViewController.h
+//
+// The container that hosts one tab's columns in the iPad pane layout. One
+// instance per tab, installed by ApolloPaneInstall as the tab bar controller's
+// child in place of that tab's ApolloNavigationController.
+//
+// Full design + RE notes: docs/ipad-pane-layout-plan.md
+
+#import <UIKit/UIKit.h>
+#import "ApolloPaneLayout.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ApolloPaneSplitViewController : UISplitViewController
+
+// `rootNavigationController` is the tab's ORIGINAL ApolloNavigationController,
+// moved verbatim into the primary column. Nothing about it is rebuilt: it keeps
+// its stack, its delegate, its gesture recognizers and its identity, which is
+// what lets Apollo's own navigation behavior survive the re-host.
++ (instancetype)paneControllerWithRootNavigationController:(UINavigationController *)rootNavigationController
+                                                  tabIndex:(NSInteger)tabIndex;
+
+// The tab index this pane belongs to, for logging and for the tab-child unwrap
+// helper to sanity-check against.
+@property (nonatomic, readonly) NSInteger apollo_tabIndex;
+
+// The navigation controller for a column, or nil when that column is not
+// installed. Every pane is two columns — list and detail — because the app's
+// fixed sidebar belongs to the tab bar controller, not to any one tab.
+// `ApolloPaneColumnSupplementary` therefore resolves to the list column too.
+- (nullable UINavigationController *)apollo_navigationControllerForColumn:(ApolloPaneColumn)column;
+
+// YES when the detail column is showing nothing but its placeholder. The router
+// uses this to decide whether a collapse should surface the detail column.
+@property (nonatomic, readonly) BOOL apollo_detailIsEmpty;
+
+// Return the detail column to its placeholder. Used when the content column
+// loads a new list, so a stale comment thread does not sit beside unrelated posts.
+- (void)apollo_clearDetailColumn;
+
+// The column a "what is the user looking at" walk should descend into: the
+// detail column when it holds real content, otherwise the primary column.
+// Discovered by ApolloContentColumnForSplitViewController via
+// respondsToSelector:, so ApolloCommon needs no dependency on this class.
+- (nullable UIViewController *)apollo_preferredContentColumnController;
+
+// Tell the pane its detail column's content changed, so it can reclaim the
+// sidebar's width for reading and hand it back when the column empties again.
+// Called by the router after it re-homes something, and internally on clear.
+- (void)apollo_detailContentDidChange;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -1,0 +1,774 @@
+// ApolloPaneSplitViewController.m — see ApolloPaneSplitViewController.h
+
+#import "ApolloPaneSplitViewController.h"
+#import <objc/runtime.h>
+#import "../ApolloCommon.h"        // ApolloLog
+#import "../ApolloThemeRuntime.h"  // ApolloThemeAccentColor
+
+#pragma mark - Detail placeholder
+
+// Shown in the detail column when nothing is selected. Deliberately plain: the
+// point is to read as "this pane is waiting", not to decorate. Themed through
+// the theme runtime so it matches whatever palette is active, with system
+// fallbacks for the stock (no custom theme) case.
+@interface ApolloPaneDetailPlaceholderViewController : UIViewController
+- (instancetype)initWithMessage:(NSString *)message symbolName:(NSString *)symbolName;
+@end
+
+@implementation ApolloPaneDetailPlaceholderViewController {
+    UIImageView *_iconView;
+    UILabel *_label;
+    NSString *_message;
+    NSString *_symbolName;
+}
+
+- (instancetype)initWithMessage:(NSString *)message symbolName:(NSString *)symbolName {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _message = [message copy];
+        _symbolName = [symbolName copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithNibName:(NSString *)nib bundle:(NSBundle *)bundle {
+    self = [super initWithNibName:nib bundle:bundle];
+    if (self) {
+        _message = @"No Post Selected";
+        _symbolName = @"text.bubble";
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    UIStackView *stack = [[UIStackView alloc] init];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.alignment = UIStackViewAlignmentCenter;
+    stack.spacing = 12.0;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+
+    _iconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:_symbolName ?: @"text.bubble"]];
+    _iconView.contentMode = UIViewContentModeScaleAspectFit;
+    [_iconView.heightAnchor constraintEqualToConstant:44.0].active = YES;
+
+    _label = [[UILabel alloc] init];
+    _label.text = _message ?: @"No Post Selected";
+    _label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    _label.adjustsFontForContentSizeCategory = YES;
+    _label.textAlignment = NSTextAlignmentCenter;
+
+    [stack addArrangedSubview:_iconView];
+    [stack addArrangedSubview:_label];
+    [self.view addSubview:stack];
+
+    // Center on the safe area, not on the view. Under iOS 26 the split
+    // controller floats the sidebar as a glass panel OVER a full-width
+    // secondary column, so `view.centerXAnchor` is the window's centre and
+    // lands the text half-underneath the sidebar. The safe area is the part of
+    // the detail column the sidebar is not covering.
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.centerXAnchor constraintEqualToAnchor:safe.centerXAnchor],
+        [stack.centerYAnchor constraintEqualToAnchor:safe.centerYAnchor],
+        [stack.leadingAnchor constraintGreaterThanOrEqualToAnchor:safe.leadingAnchor constant:24.0],
+        [stack.trailingAnchor constraintLessThanOrEqualToAnchor:safe.trailingAnchor constant:-24.0],
+    ]];
+
+    [self apollo_applyTheme];
+}
+
+// Re-resolve on every trait change: the accent is a dynamic provider color, and
+// Apollo overrides the window style, so ambient resolution can land on the wrong
+// light/dark variant (see CLAUDE.md, "Theme Accent in Tweak-Drawn UI").
+- (void)traitCollectionDidChange:(UITraitCollection *)previous {
+    [super traitCollectionDidChange:previous];
+    [self apollo_applyTheme];
+}
+
+- (void)apollo_applyTheme {
+    // The empty detail column takes Apollo's own page background, so it matches
+    // the list column beside it under every theme.
+    //
+    // This was briefly changed to clearColor on the strength of a bad
+    // measurement: a pixel sampled at (1100,800) in an open comment thread read
+    // #000000, which was taken as "Apollo's pages are black and the helper
+    // disagrees". That sample landed on a COMMENT CELL, not the page. Sampling
+    // the list column's actual page area under a themed palette gives #191926,
+    // and clearColor left the detail column black beside it.
+    UIColor *page = ApolloThemePageBackgroundColor();
+    self.view.backgroundColor = page ?: UIColor.clearColor;
+    static BOOL loggedPage = NO;
+    if (!loggedPage) {
+        loggedPage = YES;
+        UIColor *resolved = [page resolvedColorWithTraitCollection:self.traitCollection];
+        CGFloat r = 0, g = 0, b = 0, a = 0;
+        [resolved getRed:&r green:&g blue:&b alpha:&a];
+        ApolloLog(@"[PanePlaceholder] page background #%02X%02X%02X (alpha %.2f)",
+                  (unsigned)(r * 255), (unsigned)(g * 255), (unsigned)(b * 255), a);
+    }
+    UIColor *accent = ApolloThemeAccentColor() ?: self.view.tintColor;
+    _iconView.tintColor = [accent colorWithAlphaComponent:0.45];
+    _label.textColor = UIColor.secondaryLabelColor;
+}
+
+@end
+
+// A column holding nothing but its placeholder is "empty" for every decision
+// the split controller makes: which column to collapse onto, whether a stale
+// thread needs clearing, and where a content-seeking walk should descend.
+static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
+    NSArray<UIViewController *> *stack = nav.viewControllers;
+    if (stack.count == 0) return YES;
+    if (stack.count > 1) return NO;
+    return [stack.firstObject isKindOfClass:[ApolloPaneDetailPlaceholderViewController class]];
+}
+
+#pragma mark - Column host
+
+// Insets a column's navigation controller to the part of the column the sidebar
+// is not covering.
+//
+// WHY THIS EXISTS. On iPadOS 26 a split view controller lays the secondary
+// column out at the FULL window width and floats the sidebar over it as a glass
+// panel — verified from a live hierarchy dump on an iPad Pro 13":
+//
+//   secondary  _UISplitViewControllerAdaptiveColumnView  (0, 0, 1032, 1312)
+//   primary    _UISplitViewControllerAdaptiveColumnView  (10, 86, 413, 1216)
+//
+// UIKit expects content to respect the resulting left safe-area inset. Apollo's
+// screens are Texture (AsyncDisplayKit) table nodes, and ASTableView measures
+// its nodes against its own bounds, not its adjusted content inset — so every
+// comment measured 1032pt wide, got pushed right by the inset, and ran off the
+// right edge of the screen.
+//
+// Rather than fight ASTableView's measurement, give the navigation controller a
+// view that is genuinely only as wide as the visible column. Leading/trailing
+// pin to the safe area (the uncovered region); top/bottom pin to the view so
+// the navigation bar still extends under the status bar as Apollo expects.
+@interface ApolloPaneColumnHostViewController : UIViewController
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
+@property (nonatomic, strong, readonly) UINavigationController *hostedNavigationController;
+@end
+
+@implementation ApolloPaneColumnHostViewController {
+    NSLayoutConstraint *_topConstraint;
+    NSLayoutConstraint *_bottomConstraint;
+}
+
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _hostedNavigationController = navigationController;
+
+        // The same tab-bar reservation the pane itself has to opt out of (see
+        // the pane's configure method), one level further down.
+        //
+        // UISplitViewController wraps this host in a navigation controller of
+        // its own, and THAT controller applies the identical
+        // -[UITabBarController _frameForViewController:] rule to its child: it
+        // subtracts the opaque tab bar's height unless the child extends under
+        // it. The pane opting in did not help, because this host is a separate
+        // controller that never inherited the flag.
+        //
+        // Measured: the host's view came out (0,0,1376,968) inside a 1032pt
+        // wrapper, so the detail column ended at 968 while the list column ended
+        // at 1022 — the comment list stopping 54pt above the bottom of the
+        // screen with a band of background under it.
+        self.edgesForExtendedLayout = UIRectEdgeAll;
+        self.extendedLayoutIncludesOpaqueBars = YES;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // CLEAR, deliberately — this view must never paint.
+    //
+    // It is laid out at the FULL window width (iPadOS 26 gives the secondary
+    // column the whole window and floats the other columns over it), while the
+    // navigation controller inside it is inset to the visible column. Giving it
+    // a background therefore does not tint "the detail column", it tints the
+    // entire window: behind the floating sidebar, in the gap between columns,
+    // and above the list column.
+    //
+    // That is exactly what went wrong. It painted ApolloThemePageBackgroundColor(),
+    // which is black under a pure-black theme and so looked correct — until a
+    // themed palette made it #0B1F28 and the whole app turned teal behind
+    // Apollo's own black screens. Only the controllers actually occupying a
+    // column may paint; this one is scaffolding.
+    self.view.backgroundColor = UIColor.clearColor;
+
+    UINavigationController *nav = self.hostedNavigationController;
+    if (!nav) return;
+
+    [self addChildViewController:nav];
+    nav.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:nav.view];
+    // ALL FOUR edges pin to the safe area, vertically as well as horizontally.
+    //
+    // Leading/trailing is the Texture fix (see the class comment). Top/bottom
+    // used to pin to the view so the nav bar could extend under the status bar
+    // "as Apollo expects" — that was wrong, and it is what made the app read as
+    // three separate windows rather than one.
+    //
+    // Measured on an iPad Pro 13" landscape, the three navigation bars were:
+    //
+    //   sidebar   (10, 32, 270, 54)
+    //   list      (280, 32, 480, 54)
+    //   detail    (760, 86, 616, 54)   ← 54pt lower than both its neighbours
+    //
+    // UIKit positions the sidebar and the list column inside already-inset
+    // column views, so their bars start at the column's own top. The secondary
+    // column view spans the full window (0,0,1376,1032), so pinning the nav
+    // controller to its top told that controller it began at the very top of the
+    // screen and it applied the whole status-bar inset a second time. Pinning to
+    // the safe area gives it the same origin UIKit gave the other two, and the
+    // three bars line up.
+    // Leading/trailing follow the safe area — that is the Texture fix, and it is
+    // the only thing the safe area gets to decide here.
+    //
+    // Top/bottom are driven manually against the LIST column's real frame (see
+    // apollo_matchListColumnGeometry). The safe area is the wrong input for
+    // them: it produced a detail column running 32→1012 against the list
+    // column's 32→1022, and it cannot express the 10pt the navigation bar
+    // inserts above itself.
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    _topConstraint = [nav.view.topAnchor constraintEqualToAnchor:self.view.topAnchor
+                                                        constant:self.view.safeAreaInsets.top];
+    _bottomConstraint = [self.view.bottomAnchor constraintEqualToAnchor:nav.view.bottomAnchor
+                                                              constant:self.view.safeAreaInsets.bottom];
+    [NSLayoutConstraint activateConstraints:@[
+        [nav.view.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor],
+        [nav.view.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor],
+        _topConstraint,
+        _bottomConstraint,
+    ]];
+    [nav didMoveToParentViewController:self];
+}
+
+// UISplitViewController wraps any column view controller that is not already a
+// navigation controller in one of its own. This host is a plain UIViewController,
+// so the detail column ends up with TWO navigation bars stacked:
+//
+//   UIKit's wrapper bar   (0, 32, 1376, 54)   full width, empty, invisible
+//   Apollo's real bar     (760, 96, 616, 54)  pushed below it
+//
+// The wrapper bar is never seen, but it still reports itself through the safe
+// area — 86pt of top inset — which is what pushed Apollo's bar 54pt below the
+// sidebar's and the list column's bars and made the three columns read as three
+// separate windows. Its full-width background band was painting across the whole
+// app too.
+//
+// Hiding it costs nothing: the wrapper has no items, no title and no back
+// button, because everything the user interacts with lives on the real
+// navigation controller inside this host.
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    if (self.navigationController && !self.navigationController.navigationBarHidden) {
+        [self.navigationController setNavigationBarHidden:YES animated:NO];
+    }
+}
+
+// Lines the detail column up with the list column exactly, top and bottom.
+//
+// WHY NOT THE SAFE AREA. Both navigation controllers report a top safe-area
+// inset of ZERO, and yet:
+//
+//   list    view {0,0,480,990}     bar at y=0    (column starts at 32 → bar at 32)
+//   detail  view {760,32,616,980}  bar at y=10   (→ bar at 42)
+//
+// The 10pt is not an inset we can cancel — it is where Apollo's navigation
+// controller puts its own bar. UIKit's split view positions the list column's
+// navigation controller itself and gets y=0; the same class, parented into this
+// host, lays its bar at y=10. So the fix is not to argue with the bar but to
+// offset the view by exactly the gap the bar leaves, measured each layout.
+//
+// The bottom is the same idea from the other side: the safe area put the detail
+// column's bottom at 1012 against the list column's 1022, which is the band of
+// empty background under the comment list. Matching the list column's maxY
+// removes it, and matching is more robust than any constant since it tracks
+// whatever inset the platform applies to that column.
+//
+// Both values are read from the real frame every layout pass, and written only
+// when they actually change, so this cannot oscillate.
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    [self apollo_matchListColumnGeometry];
+}
+
+- (void)apollo_matchListColumnGeometry {
+    UINavigationController *nav = self.hostedNavigationController;
+    if (!nav.isViewLoaded || !_topConstraint || !_bottomConstraint) return;
+
+    CGFloat height = self.view.bounds.size.height;
+    if (height <= 0.0) return;
+
+    // Fall back to the safe area whenever the list column cannot be measured —
+    // collapsed, mid-transition, or not yet loaded.
+    CGFloat top = self.view.safeAreaInsets.top;
+    CGFloat bottom = self.view.safeAreaInsets.bottom;
+
+    UISplitViewController *split = self.splitViewController;
+    UIViewController *list = [split isKindOfClass:[UISplitViewController class]]
+        ? [split viewControllerForColumn:UISplitViewControllerColumnPrimary]
+        : nil;
+    if (list.isViewLoaded && list.view.superview && !split.isCollapsed) {
+        CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
+        if (!CGRectIsEmpty(listFrame)) {
+            bottom = height - CGRectGetMaxY(listFrame);
+
+            // Align the two NAVIGATION BARS, not the two view origins.
+            //
+            // The list column's bar is not always flush with the top of its
+            // column, and how far in it sits depends on the mode: with the
+            // sidebar showing, column and bar both start at y=32; with the
+            // sidebar collapsed to the floating tab bar, the column starts at
+            // y=86 and its bar at y=140, 54pt inside. Matching view origins got
+            // the sidebar case right and then put our bar 54pt ABOVE the list's
+            // in the tab bar case. So take the list bar's real position as the
+            // target and back out our own bar's offset within its view.
+            UINavigationBar *listBar = [list isKindOfClass:[UINavigationController class]]
+                ? ((UINavigationController *)list).navigationBar : nil;
+            CGFloat targetBarY = CGRectGetMinY(listFrame);
+            if (listBar && !listBar.isHidden && listBar.superview) {
+                targetBarY = CGRectGetMinY([listBar.superview convertRect:listBar.frame toView:self.view]);
+            }
+            top = targetBarY - nav.navigationBar.frame.origin.y;
+        }
+    }
+
+    if (fabs(_topConstraint.constant - top) > 0.5) _topConstraint.constant = top;
+    if (fabs(_bottomConstraint.constant - bottom) > 0.5) _bottomConstraint.constant = bottom;
+}
+
+// The hosted navigation controller owns the chrome; forwarding these keeps the
+// host transparent to UIKit rather than having it answer for an empty view.
+- (UIViewController *)childViewControllerForStatusBarStyle { return self.hostedNavigationController; }
+- (UIViewController *)childViewControllerForStatusBarHidden { return self.hostedNavigationController; }
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden { return self.hostedNavigationController; }
+
+@end
+
+#pragma mark - Pane split controller
+
+@interface ApolloPaneSplitViewController () <UISplitViewControllerDelegate> {
+    BOOL _apollo_loggedResolvedLayout;
+    UIView *_apollo_grabber;
+    BOOL _apollo_sidebarManaged;      // we last set the sidebar's visibility
+    BOOL _apollo_sidebarWeSetHidden;  // ...to this
+}
+@property (nonatomic, strong) UINavigationController *apollo_primaryNav;   // the list column
+@property (nonatomic, strong) UINavigationController *apollo_detailNav;
+@property (nonatomic, strong) UIViewController *apollo_detailHost;
+@property (nonatomic, copy) NSString *apollo_emptyMessage;
+@property (nonatomic, copy) NSString *apollo_emptySymbol;
+@end
+
+@implementation ApolloPaneSplitViewController
+
++ (instancetype)paneControllerWithRootNavigationController:(UINavigationController *)rootNavigationController
+                                                  tabIndex:(NSInteger)tabIndex {
+    if (!rootNavigationController) return nil;
+
+    ApolloPaneSplitViewController *pane =
+        [[self alloc] initWithStyle:UISplitViewControllerStyleDoubleColumn];
+    pane->_apollo_tabIndex = tabIndex;
+    [pane apollo_configureWithRootNavigationController:rootNavigationController];
+    return pane;
+}
+
+// WHY EVERY PANE IS TWO COLUMNS.
+//
+// The app has exactly one persistent navigation surface, and it is not a column
+// of these split views — it is the tab bar controller's own sidebar
+// (`mode = .tabSidebar`, installed by ApolloPaneInstall). That sidebar is fixed:
+// it lists the same destinations no matter which tab is selected, and selecting
+// one replaces the content beside it. A per-tab column that changed identity as
+// you moved between tabs is exactly the thing that read as janky.
+//
+// So each tab contributes list + detail and nothing more, giving a stable
+// three-region app:
+//
+//     [ sidebar: destinations ] [ list ] [ detail ]
+//        UIKit, never changes    the tab's own stack   comment thread
+//
+// The tab's navigation controller goes into the LIST column verbatim, which is
+// what keeps Apollo's own structure intact: the subreddit list pushes to a feed
+// inside that one column, exactly as it does on iPhone. Only genuinely
+// detail-shaped screens (a post's comments) leave for the second column.
+//
+// An earlier revision gave the Home tab a third column for the subreddit list.
+// That produced four visible columns next to the sidebar, two competing
+// subreddit switchers (the column and Apollo's own "Home v" title menu), and a
+// left pane whose contents changed per tab. All three problems are structural,
+// not cosmetic, and they go away by letting the sidebar be the only sidebar.
+- (void)apollo_configureWithRootNavigationController:(UINavigationController *)rootNav {
+    self.apollo_primaryNav = rootNav;
+
+    // The empty state names what THIS tab puts in the detail column. "No Post
+    // Selected" beside a settings index or a search field is just wrong, and it
+    // was a large part of why those two tabs read as nonsense on iPad.
+    NSString *message = @"No Post Selected";
+    NSString *symbol = @"text.bubble";
+    NSString *rootClass = NSStringFromClass([rootNav.viewControllers.firstObject class]) ?: @"";
+    if ([rootClass hasSuffix:@"SettingsViewController"]) {
+        message = @"No Setting Selected";
+        symbol = @"gearshape";
+    } else if ([rootClass hasSuffix:@"InboxListViewController"]) {
+        message = @"No Message Selected";
+        symbol = @"envelope";
+    } else if ([rootClass hasSuffix:@"SearchViewController"]) {
+        message = @"Search Reddit";
+        symbol = @"magnifyingglass";
+    } else if ([rootClass hasSuffix:@"ProfileViewController"]) {
+        // The profile's detail column holds whatever row you picked — a post
+        // list, trophies, friends — so it cannot promise a post.
+        message = @"Nothing Selected";
+        symbol = @"person.crop.circle";
+    }
+
+    self.apollo_detailNav = [self apollo_makeNavigationControllerWithRoot:
+        [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:message symbolName:symbol]];
+    self.apollo_emptyMessage = message;
+    self.apollo_emptySymbol = symbol;
+
+    [self setViewController:rootNav forColumn:UISplitViewControllerColumnPrimary];
+    // The secondary column is the full-width one the sidebar floats over, so it
+    // is the one that needs the safe-area host (see ApolloPaneColumnHostViewController).
+    // The primary column is already laid out as its own inset panel.
+    self.apollo_detailHost =
+        [[ApolloPaneColumnHostViewController alloc] initWithNavigationController:self.apollo_detailNav];
+    [self setViewController:self.apollo_detailHost forColumn:UISplitViewControllerColumnSecondary];
+
+    // Tile, never overlay: a detail pane that floats over the list re-creates
+    // the blown-up-iPhone feel this layout exists to remove.
+    self.preferredSplitBehavior = UISplitViewControllerSplitBehaviorTile;
+    self.preferredDisplayMode = UISplitViewControllerDisplayModeOneBesideSecondary;
+
+    // Without these the columns end 64pt short of the window, leaving a dead
+    // black strip along the bottom of the app.
+    //
+    // Recovered from UIKit's -[UITabBarController _frameForViewController:]: the
+    // tab bar's height is subtracted from a child's frame unless the tab bar is
+    // hidden, the child extends under the bottom edge, or — for an OPAQUE tab
+    // bar, which Apollo's is — the child sets extendedLayoutIncludesOpaqueBars.
+    // Apollo sets that flag on every controller it pushes (its own push body
+    // does it, which is why the router mirrors it when re-homing), so its stock
+    // screens run full height and nothing reserves the strip.
+    //
+    // This pane is a UISplitViewController we constructed, so it never inherited
+    // the flag and UIKit dutifully reserved room for a tab bar that sidebar mode
+    // had already taken off screen. Setting it here matches what every other
+    // controller in the app already does. Confirmed against the stock hierarchy:
+    // with the pane layout off, Apollo's tab child is the full 1032pt tall.
+    self.edgesForExtendedLayout = UIRectEdgeAll;
+    self.extendedLayoutIncludesOpaqueBars = YES;
+
+    // The list column carries the bounds that matter: Apollo's post cells are
+    // tuned around iPhone Pro Max width and degrade below ~340pt, so that is the
+    // floor rather than UIKit's ~320pt sidebar default.
+    //
+    // The fraction is taken of the space LEFT OVER after the tab sidebar, not of
+    // the screen — the split view is a child of the tab bar controller's content
+    // area. On a 13" iPad that is roughly 780pt in portrait and 1115pt in
+    // landscape, landing the list near its 340pt floor in portrait and around
+    // 470pt in landscape, with the detail column always the larger share.
+    self.preferredPrimaryColumnWidthFraction = 0.42;
+    self.minimumPrimaryColumnWidth = 340.0;
+    self.maximumPrimaryColumnWidth = 480.0;
+
+    // Apollo installs its own screen-edge pans on every navigation controller
+    // (left = interactive pop, right = "go forward", re-pushing from the per-nav
+    // poppedViewControllers array — confirmed by RE, see the plan doc §2). Those
+    // sit on exactly the edges UIKit would use for the sidebar show/hide pan, so
+    // the split controller's own gesture is off and the toolbar button is the
+    // supported way to reveal the sidebar.
+    self.presentsWithGesture = NO;
+
+    // Keep the tab's original title/icon on the tab bar item: the tab bar reads
+    // the child's tabBarItem, and the child is now this pane rather than the
+    // navigation controller Apollo configured.
+    // Keep the tab's original title and icon. ORDER AND SOURCE BOTH MATTER.
+    //
+    // -[UIViewController setTitle:] writes through to the tab bar item, so
+    // assigning `title` after `tabBarItem` overwrites the item's label. And the
+    // navigation controller's own title is the wrong source for it: on the
+    // profile tab Apollo names the controller "Comments" while its tab bar item
+    // is the account name, so copying the controller title renamed the profile
+    // destination to "Comments" in both the tab bar and the sidebar.
+    //
+    //   tab 0  navTitle=(null)    itemTitle=Posts
+    //   tab 1  navTitle=(null)    itemTitle=Inbox
+    //   tab 2  navTitle=Comments  itemTitle=corderjones   <- the one that broke
+    //   tab 3  navTitle=(null)    itemTitle=Search
+    //   tab 4  navTitle=(null)    itemTitle=Settings
+    //
+    // The tab bar item is what the user has always seen, so it is the source of
+    // truth; the item is assigned last so it wins outright.
+    self.title = rootNav.tabBarItem.title ?: rootNav.title;
+    self.tabBarItem = rootNav.tabBarItem;
+
+    self.delegate = self;
+    [self apollo_applyGroundTheme];
+
+    // The columns are resizable by dragging the separator, but UIKit only
+    // reveals a grabber on pointer HOVER — with touch there is no hint at all
+    // that the divider does anything, so the capability goes unnoticed.
+    // A permanently visible grabber is the affordance.
+    [self apollo_installColumnGrabber];
+
+    ApolloLog(@"[PaneSplit] tab %ld configured listRoot=%@ depth=%lu",
+              (long)self.apollo_tabIndex,
+              NSStringFromClass([rootNav.viewControllers.firstObject class]),
+              (unsigned long)rootNav.viewControllers.count);
+}
+
+// Prefer Apollo's own navigation controller subclass so the detail column
+// inherits its nav bar theming, transition animator and key commands rather
+// than looking like a foreign UIKit screen bolted on beside Apollo's chrome.
+// Falls back to a stock navigation controller if the class ever moves.
+- (UINavigationController *)apollo_makeNavigationControllerWithRoot:(UIViewController *)placeholder {
+    Class apolloNav = objc_getClass("_TtC6Apollo26ApolloNavigationController");
+    if (apolloNav) {
+        @try {
+            UINavigationController *nav = [[apolloNav alloc] initWithRootViewController:placeholder];
+            if ([nav isKindOfClass:[UINavigationController class]]) return nav;
+            ApolloLog(@"[PaneSplit] ApolloNavigationController init returned %@; using stock",
+                      NSStringFromClass([nav class]));
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PaneSplit] ApolloNavigationController init threw: %@; using stock", exception);
+        }
+    } else {
+        ApolloLog(@"[PaneSplit] ApolloNavigationController class not found; using stock");
+    }
+    return [[UINavigationController alloc] initWithRootViewController:placeholder];
+}
+
+// One-shot diagnostic: what UIKit actually resolved, versus what we asked for.
+// preferredDisplayMode/preferredSplitBehavior are requests, and UIKit overrides
+// both when the available width cannot honor them.
+// A visible grabber on the column divider.
+//
+// Deliberately NOT a hit-testable control: UIKit's own separator already owns
+// the drag, and putting a view in front of it would break the resize rather than
+// advertise it. This is a pure marker — userInteractionEnabled = NO — pinned to
+// the divider so touches pass straight through to the real thing.
+//
+// The divider's own view is private and re-created across layouts, so the
+// grabber is positioned in viewDidLayoutSubviews against the list column's
+// trailing edge instead of being added as its subview.
+- (void)apollo_installColumnGrabber {
+    if (_apollo_grabber) return;
+
+    UIView *grabber = [[UIView alloc] initWithFrame:CGRectZero];
+    grabber.userInteractionEnabled = NO;
+    grabber.layer.cornerRadius = 2.5;
+    grabber.alpha = 0.55;
+    [self.view addSubview:grabber];
+    _apollo_grabber = grabber;
+    [self apollo_applyGrabberTheme];
+}
+
+- (void)apollo_applyGrabberTheme {
+    UIColor *accent = ApolloThemeAccentColor() ?: _apollo_grabber.tintColor;
+    _apollo_grabber.backgroundColor = accent ?: UIColor.separatorColor;
+}
+
+- (void)apollo_layoutColumnGrabber {
+    UIViewController *list = [self viewControllerForColumn:UISplitViewControllerColumnPrimary];
+    if (!_apollo_grabber || !list.isViewLoaded || !list.view.superview || self.isCollapsed) {
+        _apollo_grabber.hidden = YES;
+        return;
+    }
+    CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
+    if (CGRectIsEmpty(listFrame)) { _apollo_grabber.hidden = YES; return; }
+
+    static const CGFloat kWidth = 5.0, kHeight = 44.0;
+    _apollo_grabber.hidden = NO;
+    _apollo_grabber.frame = CGRectMake(CGRectGetMaxX(listFrame) - kWidth / 2.0,
+                                       CGRectGetMidY(listFrame) - kHeight / 2.0,
+                                       kWidth, kHeight);
+    [self.view bringSubviewToFront:_apollo_grabber];
+}
+
+// The ground the floating columns sit on.
+//
+// On iPhone the tab bar controller's own background is never visible. On iPadOS
+// 26 it is: the sidebar floats over it, and it shows in the margins around and
+// between the columns. Left alone it is UIKit's black, which is why the app read
+// as "not themeable" — Apollo's pages were #191926 under the active palette
+// while the ground behind them stayed #000000.
+- (void)apollo_applyGroundTheme {
+    self.view.backgroundColor = ApolloThemePageBackgroundColor() ?: self.view.backgroundColor;
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previous {
+    [super traitCollectionDidChange:previous];
+    [self apollo_applyGroundTheme];
+    [self apollo_applyGrabberTheme];
+}
+
+// Gives the reading pane the sidebar's width once there is something to read.
+//
+// The sidebar is a third region competing with two content columns: measured at
+// 1376pt landscape it takes 270 of them, leaving 480/616. Collapsing it to the
+// floating tab bar hands that 270 back — the same tab measures 480/886, a 44%
+// wider detail column — and the destinations stay one tap away in the tab bar,
+// so nothing becomes unreachable.
+//
+// Only ever fights the user once. If the sidebar's visibility is not what we
+// last set it to, the user changed it themselves through UIKit's own toggle, and
+// this stops managing it for the rest of the session — an auto-collapse that
+// keeps undoing a deliberate choice is worse than no auto-collapse at all.
+- (void)apollo_reconcileSidebarForDetailContent {
+    if (@available(iOS 18.0, *)) {
+        UITabBarController *tabBarController = self.tabBarController;
+        UITabBarControllerSidebar *sidebar = tabBarController.sidebar;
+        if (!sidebar || tabBarController.selectedViewController != self) return;
+        if (self.isCollapsed) return;
+
+        BOOL shouldHide = !self.apollo_detailIsEmpty;
+        if (sidebar.isHidden == shouldHide) return;
+
+        // The user moved it themselves since we last did; leave it alone.
+        if (_apollo_sidebarManaged && sidebar.isHidden != _apollo_sidebarWeSetHidden) return;
+
+        // ASYMMETRIC ON PURPOSE: only ever restore what we hid.
+        //
+        // UIKit persists the sidebar/tab-bar choice across launches, so a
+        // symmetric rule would force the sidebar back open on every launch with
+        // an empty detail column — overriding a preference the user set
+        // deliberately, using UIKit's own control, possibly sessions ago.
+        // Hiding is ours to do because the detail column filling is our event;
+        // showing is only ours to undo.
+        if (!shouldHide && !(_apollo_sidebarManaged && _apollo_sidebarWeSetHidden)) return;
+
+        sidebar.hidden = shouldHide;
+        _apollo_sidebarManaged = shouldHide;
+        _apollo_sidebarWeSetHidden = shouldHide;
+        ApolloLog(@"[PaneSplit] tab %ld sidebar %@ (detail %@)",
+                  (long)self.apollo_tabIndex, shouldHide ? @"hidden" : @"shown",
+                  shouldHide ? @"filled" : @"empty");
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    [self apollo_layoutColumnGrabber];
+    if (_apollo_loggedResolvedLayout) return;
+    if (CGRectIsEmpty(self.view.bounds)) return;
+    _apollo_loggedResolvedLayout = YES;
+    // supplementaryColumnWidth is NOT read here: it THROWS on a double-column
+    // split view ("supplementaryColumnWidth properties unsupported for style =
+    // DoubleColumn"), and every pane is double-column now.
+    // `paneH` vs `hostH` is the tab-bar-reservation check: they must be equal.
+    // A short pane means extendedLayoutIncludesOpaqueBars stopped taking effect
+    // and the dead bottom strip is back.
+    ApolloLog(@"[PaneSplit] tab %ld resolved displayMode=%ld splitBehavior=%ld size=%.0fx%.0f "
+              @"hostH=%.0f primaryW=%.0f",
+              (long)self.apollo_tabIndex, (long)self.displayMode, (long)self.splitBehavior,
+              self.view.bounds.size.width, self.view.bounds.size.height,
+              self.tabBarController.view.bounds.size.height, self.primaryColumnWidth);
+}
+
+#pragma mark - Column access
+
+- (UINavigationController *)apollo_navigationControllerForColumn:(ApolloPaneColumn)column {
+    switch (column) {
+        case ApolloPaneColumnPrimary:
+        // There is no supplementary column any more — the tab sidebar took that
+        // role — so "the list column" and "the primary column" are one and the
+        // same. Kept as a distinct case so callers can still say which they mean.
+        case ApolloPaneColumnSupplementary:
+            return self.apollo_primaryNav;
+        case ApolloPaneColumnSecondary:
+            return self.apollo_detailNav;
+        case ApolloPaneColumnInPlace:
+            return nil;
+    }
+    return nil;
+}
+
+- (BOOL)apollo_detailIsEmpty {
+    return ApolloPaneStackIsPlaceholderOnly(self.apollo_detailNav);
+}
+
+- (UIViewController *)apollo_preferredContentColumnController {
+    // Collapsed, every column has merged into the primary's stack, so that is
+    // unambiguously where the user is looking.
+    if (self.isCollapsed) return self.apollo_primaryNav;
+    if (!self.apollo_detailIsEmpty) return self.apollo_detailNav;
+    return self.apollo_primaryNav;
+}
+
+- (void)apollo_clearDetailColumn {
+    if (self.apollo_detailIsEmpty) return;
+    [self.apollo_detailNav setViewControllers:@[
+        [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:self.apollo_emptyMessage
+                                                               symbolName:self.apollo_emptySymbol]
+    ] animated:NO];
+    ApolloLog(@"[PaneSplit] tab %ld detail column cleared", (long)self.apollo_tabIndex);
+    [self apollo_detailContentDidChange];
+}
+
+- (void)apollo_detailContentDidChange {
+    [self apollo_reconcileSidebarForDetailContent];
+}
+
+#pragma mark - UISplitViewControllerDelegate
+
+// Collapsing to compact (Slide Over, a narrow Stage Manager window, portrait on
+// a small iPad) must land on today's single-stack app. Surface the detail
+// column only when it actually holds something — otherwise the user would
+// collapse into a "No Post Selected" screen with their feed hidden behind it.
+- (UISplitViewControllerColumn)splitViewController:(UISplitViewController *)svc
+        topColumnForCollapsingToProposedTopColumn:(UISplitViewControllerColumn)proposedTopColumn {
+    // Land on the deepest column the user has actually reached, so collapsing
+    // feels like the single stack they navigated rather than a jump backwards.
+    if (!self.apollo_detailIsEmpty) {
+        ApolloLog(@"[PaneSplit] tab %ld collapsing onto secondary", (long)self.apollo_tabIndex);
+        return UISplitViewControllerColumnSecondary;
+    }
+    ApolloLog(@"[PaneSplit] tab %ld collapsing onto primary", (long)self.apollo_tabIndex);
+    return UISplitViewControllerColumnPrimary;
+}
+
+// UIKit merges the columns' navigation stacks on collapse, which would drag the
+// placeholder along with them. Strip it afterwards rather than trying to
+// predict the merge: the result is the same whichever way UIKit combines them.
+- (void)splitViewControllerDidCollapse:(UISplitViewController *)svc {
+    // UIKit merges onto whichever navigation controller survived as the top
+    // column, which is not necessarily the primary one.
+    UINavigationController *nav = self.apollo_primaryNav;
+    for (UINavigationController *candidate in @[ self.apollo_detailNav, self.apollo_primaryNav ]) {
+        if (candidate.viewControllers.count > 1) { nav = candidate; break; }
+    }
+    NSArray<UIViewController *> *stack = nav.viewControllers;
+    NSMutableArray<UIViewController *> *cleaned = [NSMutableArray arrayWithCapacity:stack.count];
+    for (UIViewController *vc in stack) {
+        if (![vc isKindOfClass:[ApolloPaneDetailPlaceholderViewController class]]) [cleaned addObject:vc];
+    }
+    if (cleaned.count != stack.count && cleaned.count > 0) {
+        [nav setViewControllers:cleaned animated:NO];
+        ApolloLog(@"[PaneSplit] tab %ld collapsed; stripped %lu placeholder(s)",
+                  (long)self.apollo_tabIndex, (unsigned long)(stack.count - cleaned.count));
+    }
+}
+
+// Expanding back to regular width. The detail column may have been emptied
+// entirely by the collapse merge, so restore its placeholder; without a root
+// view controller the column renders as a black rectangle.
+- (void)splitViewControllerDidExpand:(UISplitViewController *)svc {
+    if (self.apollo_detailNav.viewControllers.count == 0) {
+        [self.apollo_detailNav setViewControllers:@[
+            [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:self.apollo_emptyMessage
+                                                                   symbolName:self.apollo_emptySymbol]
+        ] animated:NO];
+        ApolloLog(@"[PaneSplit] tab %ld expanded; restored detail placeholder", (long)self.apollo_tabIndex);
+    }
+}
+
+@end

--- a/src/settings/ApolloSettingsRouter.m
+++ b/src/settings/ApolloSettingsRouter.m
@@ -154,9 +154,8 @@ BOOL ApolloSettingsRouteOpenNow(NSString *routeId) {
 
     if (![tabBarController isKindOfClass:UITabBarController.class]) return NO;
     UIViewController *selected = [(UITabBarController *)tabBarController selectedViewController];
-    UINavigationController *nav = [selected isKindOfClass:UINavigationController.class]
-        ? (UINavigationController *)selected
-        : selected.navigationController;
+    // Unwraps the iPad pane layout's split view controller; identity otherwise.
+    UINavigationController *nav = ApolloNavigationControllerForTabChild(selected);
     if (!nav) return NO;
 
     // A modal over the settings tab (e.g. account switcher) would swallow the

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -57,6 +57,7 @@
 #import "settings/TranslationSettingsViewController.h"
 #import "PictureInPictureViewController.h"
 #import "TagFiltersViewController.h"
+#import "ipad/ApolloPaneLayout.h"
 
 // The six speeds the "Hold for Video Speed" picker offers, in display order. They
 // mirror the video player's own speed menu minus 1.0× (holding at normal speed
@@ -82,6 +83,17 @@ static NSInteger sPendingLinkPreviewModeRefreshMode = ApolloLinkPreviewModeFull;
 
 static NSString *const kApolloRebornSubredditName = @"ApolloReborn";
 static char kAboutSubredditIconTaskKey;
+
+static NSString *ApolloIPadPaneLayoutSettingDetail(void) {
+    BOOL desired = [NSUserDefaults.standardUserDefaults boolForKey:UDKeyIPadPaneLayout];
+    BOOL active = ApolloPaneLayoutActive();
+    if (desired != active) {
+        return desired
+            ? @"Will turn on after Apollo quits and reopens. The current single-column layout remains active until then."
+            : @"Will turn off after Apollo quits and reopens. The current multi-column layout remains active until then.";
+    }
+    return @"Experimental on iPadOS 18 or newer. Puts your tabs in a sidebar and opens comments beside the post list instead of on top of it. Apollo restarts to apply changes.";
+}
 
 @interface ApolloFeedShortcutsPreviewState : NSObject
 @property (nonatomic, copy) NSArray<NSNumber *> *visibleIndexes;
@@ -1828,8 +1840,10 @@ typedef NS_ENUM(NSInteger, Tag) {
                                      title:@"Move Tab Bar to Bottom"
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIPadTabBarBottom]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf iPadTabBarBottomSwitchToggled:sender]; }];
+    // Meaningless once the pane layout hides the floating pill entirely.
     iPadTabBarBottom.visible = ^BOOL {
-        return UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad && IsLiquidGlass();
+        return UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad && IsLiquidGlass() &&
+               !ApolloPaneLayoutActive();
     };
 
     NSString *footer = ApolloSupportsNativeTabBarScrollBehavior()
@@ -1860,6 +1874,27 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf lgTitleGapCenteringSwitchToggled:sender]; }];
     titleGapCentering.visible = ^BOOL { return IsLiquidGlass(); };
 
+    // Experimental multi-column iPad layout. Hidden outright on iPhone rather
+    // than shown-disabled: it is a whole-app restructure with nothing to
+    // preview or explain on a device that will never run it.
+    // Installation happens at scene connect, so the handler confirms and
+    // restarts instead of pretending the change is live.
+    ApolloSettingsRow *iPadPaneLayout =
+        [ApolloSettingsRow customRowWithID:@"gen.iPadPaneLayout"
+                                      cell:^UITableViewCell *(__unused UITableView *tableView, __unused ApolloSettingsRow *row) {
+            UITableViewCell *cell = [weakSelf switchCellWithIdentifier:@"Cell_Gen_IPadPaneLayout"
+                                                                 label:@"Multi-Column Layout (Experimental)"
+                                                                detail:ApolloIPadPaneLayoutSettingDetail()
+                                                                    on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyIPadPaneLayout]
+                                                               enabled:YES
+                                                                action:@selector(iPadPaneLayoutSwitchToggled:)];
+            return cell ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        }
+                                  onSelect:nil];
+    iPadPaneLayout.visible = ^BOOL {
+        return ApolloPaneLayoutSupported();
+    };
+
     // Overrides the top scroll-edge glass under the nav bar (iOS 26+). Liquid
     // Glass only — hidden otherwise rather than shown-disabled, since the row
     // has nothing to preview/explain on a non-Glass device.
@@ -1875,7 +1910,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
     return [ApolloSettingsSection sectionWithTitle:@"Display & Navigation"
                                             footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nHeader Style: Soft is the iOS 26 default; Hard is the iOS 27 default."
-                                              rows:@[ userAvatars, titleGapCentering, scrollEdgeEffect ]];
+                                              rows:@[ userAvatars, titleGapCentering, iPadPaneLayout, scrollEdgeEffect ]];
 }
 
 // Display order of the Header Style picker. Raw values are NOT contiguous
@@ -4054,6 +4089,37 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     sIPadTabBarBottom = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sIPadTabBarBottom forKey:UDKeyIPadTabBarBottom];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloIPadTabBarBottomChangedNotification object:nil];
+}
+
+// The split controllers are built during scene connect, which already happened
+// for this process, so there is no live path — quit & reopen is the honest
+// option. The default is written FIRST so the choice survives either way: quit
+// now, or next time the user relaunches for any reason. `sIPadPaneLayout` is
+// deliberately NOT updated here — it must keep describing the layout this
+// process actually installed, or every module that gates on it starts lying.
+- (void)iPadPaneLayoutSwitchToggled:(UISwitch *)sender {
+    BOOL on = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:on forKey:UDKeyIPadPaneLayout];
+    // Dependent rows describe the hierarchy that is active in THIS process,
+    // while this switch and its pending subtitle describe the saved choice.
+    [self visibilityDidChange];
+    [self reloadRowWithID:@"gen.iPadPaneLayout"];
+
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:@"Restart to Apply"
+                         message:on
+            ? @"The multi-column layout is set up when Apollo launches, so it needs to quit and reopen to take effect."
+            : @"Apollo needs to quit and reopen to return to the single-column layout."
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Quit Apollo"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        exit(0);
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Later"
+                                              style:UIAlertActionStyleCancel
+                                            handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)proxyImgurDDGSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
Add the default-off Multi-Column Layout setting on iPadOS 18+. Rehost each tab’s native navigation controller in a split container and route basic feed/detail navigation into adjacent panes.

Stacked on `je/ipad-01-simulator`; review this PR against that base.

Validation: Simulator target compiled and linked. This is a foundation review slice; the following navigation and workspace PRs complete the experiment.

Part of the replacement stack for #886. The complete runtime stack remains experimental and opt-in. These draft slices are for review in order; do not ship an intermediate navigation implementation. Foldable/resizable-phone support is a separate follow-up. Existing device-only and performance validation gaps remain recorded in the validation PR.

Review order: #1053 → #1054 → #1055 → #1056 → #1057 → #1058; resizable iPhone support: #1059.
