### PR TITLE
iPad panes 2/4: navigation ownership and compact transitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,11 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloTabBarHideStyle.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
     $(SRC_DIR)/ipad/ApolloPaneLayout.m \
+    $(SRC_DIR)/ipad/ApolloPaneRouting.m \
+    $(SRC_DIR)/ipad/ApolloPaneForwardHistory.m \
     $(SRC_DIR)/ipad/ApolloPaneSplitViewController.m \
     $(SRC_DIR)/ipad/ApolloPaneInstall.xm \
+    $(SRC_DIR)/ipad/ApolloPaneEntryPoints.xm \
     $(SRC_DIR)/ipad/ApolloPaneRouter.xm \
     $(SRC_DIR)/ApolloScrollEdgeEffect.xm \
     $(SRC_DIR)/ApolloProgressiveBlur.xm \

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1334,13 +1334,33 @@ UIViewController *ApolloMainTabBarController(void) {
     return ApolloTabBarControllerIvarOn(application.delegate);
 }
 
-// Deliberately implemented with plain UIKit rather than by asking the pane
-// module: ApolloCommon is included by nearly every file, and a dependency on
-// src/ipad/ would drag the iPad layout into translation units that must stay
-// free of it. Class-shape matching is enough — no gate check is needed, because
-// a tab child is only ever a split view controller when the layout installed.
+// ApolloCommon is included by nearly every file, so it must not import the pane
+// module. The pane nevertheless has to be the authority for its real navigation
+// controllers: UIKit wraps our plain secondary host in another navigation
+// controller, and `viewControllerForColumn:` can therefore return either that
+// wrapper or the host rather than Apollo's navigation controller nested inside
+// it. Ask for the pane's public column accessor dynamically first, then retain a
+// plain-UIKit fallback for split controllers that do not belong to this feature.
 static UINavigationController *ApolloNavigationControllerForSplitColumn(UISplitViewController *split,
                                                                         UISplitViewControllerColumn column) {
+    SEL paneAccessor = NSSelectorFromString(@"apollo_navigationControllerForColumn:");
+    if ([split respondsToSelector:paneAccessor]) {
+        @try {
+            // ApolloPaneColumn intentionally uses the same 0/1/2 values as
+            // UISplitViewControllerColumn for primary/supplementary/secondary.
+            // Keep the call scalar so this common module needs no ipad/ import.
+            id result = ((id (*)(id, SEL, NSInteger))objc_msgSend)(split, paneAccessor, (NSInteger)column);
+            if ([result isKindOfClass:[UINavigationController class]]) {
+                return (UINavigationController *)result;
+            }
+            ApolloLog(@"[Common] pane column %ld returned non-navigation controller %@",
+                      (long)column, result ? NSStringFromClass([result class]) : @"nil");
+        } @catch (NSException *exception) {
+            ApolloLog(@"[Common] pane navigation accessor threw on %@ column %ld: %@",
+                      split, (long)column, exception);
+        }
+    }
+
     UIViewController *columnController = nil;
     if ([split respondsToSelector:@selector(viewControllerForColumn:)]) {
         @try {

--- a/src/ApolloDirectChatWeb.xm
+++ b/src/ApolloDirectChatWeb.xm
@@ -14,6 +14,7 @@
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloWebSessionStore.h"
 #import "UserDefaultConstants.h"
+#import "ipad/ApolloPaneLayout.h"
 
 #import <WebKit/WebKit.h>
 #import <math.h>
@@ -3913,14 +3914,23 @@ static void ApolloStandaloneChatBackPanForgetHost(ApolloDirectChatWebViewControl
 - (BOOL)tabBarController:(UITabBarController *)tabBarController
  shouldSelectViewController:(UIViewController *)viewController {
     for (UIViewController *candidate in tabBarController.viewControllers) {
+        // PaneEntry's narrowly-scoped native compatibility adapter may expose
+        // synthetic primary navigation controllers while this hook is chained
+        // around Apollo's same delegate method. Recover the real pane before
+        // enumerating columns so hook/link order cannot hide a preserved
+        // mailbox in detail.
+        UIViewController *actualCandidate =
+            ApolloPaneSplitControllerFor(candidate) ?: candidate;
+        UIViewController *actualSelection =
+            ApolloPaneSplitControllerFor(viewController) ?: viewController;
         // Every column: with the iPad pane layout a tab holds more than one
         // navigation controller, and the return marker can be on any of them.
-        for (UINavigationController *navigationController in ApolloAllNavigationControllersForTabChild(candidate)) {
+        for (UINavigationController *navigationController in ApolloAllNavigationControllersForTabChild(actualCandidate)) {
             ApolloDirectChatWebViewController *mailbox = ApolloMailboxReturnController(navigationController);
             // `viewController` is the tab CHILD being selected — the split view
             // controller under the pane layout — so compare by containment
             // rather than identity against the mailbox's navigation controller.
-            if (!mailbox || !ApolloViewControllerContains(viewController, mailbox.navigationController)) continue;
+            if (!mailbox || !ApolloViewControllerContains(actualSelection, mailbox.navigationController)) continue;
 
             ApolloClearMailboxReturn(navigationController);
             [mailbox apollo_prepareForMailboxReturnAnimated:NO];

--- a/src/ApolloQuickActions.xm
+++ b/src/ApolloQuickActions.xm
@@ -292,6 +292,43 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
 
 %hook _TtC6Apollo13SceneDelegate
 
+- (void)scene:(UIScene *)scene
+ willConnectToSession:(UISceneSession *)session
+             options:(UISceneConnectionOptions *)connectionOptions {
+    %orig(scene, session, connectionOptions);
+
+    // Native Apollo consumes its own connection options before the pane
+    // installer wraps the tab children. Reborn-owned routes are not known to
+    // Apollo, so claim them here and queue their existing retry-based handler.
+    // The async hop makes this independent of Logos hook ordering: pane
+    // installation will have completed before the first attempt runs.
+    for (UIOpenURLContext *context in connectionOptions.URLContexts) {
+        if (ApolloQuickActionsHandleURL(context.URL)) {
+            ApolloLog(@"[QuickActions] Queued Reborn cold URL route");
+        }
+    }
+
+    UNNotificationResponse *response = connectionOptions.notificationResponse;
+    NSDictionary *userInfo = response.notification.request.content.userInfo;
+    NSString *rawURL = [userInfo[@"apollo_deep_link"] isKindOfClass:[NSString class]]
+        ? userInfo[@"apollo_deep_link"] : nil;
+    if (!rawURL.length && [userInfo[@"url"] isKindOfClass:[NSString class]]) {
+        rawURL = userInfo[@"url"];
+    }
+    if (rawURL.length > 0 && ApolloQuickActionsHandleURL([NSURL URLWithString:rawURL])) {
+        ApolloLog(@"[QuickActions] Queued Reborn cold notification route");
+    }
+
+#if APOLLO_SIM_BUILD
+    NSString *injectedURL =
+        NSProcessInfo.processInfo.environment[@"APOLLO_SIM_COLD_REBORN_URL"];
+    if (injectedURL.length > 0 &&
+        ApolloQuickActionsHandleURL([NSURL URLWithString:injectedURL])) {
+        ApolloLog(@"[QuickActions] Queued simulator-injected Reborn cold route");
+    }
+#endif
+}
+
 - (void)scene:(UIScene *)scene openURLContexts:(NSSet *)URLContexts {
     NSMutableSet *unhandledContexts = [NSMutableSet setWithCapacity:URLContexts.count];
     BOOL handledAny = NO;

--- a/src/ApolloSwiftIvarBridge.swift
+++ b/src/ApolloSwiftIvarBridge.swift
@@ -10,6 +10,7 @@
 //
 
 import Foundation
+import UIKit
 
 @_cdecl("ApolloSwiftAssignOptionalString")
 public func ApolloSwiftAssignOptionalString(
@@ -35,4 +36,76 @@ public func ApolloSwiftAssignOptionalStringArray(
         value = nil
     }
     storage.assumingMemoryBound(to: Optional<[String]>.self).pointee = value
+}
+
+/// ApolloNavigationController keeps its forward history in a Swift
+/// `[UIViewController]` stored ivar. Objective-C can locate that ivar, but it
+/// must not treat the one-word Swift Array value as an NSArray object or write
+/// `_swiftEmptyArrayStorage` by hand. Keeping the assignment here makes Swift
+/// own the array ABI and its retain/release operations.
+@_cdecl("ApolloSwiftClearViewControllerArray")
+public func ApolloSwiftClearViewControllerArray(
+    _ storage: UnsafeMutableRawPointer?
+) {
+    guard let storage else { return }
+    storage.assumingMemoryBound(to: [UIViewController].self).pointee.removeAll(
+        keepingCapacity: false
+    )
+}
+
+/// Diagnostic companion for the clear helper. This is intentionally a count,
+/// not an NSArray bridge: no Objective-C caller should ever take ownership of
+/// Apollo's private Swift-array storage.
+@_cdecl("ApolloSwiftViewControllerArrayCount")
+public func ApolloSwiftViewControllerArrayCount(
+    _ storage: UnsafeRawPointer?
+) -> UInt {
+    guard let storage else { return 0 }
+    return UInt(storage.assumingMemoryBound(to: [UIViewController].self).pointee.count)
+}
+
+// Process-local wrapper around the exact AnyHashable identity Apollo's
+// ListAdapter uses for diffing. Objective-C must never decode Swift Array,
+// Dictionary, AnyHashable, or Foundation.IndexPath storage itself; these two C
+// entry points keep every collection operation on the Swift side of the ABI.
+private final class ApolloListAdapterIdentityToken: NSObject, NSCopying {
+    let key: AnyHashable
+
+    init(key: AnyHashable) {
+        self.key = key
+        super.init()
+    }
+
+    override var description: String { "<ApolloListAdapterIdentityToken>" }
+    override var debugDescription: String { description }
+
+    func copy(with zone: NSZone? = nil) -> Any { self }
+}
+
+@_cdecl("ApolloSwiftListAdapterModelIdentifier")
+public func ApolloSwiftListAdapterModelIdentifier(
+    _ objectsStorage: UnsafeRawPointer?,
+    _ section: Int,
+    _ row: Int
+) -> UnsafeMutableRawPointer? {
+    guard Thread.isMainThread, let objectsStorage, section == 0, row >= 0 else { return nil }
+    let objects = objectsStorage.assumingMemoryBound(to: [AnyHashable].self).pointee
+    guard row < objects.count else { return nil }
+    let token = ApolloListAdapterIdentityToken(key: objects[row])
+    return Unmanaged.passRetained(token).toOpaque()
+}
+
+@_cdecl("ApolloSwiftListAdapterIndexPathForModelIdentifier")
+public func ApolloSwiftListAdapterIndexPathForModelIdentifier(
+    _ mappingStorage: UnsafeRawPointer?,
+    _ tokenObject: UnsafeRawPointer?
+) -> UnsafeMutableRawPointer? {
+    guard Thread.isMainThread, let mappingStorage, let tokenObject else { return nil }
+    let object = Unmanaged<AnyObject>.fromOpaque(tokenObject).takeUnretainedValue()
+    guard let token = object as? ApolloListAdapterIdentityToken else { return nil }
+    let mapping = mappingStorage.assumingMemoryBound(
+        to: [AnyHashable: IndexPath].self
+    ).pointee
+    guard let path = mapping[token.key] else { return nil }
+    return Unmanaged.passRetained(path as NSIndexPath).toOpaque()
 }

--- a/src/ipad/ApolloPaneEntryPoints.xm
+++ b/src/ipad/ApolloPaneEntryPoints.xm
@@ -1,0 +1,213 @@
+// ApolloPaneEntryPoints.xm
+//
+// Compatibility adapter for Apollo's native external-entry callbacks.
+//
+// Apollo 1.15.11 assumes every tab child is an ApolloNavigationController:
+// warm URL, APNs, Handoff/Siri, and shortcut handlers either cast
+// selectedViewController directly or index viewControllers and cast the result.
+// Pane mode intentionally makes each tab child an ApolloPaneSplitViewController,
+// so those handlers otherwise select the right tab and then silently fail to
+// push their destination.
+//
+// During only those native callback bodies, the two getters Apollo uses expose
+// each pane's primary navigation controller. UIKit selection setters are run
+// with the adapter suspended and translate a synthetic navigation controller
+// back to its real pane child. The actual tab hierarchy is never mutated.
+
+#import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import "../ApolloCommon.h"
+
+// UIKit entry callbacks are main-thread APIs. A counter, rather than a BOOL,
+// preserves the scope if another hooked entry point is invoked synchronously.
+static NSUInteger sApolloPaneNativeEntryDepth = 0;
+
+static BOOL ApolloPaneNativeEntryCompatibilityActive(void) {
+    return sApolloPaneNativeEntryDepth > 0 && ApolloPaneLayoutActive();
+}
+
+static void ApolloPaneBeginNativeEntry(void) {
+    if (ApolloPaneLayoutActive()) sApolloPaneNativeEntryDepth++;
+}
+
+static void ApolloPaneEndNativeEntry(void) {
+    if (sApolloPaneNativeEntryDepth > 0) sApolloPaneNativeEntryDepth--;
+}
+
+static NSArray<UIViewController *> *ApolloPaneActualTabChildren(UITabBarController *tabBarController) {
+    NSUInteger savedDepth = sApolloPaneNativeEntryDepth;
+    sApolloPaneNativeEntryDepth = 0;
+    NSArray<UIViewController *> *children = nil;
+    @try {
+        children = tabBarController.viewControllers;
+    } @finally {
+        sApolloPaneNativeEntryDepth = savedDepth;
+    }
+    return children ?: @[];
+}
+
+static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarController *tabBarController,
+                                                                 UIViewController *candidate) {
+    if (!candidate) return candidate;
+    for (UIViewController *actual in ApolloPaneActualTabChildren(tabBarController)) {
+        if (actual == candidate) return actual;
+        if ([actual isKindOfClass:[ApolloPaneSplitViewController class]]) {
+            UINavigationController *primary =
+                [(ApolloPaneSplitViewController *)actual
+                    apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+            if (primary == candidate) return actual;
+        }
+    }
+    return candidate;
+}
+
+%group ApolloPaneEntryPointsGroup
+
+%hook UITabBarController
+
+- (UIViewController *)selectedViewController {
+    UIViewController *actual = %orig;
+    if (!ApolloPaneNativeEntryCompatibilityActive() ||
+        ![actual isKindOfClass:[ApolloPaneSplitViewController class]]) return actual;
+    UIViewController *compatible = [(ApolloPaneSplitViewController *)actual
+        apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ?: actual;
+    ApolloLog(@"[PaneEntry] exposed selected pane as %@", NSStringFromClass(compatible.class));
+    return compatible;
+}
+
+- (NSArray<UIViewController *> *)viewControllers {
+    NSArray<UIViewController *> *actual = %orig;
+    if (!ApolloPaneNativeEntryCompatibilityActive()) return actual;
+
+    NSMutableArray<UIViewController *> *compatible =
+        [NSMutableArray arrayWithCapacity:actual.count];
+    for (UIViewController *child in actual) {
+        if ([child isKindOfClass:[ApolloPaneSplitViewController class]]) {
+            UINavigationController *primary =
+                [(ApolloPaneSplitViewController *)child
+                    apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+            [compatible addObject:primary ?: child];
+        } else {
+            [compatible addObject:child];
+        }
+    }
+    return compatible;
+}
+
+- (void)setSelectedIndex:(NSUInteger)selectedIndex {
+    if (!ApolloPaneNativeEntryCompatibilityActive()) { %orig; return; }
+    NSUInteger savedDepth = sApolloPaneNativeEntryDepth;
+    sApolloPaneNativeEntryDepth = 0;
+    @try {
+        %orig(selectedIndex);
+    } @finally {
+        sApolloPaneNativeEntryDepth = savedDepth;
+    }
+}
+
+- (void)setSelectedViewController:(UIViewController *)selectedViewController {
+    if (!ApolloPaneNativeEntryCompatibilityActive()) { %orig; return; }
+    UIViewController *actual = ApolloPaneActualChildForSyntheticChild(self, selectedViewController);
+    NSUInteger savedDepth = sApolloPaneNativeEntryDepth;
+    sApolloPaneNativeEntryDepth = 0;
+    @try {
+        %orig(actual);
+    } @finally {
+        sApolloPaneNativeEntryDepth = savedDepth;
+    }
+}
+
+%end
+
+%hook _TtC6Apollo11AppDelegate
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options {
+    ApolloPaneBeginNativeEntry();
+    ApolloLog(@"[PaneEntry] AppDelegate URL callback active=%d", ApolloPaneLayoutActive());
+    @try {
+        return %orig(application, url, options);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+ didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler {
+    ApolloPaneBeginNativeEntry();
+    ApolloLog(@"[PaneEntry] AppDelegate notification callback active=%d", ApolloPaneLayoutActive());
+    @try {
+        %orig(center, response, completionHandler);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+%end
+
+
+%hook _TtC6Apollo13SceneDelegate
+
+- (BOOL)tabBarController:(UITabBarController *)tabBarController
+ shouldSelectViewController:(UIViewController *)viewController {
+    // Apollo dynamically casts this candidate to ApolloNavigationController to
+    // implement native same-tab behavior (scroll to top, then Back when already
+    // at top). Pane children are split controllers, so without this scoped
+    // translation the cast fails and reselection silently does nothing.
+    UIViewController *compatible = viewController;
+    if (ApolloPaneLayoutActive() &&
+        [viewController isKindOfClass:[ApolloPaneSplitViewController class]]) {
+        compatible = [(ApolloPaneSplitViewController *)viewController
+            apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ?: viewController;
+    }
+    ApolloPaneBeginNativeEntry();
+    @try {
+        return %orig(tabBarController, compatible);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet *)URLContexts {
+    ApolloPaneBeginNativeEntry();
+    ApolloLog(@"[PaneEntry] SceneDelegate URL callback active=%d", ApolloPaneLayoutActive());
+    @try {
+        %orig(scene, URLContexts);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+- (void)windowScene:(UIWindowScene *)windowScene
+ performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
+   completionHandler:(void (^)(BOOL succeeded))completionHandler {
+    ApolloPaneBeginNativeEntry();
+    ApolloLog(@"[PaneEntry] SceneDelegate shortcut callback active=%d", ApolloPaneLayoutActive());
+    @try {
+        %orig(windowScene, shortcutItem, completionHandler);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+    ApolloPaneBeginNativeEntry();
+    ApolloLog(@"[PaneEntry] SceneDelegate activity callback active=%d", ApolloPaneLayoutActive());
+    @try {
+        %orig(scene, userActivity);
+    } @finally {
+        ApolloPaneEndNativeEntry();
+    }
+}
+
+%end
+
+%end
+
+%ctor {
+    if (!ApolloPaneLayoutEnabled()) return;
+    %init(ApolloPaneEntryPointsGroup);
+    ApolloLog(@"[PaneEntry] installed scoped native-entry compatibility adapter");
+}

--- a/src/ipad/ApolloPaneForwardHistory.h
+++ b/src/ipad/ApolloPaneForwardHistory.h
@@ -1,0 +1,16 @@
+// ApolloPaneForwardHistory.h
+//
+// ABI-safe access to ApolloNavigationController's private Swift forward stack.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+__BEGIN_DECLS
+
+// Remove every controller Apollo could resurrect through goForward / the
+// right-edge gesture. Returns NO when the runtime class no longer exposes the
+// expected Swift ivar, allowing callers to degrade without touching raw memory.
+BOOL ApolloPaneClearForwardHistory(UINavigationController *navigationController);
+
+__END_DECLS
+NS_ASSUME_NONNULL_END

--- a/src/ipad/ApolloPaneForwardHistory.m
+++ b/src/ipad/ApolloPaneForwardHistory.m
@@ -1,0 +1,56 @@
+// ApolloPaneForwardHistory.m
+
+// Apollo's `poppedViewControllers` is a native Swift Array value, not an
+// Objective-C object pointer. The runtime gives us its byte offset; a tiny
+// Swift bridge performs the actual typed access so Swift owns its ABI and
+// reference counting.
+
+#import "ApolloPaneForwardHistory.h"
+#import <objc/runtime.h>
+#import "../ApolloCommon.h"
+
+extern void ApolloSwiftClearViewControllerArray(void *storage);
+extern NSUInteger ApolloSwiftViewControllerArrayCount(const void *storage);
+
+BOOL ApolloPaneClearForwardHistory(UINavigationController *navigationController) {
+    if (!navigationController) return NO;
+
+    // UIKit navigation mutations are main-thread-only, and the Swift storage
+    // contract below is intentionally pinned to Apollo's exact class rather
+    // than inherited by an unknown future subclass with a different layout.
+    Class apolloNavigationClass =
+        objc_getClass("_TtC6Apollo26ApolloNavigationController");
+    if (!NSThread.isMainThread || !apolloNavigationClass ||
+        navigationController.class != apolloNavigationClass) {
+        ApolloLog(@"[PaneHistory] refused clear main=%d actual=%@ expected=%@",
+                  NSThread.isMainThread,
+                  NSStringFromClass(navigationController.class),
+                  NSStringFromClass(apolloNavigationClass));
+        return NO;
+    }
+
+    Ivar forwardHistoryIvar =
+        class_getInstanceVariable(apolloNavigationClass, "poppedViewControllers");
+    Ivar followingIvar =
+        class_getInstanceVariable(apolloNavigationClass, "interactionController");
+    ptrdiff_t forwardOffset = forwardHistoryIvar ? ivar_getOffset(forwardHistoryIvar) : -1;
+    ptrdiff_t followingOffset = followingIvar ? ivar_getOffset(followingIvar) : -1;
+    if (!forwardHistoryIvar || !followingIvar ||
+        followingOffset - forwardOffset != (ptrdiff_t)sizeof(void *)) {
+        ApolloLog(@"[PaneHistory] %@ forward ivar layout mismatch (%td -> %td); history unchanged",
+                  NSStringFromClass(navigationController.class),
+                  forwardOffset, followingOffset);
+        return NO;
+    }
+
+    uint8_t *objectBytes = (uint8_t *)(__bridge void *)navigationController;
+    void *storage = objectBytes + forwardOffset;
+    NSUInteger before = ApolloSwiftViewControllerArrayCount(storage);
+    if (before == 0) return YES;
+    ApolloSwiftClearViewControllerArray(storage);
+    NSUInteger after = ApolloSwiftViewControllerArrayCount(storage);
+    ApolloLog(@"[PaneHistory] cleared %@ forward history %lu -> %lu",
+              NSStringFromClass(navigationController.class),
+              (unsigned long)before, (unsigned long)after);
+    return after == 0;
+}

--- a/src/ipad/ApolloPaneInstall.xm
+++ b/src/ipad/ApolloPaneInstall.xm
@@ -34,10 +34,129 @@
 @interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
 @end
 
-// Wraps every navigation-controller child of `tabBarController` in a pane
-// controller. Returns YES only if at least one tab was converted — a total
-// failure leaves the stock hierarchy completely untouched, which is what makes
-// the feature fail safe rather than half-applied.
+@interface ApolloPaneInstallNavigationSnapshot : NSObject
+@property (nonatomic, strong) UINavigationController *navigationController;
+@property (nonatomic, copy) NSArray<UIViewController *> *viewControllers;
+@property (nonatomic, copy) NSArray<NSNumber *> *extendedOpaqueFlags;
+@end
+
+@implementation ApolloPaneInstallNavigationSnapshot
+@end
+
+static char kApolloPaneInstallStateKey;
+static NSString *const kApolloPaneInstallStateInstalling = @"installing";
+static NSString *const kApolloPaneInstallStateInstalled = @"installed";
+static NSString *const kApolloPaneInstallStateFailed = @"failed";
+
+static BOOL ApolloPaneIdentityArraysEqual(NSArray *left, NSArray *right) {
+    if (left.count != right.count) return NO;
+    for (NSUInteger index = 0; index < left.count; index++) {
+        if (left[index] != right[index]) return NO;
+    }
+    return YES;
+}
+
+#if APOLLO_SIM_BUILD
+static BOOL ApolloPaneInstallSimMatches(NSString *phase, NSInteger tabIndex) {
+    NSString *requested = NSProcessInfo.processInfo.environment[@"APOLLO_SIM_PANE_INSTALL_FAIL"];
+    if (requested.length == 0 || phase.length == 0) return NO;
+    NSArray<NSString *> *parts = [requested componentsSeparatedByString:@":"];
+    if (![parts.firstObject isEqualToString:phase]) return NO;
+    if (parts.count == 1) return YES;
+    if (parts.count != 2 || tabIndex < 0) return NO;
+    NSScanner *scanner = [NSScanner scannerWithString:parts[1]];
+    NSInteger requestedIndex = NSNotFound;
+    return [scanner scanInteger:&requestedIndex] && scanner.isAtEnd && requestedIndex == tabIndex;
+}
+
+void ApolloPaneInstallSimCheckpoint(NSString *phase, NSInteger tabIndex) {
+    if (!ApolloPaneInstallSimMatches(phase, tabIndex)) return;
+    ApolloLog(@"[PaneInstallTest] injecting exception phase=%@ tab=%ld", phase, (long)tabIndex);
+    [NSException raise:@"ApolloPaneInstallInjectedFailure"
+                format:@"injected phase=%@ tab=%ld", phase, (long)tabIndex];
+}
+
+BOOL ApolloPaneInstallSimShouldReturnNil(NSString *phase, NSInteger tabIndex) {
+    BOOL matches = ApolloPaneInstallSimMatches(phase, tabIndex);
+    if (matches) {
+        ApolloLog(@"[PaneInstallTest] injecting nil phase=%@ tab=%ld", phase, (long)tabIndex);
+    }
+    return matches;
+}
+
+static void ApolloPaneInstallSimWriteStatus(UITabBarController *tabBarController,
+                                            NSString *result,
+                                            BOOL rollbackExact,
+                                            NSString *reason) {
+    NSMutableArray *children = [NSMutableArray array];
+    NSUInteger paneCount = 0;
+    NSUInteger navigationCount = 0;
+    for (UIViewController *child in tabBarController.viewControllers ?: @[]) {
+        BOOL pane = [child isKindOfClass:[ApolloPaneSplitViewController class]];
+        BOOL navigation = [child isKindOfClass:[UINavigationController class]];
+        if (pane) paneCount++;
+        if (navigation) navigationCount++;
+        [children addObject:@{
+            @"class": NSStringFromClass(child.class) ?: @"",
+            @"pane": @(pane),
+            @"navigation": @(navigation),
+            @"stackDepth": navigation ? @(((UINavigationController *)child).viewControllers.count) : @0,
+        }];
+    }
+    NSDictionary *status = @{
+        @"result": result ?: @"unknown",
+        @"reason": reason ?: @"",
+        @"rollbackExact": @(rollbackExact),
+        @"active": @(ApolloPaneLayoutActive()),
+        @"childCount": @(tabBarController.viewControllers.count),
+        @"paneCount": @(paneCount),
+        @"navigationCount": @(navigationCount),
+        @"selectedIndex": @(tabBarController.selectedIndex),
+        @"children": children,
+    };
+    NSData *data = [NSJSONSerialization dataWithJSONObject:status options:NSJSONWritingPrettyPrinted error:nil];
+    [data writeToFile:@"/tmp/apollo-pane-install-status.json" atomically:YES];
+}
+#endif
+
+static ApolloPaneInstallNavigationSnapshot *ApolloPaneSnapshotNavigationController(
+    UINavigationController *navigationController) {
+    ApolloPaneInstallNavigationSnapshot *snapshot = [ApolloPaneInstallNavigationSnapshot new];
+    snapshot.navigationController = navigationController;
+    snapshot.viewControllers = [navigationController.viewControllers copy] ?: @[];
+    NSMutableArray<NSNumber *> *flags = [NSMutableArray arrayWithCapacity:snapshot.viewControllers.count];
+    for (UIViewController *controller in snapshot.viewControllers) {
+        [flags addObject:@(controller.extendedLayoutIncludesOpaqueBars)];
+    }
+    snapshot.extendedOpaqueFlags = flags;
+    return snapshot;
+}
+
+static BOOL ApolloPaneRestoreMatchesSnapshots(
+    UITabBarController *tabBarController,
+    NSArray<UIViewController *> *originalChildren,
+    NSArray<ApolloPaneInstallNavigationSnapshot *> *navigationSnapshots,
+    UIViewController *originalSelectedController,
+    NSUInteger originalSelectedIndex) {
+    if (!ApolloPaneIdentityArraysEqual(tabBarController.viewControllers, originalChildren)) return NO;
+    NSUInteger expectedSelection = [originalChildren indexOfObjectIdenticalTo:originalSelectedController];
+    if (expectedSelection == NSNotFound) expectedSelection = originalSelectedIndex;
+    if (expectedSelection < originalChildren.count && tabBarController.selectedIndex != expectedSelection) return NO;
+    for (ApolloPaneInstallNavigationSnapshot *snapshot in navigationSnapshots) {
+        if (!ApolloPaneIdentityArraysEqual(snapshot.navigationController.viewControllers,
+                                           snapshot.viewControllers)) return NO;
+        for (NSUInteger index = 0; index < snapshot.viewControllers.count; index++) {
+            if (snapshot.viewControllers[index].extendedLayoutIncludesOpaqueBars !=
+                snapshot.extendedOpaqueFlags[index].boolValue) return NO;
+        }
+    }
+    return YES;
+}
+
+// Wraps every navigation-controller child of `tabBarController` in one atomic
+// transaction. Returns YES only after the complete staged hierarchy passes its
+// identity/containment postconditions; every exception restores the exact stock
+// children, stacks, flags and selection before returning to Apollo.
 static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarController) {
     if (![tabBarController isKindOfClass:[UITabBarController class]]) {
         ApolloLog(@"[PaneInstall] root is not a UITabBarController (%@); skipping",
@@ -45,51 +164,215 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
         return NO;
     }
 
-    NSArray<UIViewController *> *children = tabBarController.viewControllers;
+    NSString *existingState = objc_getAssociatedObject(tabBarController, &kApolloPaneInstallStateKey);
+    if ([existingState isEqualToString:kApolloPaneInstallStateInstalled]) {
+        ApolloLog(@"[PaneInstall] transaction already committed on this tab bar controller");
+        return YES;
+    }
+    if ([existingState isEqualToString:kApolloPaneInstallStateInstalling] ||
+        [existingState isEqualToString:kApolloPaneInstallStateFailed]) {
+        ApolloLog(@"[PaneInstall] refusing transaction in terminal state=%@", existingState);
+        return NO;
+    }
+
+    NSArray<UIViewController *> *children = [tabBarController.viewControllers copy];
     if (children.count == 0) {
         ApolloLog(@"[PaneInstall] tab bar controller has no children; skipping");
         return NO;
     }
 
-    NSMutableArray<UIViewController *> *converted = [NSMutableArray arrayWithCapacity:children.count];
-    NSUInteger wrapped = 0;
-
-    for (NSUInteger index = 0; index < children.count; index++) {
-        UIViewController *child = children[index];
-
-        // Anything that is not a navigation controller stays exactly as it is.
-        // Apollo ships five navigation controllers today, but an unexpected
-        // child must not be dropped from the tab bar.
-        if (![child isKindOfClass:[UINavigationController class]]) {
-            ApolloLog(@"[PaneInstall] tab %lu is %@, not a navigation controller; left as-is",
-                      (unsigned long)index, NSStringFromClass([child class]));
-            [converted addObject:child];
-            continue;
-        }
-
-        ApolloPaneSplitViewController *pane =
-            [ApolloPaneSplitViewController paneControllerWithRootNavigationController:(UINavigationController *)child
-                                                                            tabIndex:(NSInteger)index];
-        if (!pane) {
-            ApolloLog(@"[PaneInstall] tab %lu pane construction failed; left as-is", (unsigned long)index);
-            [converted addObject:child];
-            continue;
-        }
-
-        [converted addObject:pane];
-        wrapped++;
+    NSUInteger existingPaneCount = 0;
+    NSUInteger existingNavigationCount = 0;
+    for (UIViewController *child in children) {
+        if ([child isKindOfClass:[ApolloPaneSplitViewController class]]) existingPaneCount++;
+        if ([child isKindOfClass:[UINavigationController class]]) existingNavigationCount++;
     }
-
-    if (wrapped == 0) {
-        ApolloLog(@"[PaneInstall] no tabs converted; leaving stock hierarchy untouched");
+    if (existingPaneCount > 0) {
+        if (existingNavigationCount == 0) {
+            objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                                     kApolloPaneInstallStateInstalled, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            ApolloLog(@"[PaneInstall] complete pane hierarchy already present; adopting it");
+            return YES;
+        }
+        objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                                 kApolloPaneInstallStateFailed, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[PaneInstall] mixed pane/navigation hierarchy rejected; refusing to wrap again");
         return NO;
     }
 
-    // Reassigning `viewControllers` resets the selection, so restore it. Read
-    // the index before the write: the setter clamps/zeroes it as a side effect.
-    NSUInteger selected = tabBarController.selectedIndex;
-    tabBarController.viewControllers = converted;
-    if (selected < converted.count) tabBarController.selectedIndex = selected;
+    objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                             kApolloPaneInstallStateInstalling, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSUInteger originalSelectedIndex = tabBarController.selectedIndex;
+    UIViewController *originalSelectedController = tabBarController.selectedViewController;
+    NSMutableArray<ApolloPaneInstallNavigationSnapshot *> *navigationSnapshots = [NSMutableArray array];
+    for (UIViewController *child in children) {
+        if ([child isKindOfClass:[UINavigationController class]]) {
+            [navigationSnapshots addObject:ApolloPaneSnapshotNavigationController(
+                (UINavigationController *)child)];
+        }
+    }
+    if (navigationSnapshots.count == 0) {
+        objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                                 kApolloPaneInstallStateFailed, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[PaneInstall] no eligible navigation-controller tabs; leaving stock hierarchy intact");
+        return NO;
+    }
+
+    NSMutableArray<UIViewController *> *converted = [NSMutableArray arrayWithCapacity:children.count];
+    NSMutableArray<ApolloPaneSplitViewController *> *stagedPanes = [NSMutableArray array];
+#if APOLLO_SIM_BUILD
+    NSString *failureReason = nil;
+#endif
+
+    @try {
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"preflight", -1);
+#endif
+        // Construction reparents the original navigation controllers. Detach
+        // the entire stock array first so UIKit never sees one controller with
+        // two parents. This is a staged mutation covered by the exact rollback
+        // snapshot below; no partially converted array is ever published.
+        tabBarController.viewControllers = @[];
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"after-detach", -1);
+#endif
+
+        for (NSUInteger index = 0; index < children.count; index++) {
+            UIViewController *child = children[index];
+
+            // Anything that is not a navigation controller stays exactly as it
+            // is, at the same identity and index.
+            if (![child isKindOfClass:[UINavigationController class]]) {
+                ApolloLog(@"[PaneInstall] tab %lu is %@, not a navigation controller; left as-is",
+                          (unsigned long)index, NSStringFromClass([child class]));
+                [converted addObject:child];
+                continue;
+            }
+#if APOLLO_SIM_BUILD
+            ApolloPaneInstallSimCheckpoint(@"construct-begin", (NSInteger)index);
+            if (ApolloPaneInstallSimShouldReturnNil(@"construct-nil", (NSInteger)index)) {
+                [NSException raise:@"ApolloPaneInstallInjectedNil"
+                            format:@"injected nil pane at tab %lu", (unsigned long)index];
+            }
+#endif
+
+            ApolloPaneSplitViewController *pane =
+                [ApolloPaneSplitViewController paneControllerWithRootNavigationController:
+                    (UINavigationController *)child tabIndex:(NSInteger)index];
+            if (!pane) {
+                [NSException raise:@"ApolloPaneInstallationException"
+                            format:@"tab %lu pane construction returned nil", (unsigned long)index];
+            }
+            [stagedPanes addObject:pane];
+            [converted addObject:pane];
+#if APOLLO_SIM_BUILD
+            ApolloPaneInstallSimCheckpoint(@"construct-complete", (NSInteger)index);
+#endif
+        }
+
+        if (converted.count != children.count || stagedPanes.count != navigationSnapshots.count) {
+            [NSException raise:@"ApolloPaneInstallationException"
+                        format:@"staged child count mismatch"];
+        }
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"validate", -1);
+#endif
+        NSUInteger snapshotIndex = 0;
+        for (NSUInteger index = 0; index < children.count; index++) {
+            UIViewController *original = children[index];
+            UIViewController *replacement = converted[index];
+            if (![original isKindOfClass:[UINavigationController class]]) {
+                if (replacement != original) {
+                    [NSException raise:@"ApolloPaneInstallationException"
+                                format:@"passthrough tab %lu changed identity", (unsigned long)index];
+                }
+                continue;
+            }
+            ApolloPaneInstallNavigationSnapshot *snapshot = navigationSnapshots[snapshotIndex++];
+            ApolloPaneSplitViewController *pane = (ApolloPaneSplitViewController *)replacement;
+            if (![pane isKindOfClass:[ApolloPaneSplitViewController class]] ||
+                ![pane apollo_validateInstallationWithOriginalNavigationController:
+                    snapshot.navigationController originalStack:snapshot.viewControllers] ||
+                pane.tabBarItem != original.tabBarItem) {
+                [NSException raise:@"ApolloPaneInstallationException"
+                            format:@"tab %lu failed staging postconditions", (unsigned long)index];
+            }
+        }
+
+        tabBarController.viewControllers = converted;
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"commit-children", -1);
+#endif
+        NSUInteger selectedIndex = [children indexOfObjectIdenticalTo:originalSelectedController];
+        if (selectedIndex == NSNotFound) selectedIndex = originalSelectedIndex;
+        if (selectedIndex < converted.count) tabBarController.selectedIndex = selectedIndex;
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"commit-selection", -1);
+#endif
+        if (!ApolloPaneIdentityArraysEqual(tabBarController.viewControllers, converted) ||
+            (selectedIndex < converted.count && tabBarController.selectedViewController != converted[selectedIndex])) {
+            [NSException raise:@"ApolloPaneInstallationException"
+                        format:@"committed tab hierarchy failed exact postconditions"];
+        }
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimCheckpoint(@"postcondition", -1);
+#endif
+    } @catch (NSException *exception) {
+#if APOLLO_SIM_BUILD
+        failureReason = exception.reason ?: exception.name;
+#endif
+        ApolloLog(@"[PaneInstall] transaction failed safely: %@; restoring stock hierarchy", exception);
+        for (ApolloPaneSplitViewController *pane in stagedPanes.reverseObjectEnumerator) {
+            @try {
+                [pane apollo_prepareForInstallationRollback];
+            } @catch (NSException *cleanupException) {
+                ApolloLog(@"[PaneInstall] staged pane cleanup threw: %@", cleanupException);
+            }
+        }
+        for (ApolloPaneInstallNavigationSnapshot *snapshot in navigationSnapshots) {
+            @try {
+                [snapshot.navigationController setViewControllers:snapshot.viewControllers animated:NO];
+                for (NSUInteger index = 0; index < snapshot.viewControllers.count; index++) {
+                    snapshot.viewControllers[index].extendedLayoutIncludesOpaqueBars =
+                        snapshot.extendedOpaqueFlags[index].boolValue;
+                }
+            } @catch (NSException *restoreException) {
+                ApolloLog(@"[PaneInstall] navigation snapshot restore threw: %@", restoreException);
+            }
+        }
+        @try {
+            tabBarController.viewControllers = children;
+            NSUInteger selectedIndex = [children indexOfObjectIdenticalTo:originalSelectedController];
+            if (selectedIndex == NSNotFound) selectedIndex = originalSelectedIndex;
+            if (selectedIndex < children.count) tabBarController.selectedIndex = selectedIndex;
+        } @catch (NSException *restoreException) {
+            ApolloLog(@"[PaneInstall] stock tab hierarchy restore threw: %@", restoreException);
+        }
+        BOOL rollbackExact = ApolloPaneRestoreMatchesSnapshots(
+            tabBarController, children, navigationSnapshots,
+            originalSelectedController, originalSelectedIndex);
+        for (ApolloPaneInstallNavigationSnapshot *snapshot in navigationSnapshots) {
+            for (ApolloPaneSplitViewController *pane in stagedPanes) {
+                if (ApolloPaneNavigationControllerIsRegisteredToSplit(
+                        snapshot.navigationController, pane)) {
+                    rollbackExact = NO;
+                    ApolloLog(@"[PaneInstall] rollback left a stale navigation-owner registration");
+                }
+            }
+        }
+        objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                                 kApolloPaneInstallStateFailed, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[PaneInstall] rollback exact=%d children=%lu selected=%lu",
+                  rollbackExact, (unsigned long)tabBarController.viewControllers.count,
+                  (unsigned long)tabBarController.selectedIndex);
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimWriteStatus(tabBarController, @"rolled-back", rollbackExact, failureReason);
+#endif
+        return NO;
+    }
+
+    objc_setAssociatedObject(tabBarController, &kApolloPaneInstallStateKey,
+                             kApolloPaneInstallStateInstalled, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     // THE FIXED SIDEBAR.
     //
@@ -117,11 +400,27 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     // beside the two-column panes, which is a coherent, if less native, layout —
     // the feature degrades rather than becoming unavailable.
     if (@available(iOS 18.0, *)) {
-        tabBarController.mode = UITabBarControllerModeTabSidebar;
-        ApolloLog(@"[PaneInstall] tab sidebar on: mode=%ld sidebar=%@ hidden=%d",
-                  (long)tabBarController.mode,
-                  tabBarController.sidebar,
-                  tabBarController.sidebar ? tabBarController.sidebar.isHidden : -1);
+        UITabBarControllerMode originalMode = tabBarController.mode;
+        @try {
+#if APOLLO_SIM_BUILD
+            ApolloPaneInstallSimCheckpoint(@"sidebar-before", -1);
+#endif
+            tabBarController.mode = UITabBarControllerModeTabSidebar;
+#if APOLLO_SIM_BUILD
+            ApolloPaneInstallSimCheckpoint(@"sidebar-after", -1);
+#endif
+            ApolloLog(@"[PaneInstall] tab sidebar on: mode=%ld sidebar=%@ hidden=%d",
+                      (long)tabBarController.mode,
+                      tabBarController.sidebar,
+                      tabBarController.sidebar ? tabBarController.sidebar.isHidden : -1);
+        } @catch (NSException *exception) {
+            // Sidebar mode is enhancement, not a structural prerequisite. A
+            // failure falls back to the coherent iOS-17-style tab bar while the
+            // already validated panes remain installed and active.
+            @try { tabBarController.mode = originalMode; } @catch (__unused NSException *ignored) {}
+            ApolloLog(@"[PaneInstall] tab sidebar setup failed safely: %@; keeping panes with mode=%ld",
+                      exception, (long)tabBarController.mode);
+        }
 
         // NOT ATTEMPTED AGAIN: `sidebar.preferredLayout`.
         // -[UITabBarControllerSidebar _resolvedLayout] maps preferredLayout 0
@@ -135,7 +434,8 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     }
 
     ApolloLog(@"[PaneInstall] installed panes on %lu/%lu tabs (selected=%lu)",
-              (unsigned long)wrapped, (unsigned long)children.count, (unsigned long)selected);
+              (unsigned long)stagedPanes.count, (unsigned long)children.count,
+              (unsigned long)tabBarController.selectedIndex);
     return YES;
 }
 
@@ -145,6 +445,21 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
 
 - (void)scene:(UIScene *)scene willConnectToSession:(id)session options:(id)options {
     %orig;
+
+#if APOLLO_SIM_BUILD
+    // Deterministic cold-entry harness for Xcode 27, whose URL dispatcher does
+    // not deliver custom-scheme callbacks to this re-signed simulator app.
+    // Calling before pane installation gives Apollo the exact stock hierarchy
+    // its real cold connection-options handler sees; the constructor below
+    // must then normalize the resulting stack.
+    NSString *coldURLString = NSProcessInfo.processInfo.environment[@"APOLLO_SIM_COLD_URL"];
+    NSURL *coldURL = coldURLString.length > 0 ? [NSURL URLWithString:coldURLString] : nil;
+    if (coldURL) {
+        BOOL routed = ApolloRouteURLThroughApp(coldURL);
+        ApolloLog(@"[PaneInstall] simulator cold URL injection routed=%d scheme=%@",
+                  routed, coldURL.scheme.lowercaseString);
+    }
+#endif
 
     // Re-check the gate here rather than trusting the %ctor decision alone: a
     // second scene (Stage Manager, an external display) connects later, and the
@@ -176,15 +491,11 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
         return;
     }
 
-    // Idempotence: if this controller's children are already panes, a second
-    // pass would wrap the panes themselves.
-    if ([tabBarController.viewControllers.firstObject isKindOfClass:[ApolloPaneSplitViewController class]]) {
-        ApolloLog(@"[PaneInstall] panes already installed on this tab bar controller; skipping");
-        return;
-    }
-
     if (ApolloPaneInstallIntoTabBarController(tabBarController)) {
         ApolloPaneLayoutSetActive(YES);
+#if APOLLO_SIM_BUILD
+        ApolloPaneInstallSimWriteStatus(tabBarController, @"installed", YES, nil);
+#endif
     }
 }
 

--- a/src/ipad/ApolloPaneLayout.h
+++ b/src/ipad/ApolloPaneLayout.h
@@ -71,5 +71,23 @@ void ApolloPaneLayoutSetActive(BOOL active);
 // through parents, so it works from a deeply nested child.
 UISplitViewController *_Nullable ApolloPaneSplitControllerFor(UIViewController *_Nullable viewController);
 
+// Records a stable weak owner for a pane navigation controller. UIKit detaches
+// offscreen tab children from containment, and tab selection is not guaranteed
+// to reattach them before synchronous deep-link pushes begin.
+void ApolloPaneRegisterNavigationController(UINavigationController *navigationController,
+                                            UISplitViewController *splitViewController);
+void ApolloPaneUnregisterNavigationController(UINavigationController *navigationController);
+BOOL ApolloPaneNavigationControllerIsRegisteredToSplit(
+    UINavigationController *navigationController,
+    UISplitViewController *splitViewController);
+
+#if APOLLO_SIM_BUILD
+// Launch-time fault injection for the atomic installer. The implementation is
+// simulator-only, so production builds cannot accidentally acquire a failure
+// path from the test harness.
+void ApolloPaneInstallSimCheckpoint(NSString *phase, NSInteger tabIndex);
+BOOL ApolloPaneInstallSimShouldReturnNil(NSString *phase, NSInteger tabIndex);
+#endif
+
 __END_DECLS
 NS_ASSUME_NONNULL_END

--- a/src/ipad/ApolloPaneLayout.m
+++ b/src/ipad/ApolloPaneLayout.m
@@ -10,6 +10,7 @@
 // background reader ever appears, make this atomic rather than adding a lock
 // around a single BOOL.
 static BOOL sPaneLayoutActive = NO;
+static NSMapTable<UINavigationController *, UISplitViewController *> *sPaneNavigationOwners = nil;
 
 BOOL ApolloPaneLayoutSupported(void) {
     static BOOL supported = NO;
@@ -51,5 +52,35 @@ UISplitViewController *ApolloPaneSplitControllerFor(UIViewController *viewContro
             return (UISplitViewController *)node;
         }
     }
+
+    // UITabBarController may detach every non-selected tab's column hierarchy.
+    // A URL/shortcut selects a tab and pushes synchronously, before UIKit's next
+    // containment update, so the parent walk can still be empty here.
+    if ([viewController isKindOfClass:[UINavigationController class]]) {
+        UISplitViewController *registered =
+            [sPaneNavigationOwners objectForKey:(UINavigationController *)viewController];
+        if ([registered isKindOfClass:[ApolloPaneSplitViewController class]]) return registered;
+    }
     return nil;
+}
+
+void ApolloPaneRegisterNavigationController(UINavigationController *navigationController,
+                                            UISplitViewController *splitViewController) {
+    if (!navigationController || !splitViewController) return;
+    if (!sPaneNavigationOwners) {
+        sPaneNavigationOwners = [NSMapTable weakToWeakObjectsMapTable];
+    }
+    [sPaneNavigationOwners setObject:splitViewController forKey:navigationController];
+}
+
+void ApolloPaneUnregisterNavigationController(UINavigationController *navigationController) {
+    if (!navigationController || !sPaneNavigationOwners) return;
+    [sPaneNavigationOwners removeObjectForKey:navigationController];
+}
+
+BOOL ApolloPaneNavigationControllerIsRegisteredToSplit(
+    UINavigationController *navigationController,
+    UISplitViewController *splitViewController) {
+    if (!navigationController || !splitViewController || !sPaneNavigationOwners) return NO;
+    return [sPaneNavigationOwners objectForKey:navigationController] == splitViewController;
 }

--- a/src/ipad/ApolloPaneRouter.xm
+++ b/src/ipad/ApolloPaneRouter.xm
@@ -20,97 +20,570 @@
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
+#import <objc/message.h>
+#import <dlfcn.h>
+#import "ApolloPaneForwardHistory.h"
 #import "ApolloPaneLayout.h"
+#import "ApolloPaneRouting.h"
 #import "ApolloPaneSplitViewController.h"
 #import "../ApolloCommon.h"
+#import "../ApolloDirectChatWeb.h"
 
-typedef struct {
-    const char *className;
-    ApolloPaneColumn column;
-} ApolloPaneRoute;
+extern "C" {
+void *ApolloSwiftListAdapterModelIdentifier(
+    const void *objectsStorage, NSInteger section, NSInteger row);
+void *ApolloSwiftListAdapterIndexPathForModelIdentifier(
+    const void *mappingStorage, const void *tokenObject);
+}
 
-// Matched with isKindOfClass:, so subclasses inherit their parent's column.
-//
-// The comment-LIST controllers are deliberately absent: despite their names,
-// AllSubredditComments / SavedPostsComments / UserComments are feeds whose rows
-// open a real CommentsViewController, so they belong wherever they are pushed
-// and their selections route to the detail column on their own.
-static const ApolloPaneRoute kPaneRoutes[] = {
-    // The headline case: a post's comment thread opens beside its feed.
-    { "_TtC6Apollo22CommentsViewController", ApolloPaneColumnSecondary },
+// Bound to Apollo's Swift navigation-controller class in %ctor. Hooking
+// UINavigationController itself misses callers that enter through Apollo's
+// override (including Reborn settings deep links); the override's ObjC shim is
+// the single production push entry point recovered in the design RE.
+@interface ApolloPaneNavigationController : UINavigationController
+@end
 
-    // Feeds belong in the list column, which is where they are already being
-    // pushed — a subreddit list pushing to a feed is Apollo's own structure and
-    // it survives the pane layout untouched. They are listed anyway so that
-    // opening a new feed CLEARS whatever thread is sitting in the detail column:
-    // a comment thread beside an unrelated feed is worse than an empty pane.
-    { "_TtC6Apollo19PostsViewController",     ApolloPaneColumnPrimary },
-    { "_TtC6Apollo23LitePostsViewController", ApolloPaneColumnPrimary },
-};
+@interface ApolloPanePostsViewController : UIViewController
+@end
+
+@interface ApolloPaneSettingsViewController : UIViewController
+@end
+
+@interface ApolloPaneInboxListViewController : UIViewController
+@end
+
+@interface ApolloPaneListAdapter : NSObject
+@end
+
+@interface ApolloPaneTableNode : NSObject
+@end
 
 // Re-entrancy guard: our own re-homing must never be re-classified. Main thread
 // only, like every UIKit navigation call this hook sits on.
 static BOOL sPaneRouterReentrant = NO;
+static NSUInteger sPaneRouterPopHookDepth = 0;
+static __weak UINavigationController *sPaneRouterDeferredCompactNavigationController = nil;
+static __weak UIViewController *sPaneRouterDeferredCompactViewController = nil;
+static id sPaneRouterPendingMasterSelectionIntent = nil;
+static __weak UIViewController *sPaneRouterPendingMasterSelectionSource = nil;
+static id sPaneRouterReplayedMasterSelectionIntent = nil;
 
-// SOURCE-BASED ROUTING, for tabs whose root is an index rather than a feed.
-//
-// Settings is the case that needs it. Its rows do not lead to posts, so nothing
-// downstream ever needs the detail column, and drilling in place left an index
-// in a 480pt column beside an empty pane the width of the screen — while the
-// native iPad shape for exactly this content is index on the left, the selected
-// page on the right.
-//
-// This is deliberately NOT applied to Home or Search, even though their roots
-// are also lists. Their rows lead to FEEDS, whose posts then need the detail
-// column for comments; sending the feed there instead would leave comments
-// nowhere to go but on top of the feed. Those tabs keep feed-in-place, and only
-// the comment thread crosses over.
-//
-// Matched on the pushing controller's CURRENT top, not on the tab index, so a
-// settings screen reached from somewhere else does not accidentally re-home.
-static BOOL ApolloPaneIsIndexRootController(UIViewController *viewController) {
-    static const char *kIndexRoots[] = {
-        "_TtC6Apollo22SettingsViewController",
-        // Profile is an index by product decision rather than by structure. Its
-        // rows DO lead to post lists, so this knowingly costs one thing: a post
-        // opened from Saved (or Posts, Comments, Upvoted…) replaces that list in
-        // the detail column rather than opening beside it, because the list is
-        // already occupying the only column a thread could go to. Back returns
-        // to it. Bought in exchange for the profile card never leaving screen,
-        // which is what the tab is for.
-        "_TtC6Apollo21ProfileViewController",
-    };
-    for (size_t i = 0; i < sizeof(kIndexRoots) / sizeof(kIndexRoots[0]); i++) {
-        Class cls = objc_getClass(kIndexRoots[i]);
-        if (cls && [viewController isMemberOfClass:cls]) return YES;
-    }
-    return NO;
+static const void *ApolloPaneMasterSelectionAXMarkerKey(void) {
+    return NSSelectorFromString(@"apollo_masterSelectionAddedAXSelectedTrait");
 }
 
-static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *viewController) {
-    if (!viewController) return ApolloPaneColumnInPlace;
-    for (size_t i = 0; i < sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0]); i++) {
-        Class cls = objc_getClass(kPaneRoutes[i].className);
-        if (cls && [viewController isKindOfClass:cls]) return kPaneRoutes[i].column;
+static void *ApolloPaneSwiftWeakSlot(id object, const char *name) {
+    if (!object || !name) return NULL;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    if (!ivar) return NULL;
+    return (uint8_t *)(__bridge void *)object + ivar_getOffset(ivar);
+}
+
+static id ApolloPaneLoadSwiftWeak(id object, const char *name) {
+    typedef void *(*LoadStrongFunction)(void *slot);
+    static LoadStrongFunction loadStrong;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        loadStrong = (LoadStrongFunction)dlsym(
+            RTLD_DEFAULT, "swift_unknownObjectWeakLoadStrong");
+    });
+    void *slot = ApolloPaneSwiftWeakSlot(object, name);
+    void *value = slot && loadStrong ? loadStrong(slot) : NULL;
+    return value ? CFBridgingRelease(value) : nil;
+}
+
+static const void *ApolloPaneSwiftIvarStorage(id object, const char *name) {
+    if (!object || !name) return NULL;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    if (!ivar) return NULL;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    size_t instanceSize = class_getInstanceSize(object_getClass(object));
+    if (offset <= 0 || (size_t)offset + sizeof(void *) > instanceSize) return NULL;
+    return (const uint8_t *)(__bridge const void *)object + offset;
+}
+
+static id ApolloPaneListAdapterModelIdentifier(id adapter, NSIndexPath *indexPath) {
+    if (!NSThread.isMainThread || !indexPath) return nil;
+    const void *objectsStorage = ApolloPaneSwiftIvarStorage(adapter, "objects");
+    void *identifier = objectsStorage
+        ? ApolloSwiftListAdapterModelIdentifier(
+            objectsStorage, indexPath.section, indexPath.row)
+        : NULL;
+    return identifier ? CFBridgingRelease(identifier) : nil;
+}
+
+static NSIndexPath *ApolloPaneListAdapterIndexPath(id adapter, id identifier) {
+    if (!NSThread.isMainThread || !identifier) return nil;
+    const void *mappingStorage = ApolloPaneSwiftIvarStorage(
+        adapter, "objectToIndexPathMapping");
+    void *path = mappingStorage
+        ? ApolloSwiftListAdapterIndexPathForModelIdentifier(
+            mappingStorage, (__bridge const void *)identifier)
+        : NULL;
+    return path ? CFBridgingRelease(path) : nil;
+}
+
+static UIViewController *ApolloPaneOwningViewControllerForSurface(id surface) {
+    id view = surface;
+    if (![view isKindOfClass:[UIView class]] && [surface respondsToSelector:@selector(view)]) {
+        view = ((id (*)(id, SEL))objc_msgSend)(surface, @selector(view));
     }
-    return ApolloPaneColumnInPlace;
+    UIResponder *responder = [view isKindOfClass:[UIResponder class]] ? view : nil;
+    while (responder) {
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)responder;
+        }
+        responder = responder.nextResponder;
+    }
+    return nil;
+}
+
+static id ApolloPaneStableIdentifierForSelectedNode(id tableNode, NSIndexPath *indexPath) {
+    SEL nodeSelector = NSSelectorFromString(@"nodeForRowAtIndexPath:");
+    if (!tableNode || !indexPath || ![tableNode respondsToSelector:nodeSelector]) return nil;
+    id node = ((id (*)(id, SEL, id))objc_msgSend)(tableNode, nodeSelector, indexPath);
+    if (!node) return nil;
+    id model = nil;
+    static const char *modelIvarNames[] = { "link", "message" };
+    for (size_t index = 0; index < sizeof(modelIvarNames) / sizeof(modelIvarNames[0]); index++) {
+        const char *name = modelIvarNames[index];
+        @try {
+            Ivar ivar = class_getInstanceVariable(object_getClass(node), name);
+            if (ivar) model = object_getIvar(node, ivar);
+        } @catch (__unused NSException *exception) {}
+        if (model) break;
+    }
+    if (!model) return nil;
+    for (NSString *selectorName in @[ @"fullName", @"identifier", @"diffIdentifier" ]) {
+        SEL selector = NSSelectorFromString(selectorName);
+        if (![model respondsToSelector:selector]) continue;
+        id value = ((id (*)(id, SEL))objc_msgSend)(model, selector);
+        if ([value conformsToProtocol:@protocol(NSCopying)]) return value;
+    }
+    return nil;
+}
+
+static void ApolloPaneObservePrimaryPopSettlement(
+        ApolloPaneSplitViewController *pane,
+        UINavigationController *navigationController,
+        NSArray<UIViewController *> *beforeStack,
+        NSUInteger token);
+
+static void ApolloPanePollPrimaryPopSettlement(
+        ApolloPaneSplitViewController *pane,
+        UINavigationController *navigationController,
+        NSArray<UIViewController *> *beforeStack,
+        NSUInteger token,
+        NSUInteger observations) {
+    if (!pane || !navigationController || token == 0) return;
+    if (navigationController.transitionCoordinator) {
+        NSTimeInterval delay = observations < 120 ? 0.05 : 0.25;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            ApolloPanePollPrimaryPopSettlement(pane, navigationController, beforeStack,
+                                                token, observations + 1);
+        });
+        return;
+    }
+    [pane apollo_primaryNavigationPopDidSettle:token
+                                   beforeStack:beforeStack
+                                      cancelled:NO];
+}
+
+static void ApolloPaneObservePrimaryPopSettlement(
+        ApolloPaneSplitViewController *pane,
+        UINavigationController *navigationController,
+        NSArray<UIViewController *> *beforeStack,
+        NSUInteger token) {
+    if (!pane || !navigationController || beforeStack.count == 0 || token == 0) return;
+    void (^settle)(BOOL) = ^(BOOL cancelled) {
+        [pane apollo_primaryNavigationPopDidSettle:token
+                                       beforeStack:beforeStack
+                                          cancelled:cancelled];
+    };
+    id<UIViewControllerTransitionCoordinator> coordinator =
+        navigationController.transitionCoordinator;
+    if (coordinator) {
+        BOOL observing = [coordinator animateAlongsideTransition:nil
+            completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                BOOL cancelled = context.isCancelled;
+                dispatch_async(dispatch_get_main_queue(), ^{ settle(cancelled); });
+            }];
+        // Poll in parallel even after accepted registration. It is both the
+        // rejected-registration fallback and a watchdog for a coordinator that
+        // never invokes its completion; the pane token makes duplicate terminal
+        // observations harmless.
+        ApolloPanePollPrimaryPopSettlement(pane, navigationController, beforeStack,
+                                            token, observing ? 1 : 0);
+    } else {
+        settle(NO);
+    }
+}
+
+// Re-enter Apollo's real push override after a queued compact route settles,
+// while bypassing serialization for exactly that navigation/destination pair.
+// A broad boolean also bypassed synchronous lifecycle pushes triggered by the
+// destination; those are new semantic intents and must remain serialized.
+static void ApolloPaneReplayCompactPush(UINavigationController *navigationController,
+                                        UIViewController *viewController,
+                                        BOOL animated,
+                                        id masterSelectionIntent) {
+    sPaneRouterDeferredCompactNavigationController = navigationController;
+    sPaneRouterDeferredCompactViewController = viewController;
+    sPaneRouterReplayedMasterSelectionIntent = masterSelectionIntent;
+    @try {
+        [navigationController pushViewController:viewController animated:animated];
+    } @finally {
+        sPaneRouterDeferredCompactNavigationController = nil;
+        sPaneRouterDeferredCompactViewController = nil;
+        sPaneRouterReplayedMasterSelectionIntent = nil;
+    }
+}
+
+// Most pushed controllers already express their correct leading-item policy.
+// The one proven exception is ProfileViewController: Apollo designed it as a
+// tab root, so when it is appended above a thread its own leading items suppress
+// UIKit's only escape route. Keep that repair explicit and shared by regular and
+// compact navigation; rightward ownership alone never authorizes a mutation.
+static void ApolloPaneApplyPostPushNavigationPolicy(UINavigationController *navigationController,
+                                                    UIViewController *viewController,
+                                                    ApolloPaneColumn logicalColumn) {
+    if (logicalColumn != ApolloPaneColumnSecondary ||
+        !ApolloPaneDestinationRequiresSupplementalBack(viewController) ||
+        navigationController.topViewController != viewController ||
+        navigationController.viewControllers.count <= 1) return;
+
+    viewController.navigationItem.hidesBackButton = NO;
+    viewController.navigationItem.leftItemsSupplementBackButton = YES;
+    ApolloLog(@"[PaneRouter] supplemented Back for appended %@",
+              NSStringFromClass(viewController.class));
+}
+
+// Commit a semantic primary -> detail replacement without ever falling back to
+// an in-place push. This is shared by immediate routes and deferred routes that
+// settle after a populated pane has collapsed onto its detail branch.
+static BOOL ApolloPaneReplaceDetailRoot(ApolloPaneSplitViewController *pane,
+                                        UIViewController *viewController,
+                                        UIViewController *sourceViewController,
+                                        id masterSelectionIntent) {
+    UINavigationController *destination =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    if (!destination || !viewController) return NO;
+
+    viewController.extendedLayoutIncludesOpaqueBars = YES;
+    NSArray<UIViewController *> *oldDestinationStack = destination.viewControllers;
+    __block BOOL replacementSucceeded = NO;
+    [pane apollo_performCrossColumnNavigationTransaction:^{
+        sPaneRouterReentrant = YES;
+        @try {
+            [destination setViewControllers:@[ viewController ] animated:NO];
+            replacementSucceeded = destination.topViewController == viewController;
+            if (!replacementSucceeded) {
+                ApolloLog(@"[PaneRouter] re-homing %@ failed postcondition; restoring destination",
+                          NSStringFromClass(viewController.class));
+                [destination setViewControllers:oldDestinationStack animated:NO];
+            }
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PaneRouter] re-homing %@ threw: %@; restoring destination",
+                      NSStringFromClass(viewController.class), exception);
+            @try {
+                [destination setViewControllers:oldDestinationStack animated:NO];
+            } @catch (NSException *rollbackException) {
+                ApolloLog(@"[PaneRouter] destination rollback also threw: %@", rollbackException);
+            }
+        } @finally {
+            sPaneRouterReentrant = NO;
+        }
+    }];
+    if (!replacementSucceeded) return NO;
+
+    ApolloPaneClearForwardHistory(destination);
+    [pane apollo_recordDetailBranchFromPrimarySource:sourceViewController];
+    [pane apollo_commitMasterSelectionIntent:masterSelectionIntent
+                                  detailRoot:viewController];
+    [pane apollo_refreshCompactDetailChromeAfterRootReplacement];
+    [pane apollo_resolvedDisplayStateMayHaveChanged];
+    [pane apollo_revealDetailAfterPrimarySelectionIfNeeded];
+    ApolloLog(@"[PaneRouter] routed %@ to detail (tab %ld compact=%d)",
+              NSStringFromClass(viewController.class), (long)pane.apollo_tabIndex,
+              pane.isCollapsed);
+    return YES;
+}
+
+static ApolloPaneSplitViewController *ApolloPaneForPrimaryController(UIViewController *controller) {
+    UINavigationController *navigationController = controller.navigationController;
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController ?: controller);
+    if (![pane isKindOfClass:[ApolloPaneSplitViewController class]]) return nil;
+    return navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ? pane : nil;
+}
+
+static ApolloPaneSplitViewController *ApolloPaneForMasterSelectionSurface(id surface) {
+    UIViewController *owner = ApolloPaneOwningViewControllerForSurface(surface);
+    return ApolloPaneForPrimaryController(owner);
+}
+
+static void ApolloPaneSchedulePostsScopeReconciliation(UIViewController *posts,
+                                                        NSString *reason) {
+    __weak UIViewController *weakPosts = posts;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *strongPosts = weakPosts;
+        ApolloPaneSplitViewController *pane = ApolloPaneForPrimaryController(strongPosts);
+        [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:reason];
+    });
+}
+
+static void ApolloPaneCollectLivePanes(UIViewController *controller,
+                                       NSHashTable<ApolloPaneSplitViewController *> *panes) {
+    if (!controller || [panes containsObject:(id)controller]) return;
+    if ([controller isKindOfClass:[ApolloPaneSplitViewController class]]) {
+        [panes addObject:(ApolloPaneSplitViewController *)controller];
+    }
+    for (UIViewController *child in controller.childViewControllers) {
+        ApolloPaneCollectLivePanes(child, panes);
+    }
+    ApolloPaneCollectLivePanes(controller.presentedViewController, panes);
+}
+
+static NSArray<ApolloPaneSplitViewController *> *ApolloPaneAllLivePanes(void) {
+    NSHashTable<ApolloPaneSplitViewController *> *panes = [NSHashTable weakObjectsHashTable];
+    for (UIWindow *window in ApolloAllWindows()) {
+        ApolloPaneCollectLivePanes(window.rootViewController, panes);
+    }
+    return panes.allObjects;
+}
+
+static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavigationItem *item) {
+    for (ApolloPaneSplitViewController *pane in ApolloPaneAllLivePanes()) {
+        UINavigationController *primary =
+            [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+        for (UIViewController *controller in primary.viewControllers) {
+            if (controller.navigationItem == item) return pane;
+        }
+    }
+    return nil;
 }
 
 %group ApolloPaneRouterGroup
 
-%hook UINavigationController
+%hook ApolloPaneSettingsViewController
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    UIViewController *source = (UIViewController *)self;
+    ApolloPaneSplitViewController *pane = ApolloPaneLayoutActive()
+        ? ApolloPaneForPrimaryController(source) : nil;
+    id intent = [pane apollo_masterSelectionIntentFromSource:source
+                                                     surface:tableView
+                                                   indexPath:indexPath
+                                              itemIdentifier:nil
+                                               identityOwner:nil];
+    [pane apollo_stageMasterSelectionIntent:intent];
+    id previousIntent = sPaneRouterPendingMasterSelectionIntent;
+    UIViewController *previousSource = sPaneRouterPendingMasterSelectionSource;
+    sPaneRouterPendingMasterSelectionIntent = intent;
+    sPaneRouterPendingMasterSelectionSource = intent ? source : nil;
+    @try {
+        %orig;
+    } @finally {
+        sPaneRouterPendingMasterSelectionIntent = previousIntent;
+        sPaneRouterPendingMasterSelectionSource = previousSource;
+    }
+}
+
+%end
+
+%hook ApolloPaneInboxListViewController
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    UIViewController *source = (UIViewController *)self;
+    ApolloPaneSplitViewController *pane = ApolloPaneLayoutActive()
+        ? ApolloPaneForPrimaryController(source) : nil;
+    id intent = [pane apollo_masterSelectionIntentFromSource:source
+                                                     surface:tableView
+                                                   indexPath:indexPath
+                                              itemIdentifier:nil
+                                               identityOwner:nil];
+    [pane apollo_stageMasterSelectionIntent:intent];
+    id previousIntent = sPaneRouterPendingMasterSelectionIntent;
+    UIViewController *previousSource = sPaneRouterPendingMasterSelectionSource;
+    sPaneRouterPendingMasterSelectionIntent = intent;
+    sPaneRouterPendingMasterSelectionSource = intent ? source : nil;
+    @try {
+        %orig;
+    } @finally {
+        sPaneRouterPendingMasterSelectionIntent = previousIntent;
+        sPaneRouterPendingMasterSelectionSource = previousSource;
+    }
+}
+
+%end
+
+%hook ApolloPaneListAdapter
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    UIViewController *source = ApolloPaneLoadSwiftWeak((id)self, "viewController") ?:
+        ApolloPaneOwningViewControllerForSurface(tableView);
+    ApolloPaneSplitViewController *pane = ApolloPaneLayoutActive()
+        ? ApolloPaneForPrimaryController(source) : nil;
+    id itemIdentifier = pane
+        ? ApolloPaneListAdapterModelIdentifier((id)self, indexPath) : nil;
+    id identityOwner = itemIdentifier ? (id)self : nil;
+    id tableNode = ApolloPaneLoadSwiftWeak((id)self, "tableNode");
+    id surface = tableNode ?: tableView;
+    if (!itemIdentifier && pane) {
+        itemIdentifier = ApolloPaneStableIdentifierForSelectedNode(surface, indexPath);
+    }
+    id intent = [pane apollo_masterSelectionIntentFromSource:source
+                                                     surface:surface
+                                                   indexPath:indexPath
+                                              itemIdentifier:itemIdentifier
+                                               identityOwner:identityOwner];
+    [pane apollo_stageMasterSelectionIntent:intent];
+    id previousIntent = sPaneRouterPendingMasterSelectionIntent;
+    UIViewController *previousSource = sPaneRouterPendingMasterSelectionSource;
+    sPaneRouterPendingMasterSelectionIntent = intent;
+    sPaneRouterPendingMasterSelectionSource = intent ? source : nil;
+    @try {
+        %orig;
+    } @finally {
+        sPaneRouterPendingMasterSelectionIntent = previousIntent;
+        sPaneRouterPendingMasterSelectionSource = previousSource;
+    }
+}
+
+- (void)tableNode:(id)tableNode didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    UIViewController *source = ApolloPaneLoadSwiftWeak((id)self, "viewController") ?:
+        ApolloPaneOwningViewControllerForSurface(tableNode);
+    ApolloPaneSplitViewController *pane = ApolloPaneLayoutActive()
+        ? ApolloPaneForPrimaryController(source) : nil;
+    id itemIdentifier = pane
+        ? ApolloPaneListAdapterModelIdentifier((id)self, indexPath) : nil;
+    id identityOwner = itemIdentifier ? (id)self : nil;
+    if (!itemIdentifier && pane) {
+        itemIdentifier = ApolloPaneStableIdentifierForSelectedNode(tableNode, indexPath);
+    }
+    id intent = [pane apollo_masterSelectionIntentFromSource:source
+                                                     surface:tableNode
+                                                   indexPath:indexPath
+                                              itemIdentifier:itemIdentifier
+                                               identityOwner:identityOwner];
+    [pane apollo_stageMasterSelectionIntent:intent];
+    id previousIntent = sPaneRouterPendingMasterSelectionIntent;
+    UIViewController *previousSource = sPaneRouterPendingMasterSelectionSource;
+    sPaneRouterPendingMasterSelectionIntent = intent;
+    sPaneRouterPendingMasterSelectionSource = intent ? source : nil;
+    @try {
+        %orig;
+    } @finally {
+        sPaneRouterPendingMasterSelectionIntent = previousIntent;
+        sPaneRouterPendingMasterSelectionSource = previousSource;
+    }
+}
+
+- (id)modelIdentifierForElementAtIndexPath:(NSIndexPath *)indexPath inNode:(id)node {
+    return ApolloPaneListAdapterModelIdentifier((id)self, indexPath);
+}
+
+- (NSIndexPath *)indexPathForElementWithModelIdentifier:(id)identifier inNode:(id)node {
+    return ApolloPaneListAdapterIndexPath((id)self, identifier);
+}
+
+%end
+
+// Apollo's delayed phone-navigation deselection must not erase a selection
+// after the pane has committed that row as the owner of its visible detail.
+// The checks are identity-exact and allocation-free before pane mode is active.
+%hook UITableView
+
+- (void)reloadData {
+    %orig;
+    if (!ApolloPaneLayoutActive()) return;
+    ApolloPaneSplitViewController *pane = ApolloPaneForMasterSelectionSurface(self);
+    if (!pane) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [pane apollo_refreshMasterSelection];
+    });
+}
+
+- (void)deselectRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
+    if (ApolloPaneLayoutActive()) {
+        ApolloPaneSplitViewController *pane = ApolloPaneForMasterSelectionSurface(self);
+        if ([pane apollo_shouldRetainMasterSelectionForSurface:self indexPath:indexPath]) return;
+    }
+    %orig;
+}
+
+%end
+
+%hook ApolloPaneTableNode
+
+- (void)deselectRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
+    if (ApolloPaneLayoutActive()) {
+        ApolloPaneSplitViewController *pane = ApolloPaneForMasterSelectionSurface(self);
+        if ([pane apollo_shouldRetainMasterSelectionForSurface:self indexPath:indexPath]) return;
+    }
+    %orig;
+}
+
+%end
+
+%hook UITableViewCell
+
+- (void)prepareForReuse {
+    const void *key = ApolloPaneMasterSelectionAXMarkerKey();
+    if ([objc_getAssociatedObject(self, key) boolValue]) {
+        self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        objc_setAssociatedObject(self, key, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    %orig;
+}
+
+%end
+
+%hook ApolloPaneNavigationController
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    if (!ApolloPaneLayoutActive() || sPaneRouterReentrant) { %orig; return; }
+    if (!ApolloPaneLayoutActive()) { %orig; return; }
+
+    // Logos types `self` as id for a runtime-bound class alias.
+    UINavigationController *navigationController = (UINavigationController *)self;
 
     ApolloPaneSplitViewController *pane =
-        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(self);
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController);
 
-    if (!pane) { %orig; return; }
+    if (!pane) {
+        ApolloLog(@"[PaneRouter] no pane for navigation parent=%@ split=%@",
+                  NSStringFromClass(navigationController.parentViewController.class),
+                  NSStringFromClass(navigationController.splitViewController.class));
+        %orig;
+        return;
+    }
 
-    // Collapsed (Slide Over, a narrow Stage Manager window, portrait on a small
-    // iPad) is a single merged stack and must behave exactly like today's app.
-    if (pane.isCollapsed) { %orig; return; }
+    // During collapse UIKit appends this pane's exact secondary navigation
+    // controller to the surviving primary stack as structural bridge state.
+    // It is not an app destination and must pass through untouched; treating it
+    // as a Settings detail route recursively installs the nav inside itself.
+    if (viewController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        %orig;
+        return;
+    }
+
+    // Native Modmail has an independent superclass hook that substitutes the
+    // authenticated modern mailbox. A cross-column re-home intentionally does
+    // not call %orig, so normalize here as well; otherwise hook ordering could
+    // decide whether modern Modmail is honored. Re-pushing the replacement
+    // re-enters this router as an ordinary, explicitly classified destination.
+    Class nativeModmailClass = objc_getClass("_TtC6Apollo26ModmailInboxViewController");
+    if (nativeModmailClass &&
+        [viewController isMemberOfClass:nativeModmailClass] &&
+        ApolloModernModmailShouldOpen()) {
+        ApolloLog(@"[PaneRouter] normalizing native Modmail to modern mailbox before routing");
+        [navigationController pushViewController:ApolloCreateModernModmailViewController()
+                                         animated:animated];
+        return;
+    }
 
     // CONTENT ONLY EVER MOVES RIGHTWARD.
     //
@@ -131,29 +604,147 @@ static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *view
     // The detail column is now the browsing stack — the thing you tapped opens
     // where you were looking, and back always returns — while the list column
     // stays the stable context you navigated from.
-    BOOL fromListColumn = (self == [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]);
-
-    ApolloPaneColumn column = fromListColumn
-        ? ApolloPaneColumnForViewController(viewController)
-        : ApolloPaneColumnInPlace;
-
-    // An index root sends EVERYTHING it pushes to the detail column, so the index
-    // itself stays put. This deliberately overrides the destination table rather
-    // than only filling in for it: the profile's "Posts" row pushes a
-    // PostsViewController, which the table maps to the list column, so gating
-    // this on the table having no opinion left that row — and only that row —
-    // still replacing the profile card.
-    //
-    // Still limited to pushes coming FROM the list column: a settings page or a
-    // saved-posts list pushing deeper is already in the detail column and stays
-    // there rather than re-homing onto itself.
-    if (fromListColumn && ApolloPaneIsIndexRootController(self.topViewController)) {
-        column = ApolloPaneColumnSecondary;
+    BOOL fromListColumn =
+        (navigationController == [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]);
+    UIViewController *sourceViewController = navigationController.topViewController;
+    id routeMasterSelectionIntent = sPaneRouterReplayedMasterSelectionIntent;
+    if (!routeMasterSelectionIntent &&
+        sPaneRouterPendingMasterSelectionSource == sourceViewController) {
+        routeMasterSelectionIntent = sPaneRouterPendingMasterSelectionIntent;
+    }
+    if (fromListColumn) {
+        id stagedIntent =
+            [pane apollo_claimStagedMasterSelectionIntentForSource:sourceViewController];
+        if (!routeMasterSelectionIntent) routeMasterSelectionIntent = stagedIntent;
     }
 
-    if (column == ApolloPaneColumnInPlace) {
+    BOOL explicitlyClassified = NO;
+    ApolloPaneColumn sourceColumn = fromListColumn
+        ? ApolloPaneColumnPrimary : ApolloPaneColumnSecondary;
+    ApolloPaneColumn column = ApolloPaneResolveLogicalColumn(navigationController.topViewController,
+                                                              viewController,
+                                                              sourceColumn,
+                                                              &explicitlyClassified);
+
+    if (pane.isCollapsed) {
+        // There is only one physical stack while compact, but that does not
+        // erase column ownership. A detail route opened from the visible list
+        // must stay on this stack for now and move to the real detail column
+        // when the split expands. Once a compact route is logically detail,
+        // everything it pushes inherits detail ownership (rightward-only),
+        // regardless of the destination class table.
+        BOOL sourceBelongsToDetail =
+            [pane apollo_compactViewControllerBelongsToDetail:navigationController.topViewController] ||
+            navigationController == [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+        if (sourceBelongsToDetail) {
+            column = ApolloPaneColumnSecondary;
+        }
+
+        // A regular-width replacement can still be waiting when the window
+        // collapses. Compact navigation must participate in the same latest-
+        // intent queue or an older regular request could replay over a newer
+        // compact selection after the transition settles. Detail continuations
+        // capture the stable primary context rather than becoming unconditional
+        // source-less work that could outlive a feed/account change.
+        __weak UINavigationController *weakCompactNavigationController = navigationController;
+        __weak ApolloPaneSplitViewController *weakCompactPane = pane;
+        __weak UIViewController *weakCompactSourceViewController = sourceViewController;
+        UIViewController *deferredCompactViewController = viewController;
+        BOOL deferredCompactAnimated = animated;
+        BOOL deferredSourceBelongsToDetail = sourceBelongsToDetail;
+        NSString *compactReason = [NSString stringWithFormat:@"compact route %@",
+            NSStringFromClass(viewController.class)];
+        BOOL applyingThisDeferredPush =
+            sPaneRouterDeferredCompactNavigationController == navigationController &&
+            sPaneRouterDeferredCompactViewController == viewController;
+        // During compact Back/showColumn UIKit can temporarily expose only the
+        // index root while the pane is about to restore [index, feed]. Bind a
+        // new selection to that anticipated stable context, not the transient
+        // physical top, or reconciliation can erase the newer route.
+        UIViewController *compactValidationSource =
+            pane.apollo_primaryContextViewController ?: sourceViewController;
+        if (!applyingThisDeferredPush &&
+            [pane apollo_deferCrossColumnNavigationIfNeeded:^{
+                UINavigationController *strongNavigationController =
+                    weakCompactNavigationController;
+                ApolloPaneSplitViewController *strongPane = weakCompactPane;
+                if (!strongNavigationController || !strongPane ||
+                    ApolloPaneSplitControllerFor(strongNavigationController) != strongPane) {
+                    ApolloLog(@"[PaneTransition] dropped deferred compact %@ after pane/source detached",
+                              NSStringFromClass(deferredCompactViewController.class));
+                    return;
+                }
+                UINavigationController *resolvedNavigationController = strongNavigationController;
+                if (deferredSourceBelongsToDetail) {
+                    UIViewController *strongSourceViewController = weakCompactSourceViewController;
+                    UINavigationController *resolvedPrimary =
+                        [strongPane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+                    UINavigationController *resolvedDetail =
+                        [strongPane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+                    if (strongSourceViewController &&
+                        [resolvedDetail.viewControllers containsObject:strongSourceViewController]) {
+                        resolvedNavigationController = resolvedDetail;
+                    } else if (strongSourceViewController &&
+                               [resolvedPrimary.viewControllers containsObject:strongSourceViewController]) {
+                        resolvedNavigationController = resolvedPrimary;
+                    } else {
+                        ApolloLog(@"[PaneTransition] dropped deferred compact detail continuation after source moved away");
+                        return;
+                    }
+                    if (resolvedNavigationController.topViewController != strongSourceViewController) {
+                        ApolloLog(@"[PaneTransition] dropped deferred compact detail continuation after source was popped");
+                        return;
+                    }
+                }
+                ApolloPaneReplayCompactPush(resolvedNavigationController,
+                                            deferredCompactViewController,
+                                            deferredCompactAnimated,
+                                            routeMasterSelectionIntent);
+            }
+                                  sourceViewController:compactValidationSource
+                                                reason:compactReason]) {
+            return;
+        }
+
+        UIViewController *beforeTop = navigationController.topViewController;
+        NSUInteger beforeDepth = navigationController.viewControllers.count;
         %orig;
-        // Guarantee a way back out of the detail column.
+        BOOL pushSucceeded = navigationController.topViewController == viewController &&
+            (beforeTop != viewController || navigationController.viewControllers.count != beforeDepth);
+        if (pushSucceeded) {
+            [pane apollo_recordCompactViewController:viewController logicalColumn:column];
+        }
+        if (column == ApolloPaneColumnSecondary && !sourceBelongsToDetail && pushSucceeded) {
+            [pane apollo_recordDetailBranchFromPrimarySource:sourceViewController];
+            [pane apollo_commitMasterSelectionIntent:routeMasterSelectionIntent
+                                          detailRoot:viewController];
+        } else if (column == ApolloPaneColumnPrimary && pushSucceeded) {
+            [pane apollo_primaryNavigationPushDidMutateExternally:
+                navigationController.viewControllers];
+            [pane apollo_reconcileDetailAfterPrimaryMutation:@"compact primary push"];
+        }
+        if (pushSucceeded) {
+            ApolloPaneApplyPostPushNavigationPolicy(navigationController, viewController, column);
+        }
+        ApolloLog(@"[PaneRouter] compact push %@ logicalColumn=%ld sourceDetail=%d succeeded=%d tab=%ld",
+                  NSStringFromClass(viewController.class), (long)column, sourceBelongsToDetail,
+                  pushSucceeded, (long)pane.apollo_tabIndex);
+        return;
+    }
+
+    if (!explicitlyClassified) {
+        UIViewController *beforeTop = navigationController.topViewController;
+        NSUInteger beforeDepth = navigationController.viewControllers.count;
+        %orig;
+        if (fromListColumn && navigationController.topViewController == viewController &&
+            (beforeTop != viewController ||
+             navigationController.viewControllers.count != beforeDepth)) {
+            [pane apollo_primaryNavigationPushDidMutateExternally:
+                navigationController.viewControllers];
+        }
+        // Guarantee a way back out of the one known tab-root destination that
+        // suppresses it, without rewriting arbitrary controllers merely because
+        // they inherited rightward ownership from their source.
         //
         // Some Apollo screens are designed to be a TAB ROOT and supply their own
         // leading bar items, so when one is pushed they render no back button at
@@ -167,10 +758,9 @@ static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *view
         //
         // leftItemsSupplementBackButton keeps the screen's own items (the
         // profile's hide/history buttons) rather than replacing them.
-        if (self.viewControllers.count > 1) {
-            viewController.navigationItem.hidesBackButton = NO;
-            viewController.navigationItem.leftItemsSupplementBackButton = YES;
-        }
+        // Unknown composers, login screens, settings descendants and modal-like
+        // screens keep their exact native leading-item policy.
+        ApolloPaneApplyPostPushNavigationPolicy(navigationController, viewController, column);
         return;
     }
 
@@ -178,9 +768,57 @@ static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *view
 
     // Already in the right column. A feed arriving here means the user moved to
     // different content, so the stale thread beside it goes.
-    if (!destination || destination == self) {
-        if (column != ApolloPaneColumnSecondary) [pane apollo_clearDetailColumn];
+    if (!destination || destination == navigationController) {
+        UIViewController *beforeTop = navigationController.topViewController;
         %orig;
+        // Apollo rejects duplicate pushes. Reconcile after the call so a no-op
+        // intent cannot erase detail whose primary context never changed.
+        if (column != ApolloPaneColumnSecondary &&
+            navigationController.topViewController != beforeTop) {
+            [pane apollo_primaryNavigationPushDidMutateExternally:
+                navigationController.viewControllers];
+            [pane apollo_reconcileDetailAfterPrimaryMutation:@"primary push"];
+        }
+        return;
+    }
+
+    // A detail pop/push may still own UIKit's transition context even though
+    // the primary row tap has already delivered a new destination. Replacing
+    // the detail stack in that interval produces nested-transition warnings and
+    // can strand Apollo's custom edge gesture. Keep only the newest semantic
+    // intent, then re-enter this same router after commit/cancellation so source
+    // ownership and compact/regular topology are resolved from final state.
+    __weak UINavigationController *weakSourceNavigationController = navigationController;
+    __weak ApolloPaneSplitViewController *weakPane = pane;
+    __weak UIViewController *weakSourceViewController = sourceViewController;
+    UIViewController *deferredViewController = viewController;
+    BOOL deferredAnimated = animated;
+    NSString *deferredReason = [NSString stringWithFormat:@"route %@",
+        NSStringFromClass(viewController.class)];
+    if ([pane apollo_deferCrossColumnNavigationIfNeeded:^{
+            ApolloPaneSplitViewController *strongPane = weakPane;
+            UINavigationController *strongSourceNavigationController =
+                weakSourceNavigationController;
+            if (!strongPane || !strongSourceNavigationController ||
+                ApolloPaneSplitControllerFor(strongSourceNavigationController) != strongPane) {
+                ApolloLog(@"[PaneTransition] dropped deferred %@ after pane/source detached",
+                          NSStringFromClass(deferredViewController.class));
+                return;
+            }
+            if (!strongPane.isCollapsed || !strongPane.apollo_detailIsEmpty) {
+                ApolloPaneReplaceDetailRoot(strongPane, deferredViewController,
+                                           weakSourceViewController,
+                                           routeMasterSelectionIntent);
+            } else {
+                UINavigationController *resolvedPrimary =
+                    [strongPane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+                ApolloPaneReplayCompactPush(resolvedPrimary, deferredViewController,
+                                            deferredAnimated,
+                                            routeMasterSelectionIntent);
+            }
+        }
+                              sourceViewController:sourceViewController
+                                            reason:deferredReason]) {
         return;
     }
 
@@ -195,26 +833,204 @@ static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *view
     // `pushing` flag, the hidden-nav-bar re-show timer loop) is specific to an
     // animated push onto an existing stack and does not apply to replacing a
     // column's root.
-    viewController.extendedLayoutIncludesOpaqueBars = YES;
+    ApolloPaneReplaceDetailRoot(pane, viewController, sourceViewController,
+                               routeMasterSelectionIntent);
+}
 
-    sPaneRouterReentrant = YES;
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    UINavigationController *navigationController = (UINavigationController *)self;
+    BOOL observesSettlement = sPaneRouterPopHookDepth++ == 0;
+    NSArray<UIViewController *> *beforeStack = observesSettlement
+        ? [navigationController.viewControllers copy] : nil;
+    ApolloPaneSplitViewController *pane = observesSettlement && ApolloPaneLayoutActive()
+        ? (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController) : nil;
+    NSUInteger popToken = navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]
+            ? [pane apollo_primaryNavigationPopWillBeginWithOperation:@"popViewController"
+                                                              animated:animated] : 0;
+    UIViewController *popped = nil;
+    BOOL originalCompleted = NO;
     @try {
-        [destination setViewControllers:@[ viewController ] animated:NO];
-    } @catch (NSException *exception) {
-        ApolloLog(@"[PaneRouter] re-homing %@ threw: %@; falling back to an in-place push",
-                  NSStringFromClass([viewController class]), exception);
-        sPaneRouterReentrant = NO;
-        %orig;
-        return;
+        popped = %orig;
+        originalCompleted = YES;
+    } @finally {
+        --sPaneRouterPopHookDepth;
+        if (!originalCompleted && popToken != 0) {
+            [pane apollo_primaryNavigationPopDidSettle:popToken
+                                           beforeStack:beforeStack
+                                              cancelled:YES];
+        }
     }
-    sPaneRouterReentrant = NO;
+    if (popToken != 0 && popped) {
+        ApolloPaneObservePrimaryPopSettlement(
+            pane, navigationController, beforeStack, popToken);
+    } else if (popToken != 0) {
+        [pane apollo_primaryNavigationPopDidSettle:popToken
+                                       beforeStack:beforeStack
+                                          cancelled:YES];
+    }
+    return popped;
+}
 
-    // The detail column just filled, so the pane can reclaim the sidebar's width
-    // for it.
-    [pane apollo_detailContentDidChange];
+- (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController
+                                             animated:(BOOL)animated {
+    UINavigationController *navigationController = (UINavigationController *)self;
+    BOOL observesSettlement = sPaneRouterPopHookDepth++ == 0;
+    NSArray<UIViewController *> *beforeStack = observesSettlement
+        ? [navigationController.viewControllers copy] : nil;
+    ApolloPaneSplitViewController *pane = observesSettlement && ApolloPaneLayoutActive()
+        ? (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController) : nil;
+    NSUInteger popToken = navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]
+            ? [pane apollo_primaryNavigationPopWillBeginWithOperation:@"popToViewController"
+                                                              animated:animated] : 0;
+    NSArray<UIViewController *> *popped = nil;
+    BOOL originalCompleted = NO;
+    @try {
+        popped = %orig;
+        originalCompleted = YES;
+    } @finally {
+        --sPaneRouterPopHookDepth;
+        if (!originalCompleted && popToken != 0) {
+            [pane apollo_primaryNavigationPopDidSettle:popToken
+                                           beforeStack:beforeStack
+                                              cancelled:YES];
+        }
+    }
+    if (popToken != 0 && popped.count > 0) {
+        ApolloPaneObservePrimaryPopSettlement(
+            pane, navigationController, beforeStack, popToken);
+    } else if (popToken != 0) {
+        [pane apollo_primaryNavigationPopDidSettle:popToken
+                                       beforeStack:beforeStack
+                                          cancelled:YES];
+    }
+    return popped;
+}
 
-    ApolloLog(@"[PaneRouter] routed %@ to column %ld (tab %ld)",
-              NSStringFromClass([viewController class]), (long)column, (long)pane.apollo_tabIndex);
+- (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
+    UINavigationController *navigationController = (UINavigationController *)self;
+    BOOL observesSettlement = sPaneRouterPopHookDepth++ == 0;
+    NSArray<UIViewController *> *beforeStack = observesSettlement
+        ? [navigationController.viewControllers copy] : nil;
+    ApolloPaneSplitViewController *pane = observesSettlement && ApolloPaneLayoutActive()
+        ? (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController) : nil;
+    NSUInteger popToken = navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]
+            ? [pane apollo_primaryNavigationPopWillBeginWithOperation:@"popToRoot"
+                                                              animated:animated] : 0;
+    NSArray<UIViewController *> *popped = nil;
+    BOOL originalCompleted = NO;
+    @try {
+        popped = %orig;
+        originalCompleted = YES;
+    } @finally {
+        --sPaneRouterPopHookDepth;
+        if (!originalCompleted && popToken != 0) {
+            [pane apollo_primaryNavigationPopDidSettle:popToken
+                                           beforeStack:beforeStack
+                                              cancelled:YES];
+        }
+    }
+    if (popToken != 0 && popped.count > 0) {
+        ApolloPaneObservePrimaryPopSettlement(
+            pane, navigationController, beforeStack, popToken);
+    } else if (popToken != 0) {
+        [pane apollo_primaryNavigationPopDidSettle:popToken
+                                       beforeStack:beforeStack
+                                          cancelled:YES];
+    }
+    return popped;
+}
+
+- (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers animated:(BOOL)animated {
+    %orig;
+    if (!ApolloPaneLayoutActive() || sPaneRouterReentrant) return;
+    UINavigationController *navigationController = (UINavigationController *)self;
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController);
+    if (navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]) {
+        [pane apollo_primaryNavigationStackWasReplacedExternally:
+            navigationController.viewControllers];
+        [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:@"primary stack replacement"];
+    }
+}
+
+- (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers {
+    %orig;
+    if (!ApolloPaneLayoutActive() || sPaneRouterReentrant) return;
+    UINavigationController *navigationController = (UINavigationController *)self;
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(navigationController);
+    if (navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]) {
+        [pane apollo_primaryNavigationStackWasReplacedExternally:
+            navigationController.viewControllers];
+        [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:@"primary stack replacement"];
+    }
+}
+
+- (void)navigationController:(UINavigationController *)navigationController
+       didShowViewController:(UIViewController *)viewController
+                    animated:(BOOL)animated {
+    %orig;
+    if (!ApolloPaneLayoutActive()) return;
+    UINavigationController *selfNavigationController = (UINavigationController *)self;
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(selfNavigationController);
+    [pane apollo_navigationTransitionDidSettle];
+    [pane apollo_resolvedDisplayStateMayHaveChanged];
+    if (selfNavigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]) {
+        [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:@"primary navigation settled"];
+    }
+}
+
+%end
+
+
+%hook ApolloPanePostsViewController
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    // Posts owns a second UITableView only while its Jump Bar dropdown is open.
+    // Selecting a post on the main Texture table must not clear first; selecting
+    // a dropdown row can synchronously reuse this same controller for a new
+    // subreddit/feed, so request a semantic comparison after Apollo settles.
+    UITableView *dropDownTableView = nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable([self class], "dropDownTableView");
+        if (ivar) dropDownTableView = object_getIvar(self, ivar);
+    } @catch (__unused NSException *exception) {}
+    BOOL wasDropDownSelection = dropDownTableView && tableView == dropDownTableView;
+    %orig;
+    if (wasDropDownSelection) {
+        ApolloPaneSchedulePostsScopeReconciliation((UIViewController *)self,
+                                                   @"Jump Bar dropdown selection");
+    }
+}
+
+- (void)redditAccountChangedWithNotification:(NSNotification *)notification {
+    %orig;
+    ApolloPaneSplitViewController *pane =
+        ApolloPaneForPrimaryController((UIViewController *)self);
+    [pane apollo_forcePrimaryContextChangedForViewController:(UIViewController *)self
+                                                      reason:@"account changed"];
+}
+
+%end
+
+
+%hook UINavigationItem
+
+- (void)setTitle:(NSString *)title {
+    NSString *before = self.title;
+    %orig;
+    NSString *after = self.title;
+    if (!ApolloPaneLayoutActive() || before == after || [before isEqualToString:after]) return;
+    ApolloPaneSplitViewController *pane = ApolloPaneForPrimaryNavigationItem(self);
+    [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:
+        @"primary navigation title changed"];
 }
 
 %end
@@ -227,7 +1043,44 @@ static ApolloPaneColumn ApolloPaneColumnForViewController(UIViewController *view
     // hook would be pure overhead on Apollo's hottest navigation path.
     if (!ApolloPaneLayoutEnabled()) return;
 
-    %init(ApolloPaneRouterGroup);
+    Class navigationControllerClass = objc_getClass("_TtC6Apollo26ApolloNavigationController");
+    if (!navigationControllerClass) {
+        ApolloLog(@"[PaneRouter] ApolloNavigationController class missing; router not installed");
+        return;
+    }
+    Class postsClass = objc_getClass("_TtC6Apollo19PostsViewController");
+    Class settingsClass = objc_getClass("_TtC6Apollo22SettingsViewController");
+    Class inboxListClass = objc_getClass("_TtC6Apollo23InboxListViewController");
+    Class listAdapterClass = objc_getClass("_TtC6Apollo11ListAdapter");
+    Class tableNodeClass = objc_getClass("ASTableNode");
+    if (!postsClass || !settingsClass || !inboxListClass || !listAdapterClass ||
+        !tableNodeClass) {
+        ApolloLog(@"[PaneRouter] required class missing posts=%@ settings=%@ inbox=%@ adapter=%@ tableNode=%@; router not installed",
+                  NSStringFromClass(postsClass), NSStringFromClass(settingsClass),
+                  NSStringFromClass(inboxListClass), NSStringFromClass(listAdapterClass),
+                  NSStringFromClass(tableNodeClass));
+        return;
+    }
+    %init(ApolloPaneRouterGroup,
+          ApolloPaneNavigationController=navigationControllerClass,
+          ApolloPanePostsViewController=postsClass,
+          ApolloPaneSettingsViewController=settingsClass,
+          ApolloPaneInboxListViewController=inboxListClass,
+          ApolloPaneListAdapter=listAdapterClass,
+          ApolloPaneTableNode=tableNodeClass);
+
+    NSArray<NSString *> *accountNotifications = @[
+        @"com.christianselig.RedditCurrentAccountChanged",
+        @"com.christianselig.RedditAccountChanged",
+    ];
+    for (NSString *name in accountNotifications) {
+        [NSNotificationCenter.defaultCenter addObserverForName:name object:nil
+            queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *notification) {
+                for (ApolloPaneSplitViewController *pane in ApolloPaneAllLivePanes()) {
+                    [pane apollo_accountContextDidChange];
+                }
+            }];
+    }
     ApolloLog(@"[PaneRouter] installed with %lu routed classes",
-              (unsigned long)(sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0])));
+              (unsigned long)ApolloPaneExplicitRouteCount());
 }

--- a/src/ipad/ApolloPaneRouting.h
+++ b/src/ipad/ApolloPaneRouting.h
@@ -1,0 +1,31 @@
+// ApolloPaneRouting.h
+//
+// Shared logical-column policy for live pushes and stacks Apollo constructed
+// before the pane hierarchy was installed (cold URLs, Handoff/Siri, and state
+// restoration). Keeping one resolver prevents cold and warm navigation from
+// assigning the same destination to different columns.
+
+#import <UIKit/UIKit.h>
+#import "ApolloPaneLayout.h"
+
+NS_ASSUME_NONNULL_BEGIN
+__BEGIN_DECLS
+
+// Resolve one navigation edge. Unknown destinations inherit their source
+// column; once navigation reaches detail it can only continue rightward.
+ApolloPaneColumn ApolloPaneResolveLogicalColumn(UIViewController *_Nullable sourceViewController,
+                                                UIViewController *_Nullable destinationViewController,
+                                                ApolloPaneColumn sourceColumn,
+                                                BOOL *_Nullable explicitlyClassified);
+
+// Whether this exact destination is a tab-root-designed controller proven to
+// suppress UIKit's Back item when physically appended to a detail stack. This
+// policy is intentionally narrower than the column-routing allowlist.
+BOOL ApolloPaneDestinationRequiresSupplementalBack(UIViewController *_Nullable destinationViewController);
+
+// Number of destination classes explicitly listed in the policy. Diagnostic
+// only, so the router can report what it installed without owning the table.
+NSUInteger ApolloPaneExplicitRouteCount(void);
+
+__END_DECLS
+NS_ASSUME_NONNULL_END

--- a/src/ipad/ApolloPaneRouting.m
+++ b/src/ipad/ApolloPaneRouting.m
@@ -1,0 +1,110 @@
+// ApolloPaneRouting.m
+
+// Pure destination/source classification shared by ApolloPaneRouter's live
+// push hook and ApolloPaneSplitViewController's pre-install stack normalizer.
+
+#import "ApolloPaneRouting.h"
+#import <objc/runtime.h>
+
+typedef struct {
+    const char *className;
+    ApolloPaneColumn column;
+} ApolloPaneRoute;
+
+// Matched with isKindOfClass:, so subclasses inherit their parent's column.
+// Comment-list controllers are feeds and intentionally stay unlisted.
+static const ApolloPaneRoute kPaneRoutes[] = {
+#if APOLLO_SIM_BUILD
+    // Deterministic Task 11 transition probe. The class exists only in the
+    // simulator debug bridge, so no device destination can match this entry.
+    { "ApolloPaneTransitionProbeViewController", ApolloPaneColumnSecondary },
+#endif
+    { "_TtC6Apollo22CommentsViewController", ApolloPaneColumnSecondary },
+
+    // Apollo's concrete private-message/modmail conversation. Do not classify
+    // its generic MessagesViewController base: an unrelated future subclass
+    // should not acquire column behavior without its own test pass.
+    { "_TtC6Apollo28PrivateMessageViewController", ApolloPaneColumnSecondary },
+
+    // These screens describe the item selected in a list/feed. A profile also
+    // serves as the Profile tab's root, but that instance is already installed
+    // before panes are built; subsequent profile pushes are author details.
+    { "_TtC6Apollo21ProfileViewController",          ApolloPaneColumnSecondary },
+    { "_TtC6Apollo30SubredditSidebarViewController", ApolloPaneColumnSecondary },
+    { "_TtC6Apollo28SubredditRulesViewController",   ApolloPaneColumnSecondary },
+
+    // Reborn's authenticated Chat/Modmail surface is opened from the Inbox
+    // Boxes index (including notification deep links), so it owns detail even
+    // though one controller renders both its list and conversation routes.
+    { "ApolloDirectChatWebViewController", ApolloPaneColumnSecondary },
+
+    // The Inbox Boxes controller remains the tab's stable index. Selecting a
+    // category or native Modmail opens its list in detail; selecting a message
+    // then appends the conversation on that same rightward stack.
+    { "_TtC6Apollo19InboxViewController",        ApolloPaneColumnSecondary },
+    { "_TtC6Apollo26ModmailInboxViewController", ApolloPaneColumnSecondary },
+
+    // Feed indexes stay on the left. Explicit classification also tells the
+    // router to clear stale detail when the user changes feeds.
+    { "_TtC6Apollo19PostsViewController",     ApolloPaneColumnPrimary },
+    { "_TtC6Apollo23LitePostsViewController", ApolloPaneColumnPrimary },
+};
+
+static BOOL ApolloPaneIsIndexRootController(UIViewController *viewController) {
+    static const char *kIndexRoots[] = {
+        "_TtC6Apollo22SettingsViewController",
+        "_TtC6Apollo21ProfileViewController",
+    };
+    for (size_t index = 0; index < sizeof(kIndexRoots) / sizeof(kIndexRoots[0]); index++) {
+        Class cls = objc_getClass(kIndexRoots[index]);
+        if (cls && [viewController isMemberOfClass:cls]) return YES;
+    }
+    return NO;
+}
+
+static ApolloPaneColumn ApolloPaneExplicitColumnForViewController(UIViewController *viewController) {
+    if (!viewController) return ApolloPaneColumnInPlace;
+    for (size_t index = 0; index < sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0]); index++) {
+        Class cls = objc_getClass(kPaneRoutes[index].className);
+        if (cls && [viewController isKindOfClass:cls]) return kPaneRoutes[index].column;
+    }
+    return ApolloPaneColumnInPlace;
+}
+
+BOOL ApolloPaneDestinationRequiresSupplementalBack(UIViewController *destinationViewController) {
+    Class profileClass = objc_getClass("_TtC6Apollo21ProfileViewController");
+    return profileClass && [destinationViewController isMemberOfClass:profileClass];
+}
+
+ApolloPaneColumn ApolloPaneResolveLogicalColumn(UIViewController *sourceViewController,
+                                                UIViewController *destinationViewController,
+                                                ApolloPaneColumn sourceColumn,
+                                                BOOL *explicitlyClassified) {
+    if (explicitlyClassified) *explicitlyClassified = NO;
+
+    // Content only moves rightward. A link opened from detail stays in detail
+    // even when its class would ordinarily be a primary feed.
+    if (sourceColumn == ApolloPaneColumnSecondary) return ApolloPaneColumnSecondary;
+
+    // Settings and Profile are index roots by product policy. Their first
+    // destination occupies detail regardless of the destination class table.
+    if (ApolloPaneIsIndexRootController(sourceViewController)) {
+        if (explicitlyClassified) *explicitlyClassified = YES;
+        return ApolloPaneColumnSecondary;
+    }
+
+    ApolloPaneColumn explicitColumn =
+        ApolloPaneExplicitColumnForViewController(destinationViewController);
+    if (explicitColumn != ApolloPaneColumnInPlace) {
+        if (explicitlyClassified) *explicitlyClassified = YES;
+        return explicitColumn;
+    }
+
+    // Unknown controllers behave exactly like a stock in-place push.
+    return sourceColumn == ApolloPaneColumnSecondary
+        ? ApolloPaneColumnSecondary : ApolloPaneColumnPrimary;
+}
+
+NSUInteger ApolloPaneExplicitRouteCount(void) {
+    return sizeof(kPaneRoutes) / sizeof(kPaneRoutes[0]);
+}

--- a/src/ipad/ApolloPaneSplitViewController.h
+++ b/src/ipad/ApolloPaneSplitViewController.h
@@ -20,6 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)paneControllerWithRootNavigationController:(UINavigationController *)rootNavigationController
                                                   tabIndex:(NSInteger)tabIndex;
 
+// Install-time rollback only. Removes pane-owned gesture targets/registrations
+// and detaches the original navigation controller so the stock tab hierarchy
+// can reclaim it after a failed atomic install.
+- (void)apollo_prepareForInstallationRollback;
+
+// Exact staging postcondition used by the atomic installer before it publishes
+// the replacement tab-child array.
+- (BOOL)apollo_validateInstallationWithOriginalNavigationController:
+    (UINavigationController *)navigationController
+                                                        originalStack:
+    (NSArray<UIViewController *> *)originalStack;
+
 // The tab index this pane belongs to, for logging and for the tab-child unwrap
 // helper to sanity-check against.
 @property (nonatomic, readonly) NSInteger apollo_tabIndex;
@@ -38,16 +50,94 @@ NS_ASSUME_NONNULL_BEGIN
 // loads a new list, so a stale comment thread does not sit beside unrelated posts.
 - (void)apollo_clearDetailColumn;
 
-// The column a "what is the user looking at" walk should descend into: the
-// detail column when it holds real content, otherwise the primary column.
+// The attached column a "what is the user looking at" walk should descend
+// into: the detail column when it is the surviving visible compact column (or
+// holds real content in regular width), otherwise the primary column.
 // Discovered by ApolloContentColumnForSplitViewController via
 // respondsToSelector:, so ApolloCommon needs no dependency on this class.
 - (nullable UIViewController *)apollo_preferredContentColumnController;
 
-// Tell the pane its detail column's content changed, so it can reclaim the
-// sidebar's width for reading and hand it back when the column empties again.
-// Called by the router after it re-homes something, and internally on clear.
-- (void)apollo_detailContentDidChange;
+// Compact mode has one physical navigation stack, but destinations still need
+// a logical column so they can be split back out when the window expands.
+// The router records pushed controllers here; the pane owns and consumes the
+// bookkeeping so no global navigation state survives the controller.
+- (void)apollo_recordCompactViewController:(UIViewController *)viewController
+                              logicalColumn:(ApolloPaneColumn)column;
+- (BOOL)apollo_compactViewControllerBelongsToDetail:(nullable UIViewController *)viewController;
+- (void)apollo_refreshCompactDetailChromeAfterRootReplacement;
+
+// The stable primary-context owner used by pending-route validation. Compact
+// detail continuations capture this instead of becoming unconditional,
+// source-less work that could survive a feed/account change while queued.
+- (nullable UIViewController *)apollo_primaryContextViewController;
+
+// Detail-context ownership. A detail root belongs to the semantic primary
+// context that selected it, not merely to whichever controller happened to be
+// topmost at that instant. The router records successful primary -> detail
+// branches; settled primary navigation and narrow in-place feed probes ask the
+// pane to reconcile. Unknown semantic scopes fail open, while a removed owner
+// or proven scope change clears stale detail.
+- (void)apollo_recordDetailBranchFromPrimarySource:(nullable UIViewController *)sourceViewController;
+- (void)apollo_reconcileDetailAfterPrimaryMutation:(NSString *)reason;
+- (void)apollo_scheduleDetailReconciliationAfterPrimaryMutation:(NSString *)reason;
+- (void)apollo_forcePrimaryContextChangedForViewController:(UIViewController *)viewController
+                                                    reason:(NSString *)reason;
+- (void)apollo_accountContextDidChange;
+
+// Cross-column stack replacements must never run while either Apollo
+// navigation controller (or the split topology) is mid-transition. Returns YES
+// when the request was accepted into the pane's latest-intent queue; the block
+// is invoked only after the final committed/cancelled state is settled and the
+// captured primary source is still current.
+- (BOOL)apollo_deferCrossColumnNavigationIfNeeded:(dispatch_block_t)navigation
+                              sourceViewController:(nullable UIViewController *)sourceViewController
+                                            reason:(NSString *)reason;
+- (void)apollo_performCrossColumnNavigationTransaction:(dispatch_block_t)navigation;
+- (void)apollo_navigationTransitionDidSettle;
+- (void)apollo_resolvedDisplayStateMayHaveChanged;
+- (void)apollo_revealDetailAfterPrimarySelectionIfNeeded;
+
+// A selected row is part of the semantic primary -> detail branch on iPad.
+// Apollo normally deselects immediately because the list disappears after an
+// iPhone push; in a pane that leaves the still-visible list ambiguous. Source
+// callbacks create an opaque intent before Apollo clears its UIKit selection,
+// and the router commits it only after the detail replacement succeeds.
+- (nullable id)apollo_masterSelectionIntentFromSource:(UIViewController *)sourceViewController
+                                               surface:(id)surface
+                                             indexPath:(NSIndexPath *)indexPath
+                                        itemIdentifier:(nullable id<NSCopying>)itemIdentifier
+                                         identityOwner:(nullable id)identityOwner;
+- (void)apollo_stageMasterSelectionIntent:(nullable id)intent;
+- (nullable id)apollo_claimStagedMasterSelectionIntentForSource:
+    (UIViewController *)sourceViewController;
+- (void)apollo_commitMasterSelectionIntent:(nullable id)intent
+                                detailRoot:(UIViewController *)detailRoot;
+- (void)apollo_refreshMasterSelection;
+- (BOOL)apollo_shouldRetainMasterSelectionForSurface:(id)surface
+                                           indexPath:(NSIndexPath *)indexPath;
+// Called by the Apollo navigation-controller hooks only after a real public
+// primary-stack mutation succeeds. It invalidates compact restoration tokens
+// so a genuine pop/replacement can never be mistaken for UIKit truncation.
+- (void)apollo_primaryNavigationStackDidMutateExternally;
+- (void)apollo_primaryNavigationPushDidMutateExternally:
+    (NSArray<UIViewController *> *)viewControllers;
+- (void)apollo_primaryNavigationStackWasReplacedExternally:
+    (NSArray<UIViewController *> *)viewControllers;
+- (NSUInteger)apollo_primaryNavigationPopWillBeginWithOperation:(NSString *)operation
+                                                        animated:(BOOL)animated;
+- (void)apollo_primaryNavigationPopDidSettle:(NSUInteger)token
+                                 beforeStack:(NSArray<UIViewController *> *)beforeStack
+                                    cancelled:(BOOL)cancelled;
+
+#if APOLLO_SIM_BUILD
+- (void)apollo_simSetCrossColumnNavigationBlocked:(BOOL)blocked;
+- (NSString *)apollo_simCrossColumnNavigationState;
+- (void)apollo_simSetResolvedLayoutMode:(NSString *)mode;
+- (NSString *)apollo_simResolvedLayoutState;
+- (BOOL)apollo_simActivateShowPrimaryItem;
+- (NSString *)apollo_simMasterSelectionState;
++ (void)apollo_simRunDeallocatedSourceProbe;
+#endif
 
 @end
 

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -1,9 +1,119 @@
 // ApolloPaneSplitViewController.m — see ApolloPaneSplitViewController.h
 
 #import "ApolloPaneSplitViewController.h"
+#import "ApolloPaneForwardHistory.h"
+#import "ApolloPaneRouting.h"
 #import <objc/runtime.h>
+#import <objc/message.h>
+#import <string.h>
 #import "../ApolloCommon.h"        // ApolloLog
 #import "../ApolloThemeRuntime.h"  // ApolloThemeAccentColor
+
+extern void *ApolloSwiftListAdapterIndexPathForModelIdentifier(
+    const void *mappingStorage, const void *tokenObject);
+
+#pragma mark - Primary context identity
+
+// A utility controller temporarily pushed above a feed does not change what a
+// detail selection belongs to. Walk backward to the newest feed-shaped owner;
+// tabs without feeds use their stable index/root controller as the context.
+static UIViewController *ApolloPanePrimaryContextController(NSArray<UIViewController *> *stack) {
+    Class postsClass = objc_getClass("_TtC6Apollo19PostsViewController");
+    Class litePostsClass = objc_getClass("_TtC6Apollo23LitePostsViewController");
+    for (UIViewController *controller in stack.reverseObjectEnumerator) {
+        if ((postsClass && [controller isKindOfClass:postsClass]) ||
+            (litePostsClass && [controller isKindOfClass:litePostsClass])) {
+            return controller;
+        }
+    }
+    return stack.firstObject;
+}
+
+static BOOL ApolloPaneStacksIdentityEqual(NSArray<UIViewController *> *left,
+                                          NSArray<UIViewController *> *right) {
+    if (left.count != right.count) return NO;
+    for (NSUInteger index = 0; index < left.count; index++) {
+        if (left[index] != right[index]) return NO;
+    }
+    return YES;
+}
+
+static BOOL ApolloPaneStackIsStrictIdentityPrefix(NSArray<UIViewController *> *candidate,
+                                                   NSArray<UIViewController *> *fullStack) {
+    if (candidate.count >= fullStack.count) return NO;
+    for (NSUInteger index = 0; index < candidate.count; index++) {
+        if (candidate[index] != fullStack[index]) return NO;
+    }
+    return YES;
+}
+
+static BOOL ApolloPaneStackStartsWithIdentityStack(NSArray<UIViewController *> *stack,
+                                                    NSArray<UIViewController *> *prefix) {
+    if (stack.count < prefix.count) return NO;
+    for (NSUInteger index = 0; index < prefix.count; index++) {
+        if (stack[index] != prefix[index]) return NO;
+    }
+    return YES;
+}
+
+static BOOL ApolloPaneControllerIsAttached(UIViewController *controller);
+
+// `isCollapsed` answers whether UIKit merged columns into one navigation
+// topology; it does not answer whether an expanded primary is currently
+// visible. A constrained regular-width split can resolve to SecondaryOnly or
+// OneOverSecondary while remaining uncollapsed. Prefer iOS 26's direct query,
+// with the documented resolved display-mode mapping as the older-OS fallback.
+static BOOL ApolloPaneSplitShowsPrimary(UISplitViewController *split) {
+    if (!split) return NO;
+    if (@available(iOS 26.0, *)) {
+        return [split isShowingColumn:UISplitViewControllerColumnPrimary];
+    }
+    if (split.isCollapsed) {
+        UIViewController *primary = [split viewControllerForColumn:UISplitViewControllerColumnPrimary];
+        return ApolloPaneControllerIsAttached(primary);
+    }
+    switch (split.displayMode) {
+        case UISplitViewControllerDisplayModeOneBesideSecondary:
+        case UISplitViewControllerDisplayModeOneOverSecondary:
+            return YES;
+        case UISplitViewControllerDisplayModeSecondaryOnly:
+        default:
+            return NO;
+    }
+}
+
+static BOOL ApolloPaneSplitShowsTiledPrimary(UISplitViewController *split) {
+    if (!split || split.isCollapsed || !ApolloPaneSplitShowsPrimary(split)) return NO;
+    // For a double-column split this is the sole resolved mode in which both
+    // columns are side-by-side and interactive. OneOverSecondary is visible,
+    // but it is an overlay—not a divider that should receive our grabber or
+    // drive detail-column geometry.
+    return split.displayMode == UISplitViewControllerDisplayModeOneBesideSecondary &&
+        split.splitBehavior == UISplitViewControllerSplitBehaviorTile &&
+        split.transitionCoordinator == nil;
+}
+
+// Semantic scope for the one Apollo screen that reuses a controller while
+// changing feeds. `currentSubreddit` and `currentMultireddit` are asynchronous
+// and can retain stale values after reuse, so they cannot safely participate in
+// identity. The PostsType tag is synchronous and the displayed Jump Bar title
+// is the exact user-visible payload that changes for dropdown, typed, and
+// random navigation. Never log the returned value: it stays process-local.
+static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
+    Class postsClass = objc_getClass("_TtC6Apollo19PostsViewController");
+    if (!postsClass || ![controller isKindOfClass:postsClass]) return nil;
+    Ivar postsTypeIvar = class_getInstanceVariable([controller class], "currentPostsType");
+    if (!postsTypeIvar) return nil;
+    uint8_t tag = 0;
+    const uint8_t *bytes = (const uint8_t *)(__bridge const void *)controller;
+    memcpy(&tag, bytes + ivar_getOffset(postsTypeIvar) + 0x20, sizeof(tag));
+
+    NSString *title = controller.navigationItem.title ?: controller.title;
+    NSString *normalizedTitle = [[title stringByTrimmingCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet] lowercaseString];
+    if (normalizedTitle.length == 0) return nil;
+    return [NSString stringWithFormat:@"type=%u|title=%@", tag, normalizedTitle];
+}
 
 #pragma mark - Detail placeholder
 
@@ -123,6 +233,73 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     if (stack.count == 0) return YES;
     if (stack.count > 1) return NO;
     return [stack.firstObject isKindOfClass:[ApolloPaneDetailPlaceholderViewController class]];
+}
+
+// Do not make a detached column the origin for an alert, activity controller,
+// or other presentation. `isViewLoaded` avoids loading an off-screen column as
+// a side effect of merely asking what the user can see.
+static BOOL ApolloPaneControllerIsAttached(UIViewController *controller) {
+    if (!controller.isViewLoaded) return NO;
+    UIView *view = controller.viewIfLoaded;
+    return view.window != nil && !view.hidden && view.alpha > 0.01;
+}
+
+// ApolloNavigationController uses its own UIPanGestureRecognizers rather than
+// UIKit's `interactivePopGestureRecognizer`. Read them through the ObjC runtime
+// because this file cannot import a generated private-class header, and because
+// MSHookIvar is only legal inside Logos hooks in this project.
+static UIGestureRecognizer *ApolloPaneNavigationGesture(UINavigationController *nav,
+                                                        const char *ivarName) {
+    if (!nav || !ivarName) return nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable(nav.class, ivarName);
+        id value = ivar ? object_getIvar(nav, ivar) : nil;
+        return [value isKindOfClass:[UIGestureRecognizer class]] ? value : nil;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneSplit] failed reading navigation gesture %s on %@: %@",
+                  ivarName, NSStringFromClass(nav.class), exception);
+        return nil;
+    }
+}
+
+// Apollo keeps transition state in private Swift fields. Validate the runtime
+// encoding before reading the one-byte Bool storage so a future app update fails
+// open to the public coordinator/gesture checks instead of reading a wider field.
+static BOOL ApolloPaneNavigationBoolFlag(UINavigationController *navigationController,
+                                         const char *ivarName) {
+    if (!navigationController || !ivarName) return NO;
+    Ivar ivar = class_getInstanceVariable(navigationController.class, ivarName);
+    if (!ivar) return NO;
+    const char *encoding = ivar_getTypeEncoding(ivar);
+    if (!encoding || !(encoding[0] == 'B' || encoding[0] == 'c' || encoding[0] == 'C')) {
+        return NO;
+    }
+    uint8_t value = 0;
+    @try {
+        uint8_t *bytes = (uint8_t *)(__bridge void *)navigationController;
+        memcpy(&value, bytes + ivar_getOffset(ivar), sizeof(value));
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+    return value != 0;
+}
+
+static id ApolloPaneNavigationObjectIvar(UINavigationController *navigationController,
+                                         const char *ivarName) {
+    if (!navigationController || !ivarName) return nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable(navigationController.class, ivarName);
+        const char *encoding = ivar ? ivar_getTypeEncoding(ivar) : NULL;
+        return encoding && encoding[0] == '@'
+            ? object_getIvar(navigationController, ivar) : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
+    return gesture.state == UIGestureRecognizerStateBegan ||
+        gesture.state == UIGestureRecognizerStateChanged;
 }
 
 #pragma mark - Column host
@@ -315,9 +492,10 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     UIViewController *list = [split isKindOfClass:[UISplitViewController class]]
         ? [split viewControllerForColumn:UISplitViewControllerColumnPrimary]
         : nil;
-    if (list.isViewLoaded && list.view.superview && !split.isCollapsed) {
+    if (list.isViewLoaded && list.view.superview && ApolloPaneSplitShowsTiledPrimary(split)) {
         CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
-        if (!CGRectIsEmpty(listFrame)) {
+        CGRect splitBoundsInHost = [split.view convertRect:split.view.bounds toView:self.view];
+        if (!CGRectIsEmpty(listFrame) && CGRectIntersectsRect(listFrame, splitBoundsInHost)) {
             bottom = height - CGRectGetMaxY(listFrame);
 
             // Align the two NAVIGATION BARS, not the two view origins.
@@ -354,20 +532,840 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 
 #pragma mark - Pane split controller
 
-@interface ApolloPaneSplitViewController () <UISplitViewControllerDelegate> {
+@interface ApolloPaneMasterSelectionIntent : NSObject
+@property (nonatomic, weak) UIViewController *sourceViewController;
+@property (nonatomic, weak) id surface;
+@property (nonatomic, weak) id identityOwner;
+@property (nonatomic, copy) NSIndexPath *indexPath;
+@property (nonatomic, copy, nullable) id itemIdentifier;
+@property (nonatomic, copy, nullable) NSString *cellFingerprint;
+@property (nonatomic) BOOL textureBacked;
+@end
+
+@implementation ApolloPaneMasterSelectionIntent
+@end
+
+// A selector is a process-stable associated-object key shared with the
+// UITableViewCell reuse hook in ApolloPaneRouter.xm. The marker is set only when
+// this tweak had to add the Selected trait itself, so cleanup never removes a
+// trait supplied by Apollo or UIKit.
+static const void *ApolloPaneMasterSelectionAXMarkerKey(void) {
+    return NSSelectorFromString(@"apollo_masterSelectionAddedAXSelectedTrait");
+}
+
+static UITableView *ApolloPaneMasterSelectionTable(id surface) {
+    if ([surface isKindOfClass:[UITableView class]]) return (UITableView *)surface;
+    if (![surface respondsToSelector:@selector(view)]) return nil;
+    id view = ((id (*)(id, SEL))objc_msgSend)(surface, @selector(view));
+    return [view isKindOfClass:[UITableView class]] ? view : nil;
+}
+
+static id ApolloPaneMasterSelectionNode(id surface, NSIndexPath *indexPath) {
+    if (!surface || [surface isKindOfClass:[UITableView class]] || !indexPath ||
+        ![surface respondsToSelector:NSSelectorFromString(@"nodeForRowAtIndexPath:")]) return nil;
+    return ((id (*)(id, SEL, id))objc_msgSend)(
+        surface, NSSelectorFromString(@"nodeForRowAtIndexPath:"), indexPath);
+}
+
+static id ApolloPaneMasterSelectionObjectIvar(id object, const char *name) {
+    if (!object || !name) return nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+        return ivar ? object_getIvar(object, ivar) : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static const void *ApolloPaneMasterSelectionSwiftIvarStorage(id object,
+                                                             const char *name) {
+    if (!object || !name) return NULL;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    if (!ivar) return NULL;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    size_t instanceSize = class_getInstanceSize(object_getClass(object));
+    if (offset <= 0 || (size_t)offset + sizeof(void *) > instanceSize) return NULL;
+    return (const uint8_t *)(__bridge const void *)object + offset;
+}
+
+static id ApolloPaneMasterSelectionIdentifierAtPath(id surface, NSIndexPath *indexPath) {
+    id node = ApolloPaneMasterSelectionNode(surface, indexPath);
+    if (!node) return nil;
+    id model = ApolloPaneMasterSelectionObjectIvar(node, "link") ?:
+        ApolloPaneMasterSelectionObjectIvar(node, "message");
+    if (!model) return nil;
+    for (NSString *selectorName in @[ @"fullName", @"identifier", @"diffIdentifier" ]) {
+        SEL selector = NSSelectorFromString(selectorName);
+        if (![model respondsToSelector:selector]) continue;
+        id value = ((id (*)(id, SEL))objc_msgSend)(model, selector);
+        if ([value conformsToProtocol:@protocol(NSCopying)]) return value;
+    }
+    return nil;
+}
+
+static BOOL ApolloPaneMasterSelectionPathIsInBounds(UITableView *tableView,
+                                                     NSIndexPath *indexPath) {
+    if (!tableView || !indexPath || indexPath.section < 0 || indexPath.row < 0 ||
+        indexPath.section >= [tableView numberOfSections]) return NO;
+    return indexPath.row < [tableView numberOfRowsInSection:indexPath.section];
+}
+
+static NSString *ApolloPaneMasterSelectionCellFingerprint(UITableView *tableView,
+                                                           NSIndexPath *indexPath) {
+    if (!ApolloPaneMasterSelectionPathIsInBounds(tableView, indexPath)) return nil;
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (!cell) return nil;
+    // This stays in memory and is never logged. It is validation for static
+    // Settings/Inbox matrices, not a user-data diagnostic or a global identity.
+    return [NSString stringWithFormat:@"%@\x1f%@\x1f%@\x1f%@\x1f%@",
+        NSStringFromClass(cell.class), cell.reuseIdentifier ?: @"",
+        cell.accessibilityIdentifier ?: @"", cell.textLabel.text ?: @"",
+        cell.detailTextLabel.text ?: @""];
+}
+
+static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *cell,
+                                                               BOOL selected) {
+    if (!cell) return;
+    const void *key = ApolloPaneMasterSelectionAXMarkerKey();
+    BOOL addedByPane = [objc_getAssociatedObject(cell, key) boolValue];
+    if (selected) {
+        if (!(cell.accessibilityTraits & UIAccessibilityTraitSelected)) {
+            cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            objc_setAssociatedObject(cell, key, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    } else if (addedByPane) {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        objc_setAssociatedObject(cell, key, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+@interface ApolloPaneSplitViewController () <UISplitViewControllerDelegate, UIGestureRecognizerDelegate> {
     BOOL _apollo_loggedResolvedLayout;
     UIView *_apollo_grabber;
-    BOOL _apollo_sidebarManaged;      // we last set the sidebar's visibility
-    BOOL _apollo_sidebarWeSetHidden;  // ...to this
+
+    // Compact-mode chrome. UIKit stacks the secondary column's wrapper onto the
+    // primary navigation controller when a double-column split collapses. Left
+    // alone that exposes TWO bars: the primary bar carrying cross-column Back,
+    // then Apollo's real detail bar carrying the title and actions. We hide the
+    // empty primary chrome and put an explicit Back affordance on the detail
+    // root instead, while retaining UIKit's bridge controller and installing a
+    // coordinator-owned edge gesture that cannot leave stale column state.
+    BOOL _apollo_compactDetailChromeActive;
+    BOOL _apollo_primaryNavBarWasHiddenBeforeCompact;
+    BOOL _apollo_detailNavBarWasHiddenBeforeCompact;
+    BOOL _apollo_trackingCompactPrimaryPopGesture;
+    BOOL _apollo_primaryPopGestureWasEnabled;
+    BOOL _apollo_detailPopGestureWasEnabled;
+    BOOL _apollo_primaryApolloBackGestureWasEnabled;
+    BOOL _apollo_detailApolloBackGestureWasEnabled;
+    BOOL _apollo_compactBackUsesRightEdge;
+    UIViewController *_apollo_compactPrimaryAnchor;
+    UIViewController *_apollo_compactDetailRoot;
+    UIBarButtonItem *_apollo_compactBackItem;
+    UIPanGestureRecognizer *_apollo_compactBackEdgeGesture;
+    UIGestureRecognizer *_apollo_primaryApolloBackGesture;
+    UIGestureRecognizer *_apollo_detailApolloBackGesture;
+    NSMapTable<UIViewController *, NSNumber *> *_apollo_compactLogicalColumns;
+    // iPadOS 26 can truncate an empty-detail pane's primary stack while it
+    // collapses. Keep the pre-transition controllers so an inactive tab does
+    // not reset merely because the window entered Slide Over.
+    NSArray<UIViewController *> *_apollo_preCollapsePrimaryStack;
+    NSArray<UIViewController *> *_apollo_compactPrimaryReturnStack;
+    NSArray<UIViewController *> *_apollo_postCollapsePrimaryBridgeStack;
+    NSArray<UIViewController *> *_apollo_expectedCompactPrimaryRestoreStack;
+    NSUInteger _apollo_compactPrimaryRestoreGeneration;
+    NSUInteger _apollo_compactPrimaryRestoreLineage;
+    NSUInteger _apollo_primaryNavigationMutationGeneration;
+    NSUInteger _apollo_compactPrimaryRestoreMutationGeneration;
+    NSUInteger _apollo_internalPrimaryStackMutationDepth;
+    BOOL _apollo_expectUIKitCompactPrimaryStackReplacement;
+    BOOL _apollo_expectOneLateUIKitCompactPrimaryStackReplacement;
+    NSUInteger _apollo_lateUIKitCompactPrimaryStableObservations;
+    BOOL _apollo_performingCompactShowColumn;
+    NSArray<UIViewController *> *_apollo_knownUIKitCompactPrimaryTransientStack;
+    NSUInteger _apollo_primaryPopSequence;
+    NSUInteger _apollo_pendingPrimaryPopToken;
+    BOOL _apollo_pendingPrimaryPopRestoreWasActive;
+    BOOL _apollo_expectUIKitExpansionPrimaryMutation;
+    BOOL _apollo_pendingPrimaryPopWasExpectedUIKitExpansion;
+    BOOL _apollo_pendingPrimaryPopAnimated;
+    NSUInteger _apollo_pendingPrimaryPopRestoreGeneration;
+    NSUInteger _apollo_pendingPrimaryPopRestoreLineage;
+    NSUInteger _apollo_pendingPrimaryPopMutationGeneration;
+    NSArray<UIViewController *> *_apollo_pendingPrimaryPopExpectedRestoreStack;
+    NSString *_apollo_pendingPrimaryPopOperation;
+
+    // The concrete source must remain in the logical primary stack. The
+    // semantic owner is normally the deepest Posts controller (or the tab
+    // root), so temporary utility pushes above it do not invalidate detail.
+    // Both are weak: a popped/deallocated owner is an immediate mismatch.
+    __weak UIViewController *_apollo_detailContextOwner;
+    __weak UIViewController *_apollo_detailSemanticOwner;
+    NSString *_apollo_detailContextScope;
+    BOOL _apollo_contextTrackingReady;
+    BOOL _apollo_clearingContext;
+    BOOL _apollo_contextReconciliationScheduled;
+    NSString *_apollo_pendingContextReconciliationReason;
+
+    // Per-pane latest-intent serialization. Pending work represents semantic
+    // navigation, never a pre-resolved physical stack write, so collapse/expand
+    // during the wait cannot send a controller to the wrong column.
+    dispatch_block_t _apollo_pendingCrossColumnNavigation;
+    __weak UIViewController *_apollo_pendingCrossColumnSource;
+    __weak UIViewController *_apollo_pendingCrossColumnSemanticOwner;
+    BOOL _apollo_pendingCrossColumnHadSource;
+    NSString *_apollo_pendingCrossColumnSourceScope;
+    NSString *_apollo_pendingCrossColumnReason;
+    NSUInteger _apollo_crossColumnIntentSequence;
+    NSUInteger _apollo_pendingCrossColumnSequence;
+    BOOL _apollo_crossColumnDrainScheduled;
+    BOOL _apollo_transitionFallbackScheduled;
+    BOOL _apollo_compactPrimaryRestoreInProgress;
+    BOOL _apollo_executingCrossColumnNavigation;
+    BOOL _apollo_topologyMutationInProgress;
+    NSUInteger _apollo_topologyMutationGeneration;
+    BOOL _apollo_compactBackInProgress;
+    __weak id<UIViewControllerTransitionCoordinator> _apollo_observedTransitionCoordinator;
+    UIBarButtonItem *_apollo_showPrimaryItem;
+    __weak UINavigationItem *_apollo_showPrimaryOwner;
+    BOOL _apollo_showPrimaryItemOnRight;
+    BOOL _apollo_resolvedDisplayRefreshScheduled;
+    UISplitViewControllerDisplayMode _apollo_lastSampledDisplayMode;
+    UISplitViewControllerSplitBehavior _apollo_lastSampledSplitBehavior;
+    BOOL _apollo_lastSampledCollapsed;
+    __weak UIViewController *_apollo_lastSampledDetailTop;
+    BOOL _apollo_hasSampledResolvedDisplayState;
+
+    // Pane-owned master selection. The opaque intent retains only copied
+    // identity while its controller and list surface references remain weak.
+    // This cannot keep an inactive tab's view hierarchy alive.
+    id _apollo_masterSelectionIntent;
+    __weak UIViewController *_apollo_masterSelectionDetailRoot;
+    NSUInteger _apollo_masterSelectionGeneration;
+    BOOL _apollo_mutatingMasterSelection;
+    id _apollo_stagedMasterSelectionIntent;
+    NSUInteger _apollo_stagedMasterSelectionGeneration;
+#if APOLLO_SIM_BUILD
+    BOOL _apollo_simCrossColumnNavigationBlocked;
+#endif
 }
 @property (nonatomic, strong) UINavigationController *apollo_primaryNav;   // the list column
 @property (nonatomic, strong) UINavigationController *apollo_detailNav;
 @property (nonatomic, strong) UIViewController *apollo_detailHost;
 @property (nonatomic, copy) NSString *apollo_emptyMessage;
 @property (nonatomic, copy) NSString *apollo_emptySymbol;
+- (BOOL)apollo_normalizePreinstalledPrimaryStack;
+- (void)apollo_setPrimaryViewControllers:(NSArray<UIViewController *> *)viewControllers;
+- (void)apollo_scheduleCompactPrimaryRestoreReconciliation:(NSUInteger)generation
+                                               observations:(NSUInteger)observations;
+- (BOOL)apollo_navigationOrTopologyTransitionIsActive;
+- (nullable id<UIViewControllerTransitionCoordinator>)apollo_activeTransitionCoordinator;
+- (void)apollo_scheduleCrossColumnNavigationDrain;
+- (void)apollo_drainCrossColumnNavigationIfPossible;
+- (void)apollo_removeShowPrimaryItem;
+- (void)apollo_refreshShowPrimaryItem;
+- (void)apollo_scheduleShowPrimaryItemRefresh;
+- (void)apollo_clearMasterSelectionForReason:(NSString *)reason;
+- (nullable NSIndexPath *)apollo_resolvedMasterSelectionPath:
+    (ApolloPaneMasterSelectionIntent *)intent;
+- (void)apollo_deselectMasterSelectionIntent:(ApolloPaneMasterSelectionIntent *)intent;
 @end
 
 @implementation ApolloPaneSplitViewController
+
+- (id)apollo_masterSelectionIntentFromSource:(UIViewController *)sourceViewController
+                                      surface:(id)surface
+                                    indexPath:(NSIndexPath *)indexPath
+                               itemIdentifier:(id<NSCopying>)itemIdentifier
+                                identityOwner:(id)identityOwner {
+    NSAssert(NSThread.isMainThread, @"Pane master selection is main-thread UI state");
+    if (!sourceViewController || !surface || ![indexPath isKindOfClass:[NSIndexPath class]]) {
+        return nil;
+    }
+    UITableView *tableView = ApolloPaneMasterSelectionTable(surface);
+    if (!ApolloPaneMasterSelectionPathIsInBounds(tableView, indexPath)) return nil;
+
+    BOOL textureBacked = ![surface isKindOfClass:[UITableView class]];
+    id resolvedIdentifier = itemIdentifier;
+    if (!resolvedIdentifier && textureBacked) {
+        resolvedIdentifier = ApolloPaneMasterSelectionIdentifierAtPath(surface, indexPath);
+    }
+    // A shifting Texture feed must never be tracked by index path alone. If a
+    // future node/model shape is unknown, fail closed instead of highlighting a
+    // different post or message after a diff update.
+    if (textureBacked && !resolvedIdentifier) {
+        ApolloLog(@"[PaneSelection] tab %ld ignored Texture selection without stable identity source=%@",
+                  (long)self.apollo_tabIndex, NSStringFromClass(sourceViewController.class));
+        return nil;
+    }
+
+    ApolloPaneMasterSelectionIntent *intent = [ApolloPaneMasterSelectionIntent new];
+    intent.sourceViewController = sourceViewController;
+    intent.surface = surface;
+    intent.identityOwner = identityOwner;
+    intent.indexPath = [indexPath copy];
+    intent.itemIdentifier = [resolvedIdentifier copyWithZone:nil];
+    intent.textureBacked = textureBacked;
+    if (!textureBacked) {
+        intent.cellFingerprint = ApolloPaneMasterSelectionCellFingerprint(tableView, indexPath);
+    }
+    return intent;
+}
+
+- (void)apollo_stageMasterSelectionIntent:(id)opaqueIntent {
+    ApolloPaneMasterSelectionIntent *intent =
+        [opaqueIntent isKindOfClass:[ApolloPaneMasterSelectionIntent class]]
+            ? opaqueIntent : nil;
+    _apollo_stagedMasterSelectionIntent = intent;
+    NSUInteger generation = ++_apollo_stagedMasterSelectionGeneration;
+    if (!intent) return;
+    // Texture's ListAdapter may hand the selected SectionController work to a
+    // later main-queue turn. Keep exactly the newest tap briefly, one-shot; a
+    // toggle/modal row that never performs a pane route simply expires without
+    // changing the currently committed selection.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (self->_apollo_stagedMasterSelectionGeneration == generation) {
+            self->_apollo_stagedMasterSelectionIntent = nil;
+        }
+    });
+}
+
+- (id)apollo_claimStagedMasterSelectionIntentForSource:
+    (UIViewController *)sourceViewController {
+    ApolloPaneMasterSelectionIntent *intent = _apollo_stagedMasterSelectionIntent;
+    if (!intent || intent.sourceViewController != sourceViewController) return nil;
+    _apollo_stagedMasterSelectionIntent = nil;
+    ++_apollo_stagedMasterSelectionGeneration;
+    return intent;
+}
+
+- (NSIndexPath *)apollo_resolvedMasterSelectionPath:(ApolloPaneMasterSelectionIntent *)intent {
+    UITableView *tableView = ApolloPaneMasterSelectionTable(intent.surface);
+    if (!tableView || !intent.indexPath) return nil;
+    if (intent.itemIdentifier && intent.identityOwner) {
+        const void *mappingStorage = ApolloPaneMasterSelectionSwiftIvarStorage(
+            intent.identityOwner, "objectToIndexPathMapping");
+        void *pathObject = mappingStorage
+            ? ApolloSwiftListAdapterIndexPathForModelIdentifier(
+                mappingStorage, (__bridge const void *)intent.itemIdentifier)
+            : NULL;
+        NSIndexPath *mappedPath = pathObject ? CFBridgingRelease(pathObject) : nil;
+        if (ApolloPaneMasterSelectionPathIsInBounds(tableView, mappedPath)) {
+            intent.indexPath = [mappedPath copy];
+            return intent.indexPath;
+        }
+        return nil;
+    }
+    if (intent.itemIdentifier) {
+        id cachedIdentifier = ApolloPaneMasterSelectionIdentifierAtPath(
+            intent.surface, intent.indexPath);
+        if ([cachedIdentifier isEqual:intent.itemIdentifier]) return intent.indexPath;
+
+        // Never instantiate offscreen Texture nodes to find an identity. Search
+        // only the nodes already materialized by the list and defer painting if
+        // the selected item is currently outside that window.
+        for (NSIndexPath *visiblePath in tableView.indexPathsForVisibleRows ?: @[]) {
+            id visibleIdentifier = ApolloPaneMasterSelectionIdentifierAtPath(
+                intent.surface, visiblePath);
+            if ([visibleIdentifier isEqual:intent.itemIdentifier]) {
+                intent.indexPath = [visiblePath copy];
+                return intent.indexPath;
+            }
+        }
+        return nil;
+    }
+
+    if (!ApolloPaneMasterSelectionPathIsInBounds(tableView, intent.indexPath)) return nil;
+    NSString *currentFingerprint = ApolloPaneMasterSelectionCellFingerprint(
+        tableView, intent.indexPath);
+    if (intent.cellFingerprint && currentFingerprint &&
+        ![intent.cellFingerprint isEqualToString:currentFingerprint]) return nil;
+    return intent.indexPath;
+}
+
+- (void)apollo_deselectMasterSelectionIntent:(ApolloPaneMasterSelectionIntent *)intent {
+    if (!intent) return;
+    UITableView *tableView = ApolloPaneMasterSelectionTable(intent.surface);
+    NSIndexPath *path = intent.indexPath;
+    if (!tableView || !path) return;
+    _apollo_mutatingMasterSelection = YES;
+    @try {
+        if ([tableView.indexPathsForSelectedRows containsObject:path]) {
+            [tableView deselectRowAtIndexPath:path animated:NO];
+        }
+        ApolloPaneMasterSelectionSetAccessibilitySelected(
+            [tableView cellForRowAtIndexPath:path], NO);
+    } @finally {
+        _apollo_mutatingMasterSelection = NO;
+    }
+}
+
+- (void)apollo_clearMasterSelectionForReason:(NSString *)reason {
+    ApolloPaneMasterSelectionIntent *oldIntent = _apollo_masterSelectionIntent;
+    if (!oldIntent) return;
+    _apollo_masterSelectionIntent = nil;
+    _apollo_masterSelectionDetailRoot = nil;
+    ++_apollo_masterSelectionGeneration;
+    [self apollo_deselectMasterSelectionIntent:oldIntent];
+    ApolloLog(@"[PaneSelection] tab %ld cleared master selection reason=%@",
+              (long)self.apollo_tabIndex, reason ?: @"detail invalidated");
+}
+
+- (void)apollo_refreshMasterSelection {
+    ApolloPaneMasterSelectionIntent *intent = _apollo_masterSelectionIntent;
+    if (!intent) return;
+    UIViewController *source = intent.sourceViewController;
+    id surface = intent.surface;
+    NSArray<UIViewController *> *logicalPrimary = self.apollo_logicalPrimaryControllers;
+    if (!source || !surface || ![logicalPrimary containsObject:source]) {
+        [self apollo_clearMasterSelectionForReason:@"source left primary branch"];
+        return;
+    }
+
+    UITableView *tableView = ApolloPaneMasterSelectionTable(surface);
+    if (!tableView) {
+        [self apollo_clearMasterSelectionForReason:@"source surface deallocated"];
+        return;
+    }
+
+    // Compact is deliberately phone-like: preserve logical identity while the
+    // list is hidden, but do not expose an invisible Selected element to VoiceOver.
+    if (self.isCollapsed) {
+        [self apollo_deselectMasterSelectionIntent:intent];
+        return;
+    }
+
+    UIViewController *detailRoot = _apollo_masterSelectionDetailRoot;
+    if (!detailRoot || self.apollo_detailIsEmpty ||
+        self.apollo_detailNav.viewControllers.firstObject != detailRoot) {
+        [self apollo_clearMasterSelectionForReason:@"detail branch changed"];
+        return;
+    }
+
+    NSIndexPath *resolvedPath = [self apollo_resolvedMasterSelectionPath:intent];
+    if (!resolvedPath) {
+        // A dynamic item may simply be offscreen. Remove a stale physical mark
+        // but keep its semantic identity so a later appearance/expansion can
+        // re-resolve it without scrolling the user's list.
+        [self apollo_deselectMasterSelectionIntent:intent];
+        return;
+    }
+
+    _apollo_mutatingMasterSelection = YES;
+    @try {
+        for (NSIndexPath *selectedPath in tableView.indexPathsForSelectedRows ?: @[]) {
+            if (![selectedPath isEqual:resolvedPath]) {
+                ApolloPaneMasterSelectionSetAccessibilitySelected(
+                    [tableView cellForRowAtIndexPath:selectedPath], NO);
+                [tableView deselectRowAtIndexPath:selectedPath animated:NO];
+            }
+        }
+        [tableView selectRowAtIndexPath:resolvedPath animated:NO
+                         scrollPosition:UITableViewScrollPositionNone];
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:resolvedPath];
+        [cell setSelected:YES animated:NO];
+        ApolloPaneMasterSelectionSetAccessibilitySelected(cell, YES);
+    } @finally {
+        _apollo_mutatingMasterSelection = NO;
+    }
+}
+
+- (void)apollo_commitMasterSelectionIntent:(id)opaqueIntent
+                                detailRoot:(UIViewController *)detailRoot {
+    ApolloPaneMasterSelectionIntent *intent =
+        [opaqueIntent isKindOfClass:[ApolloPaneMasterSelectionIntent class]]
+            ? opaqueIntent : nil;
+    [self apollo_clearMasterSelectionForReason:intent
+        ? @"detail selection replaced" : @"detail replaced without master selection"];
+    if (!intent || !detailRoot) return;
+
+    _apollo_masterSelectionIntent = intent;
+    _apollo_masterSelectionDetailRoot = detailRoot;
+    NSUInteger generation = ++_apollo_masterSelectionGeneration;
+    [self apollo_refreshMasterSelection];
+
+    // Apollo has source-specific delayed deselection paths (notably Chat and
+    // Modmail). Reassert only this still-current generation after their queued
+    // work settles; the UITableView/ASTableNode hooks below also reject later
+    // attempts while the branch remains committed.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_apollo_masterSelectionGeneration == generation) {
+            [self apollo_refreshMasterSelection];
+        }
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (self->_apollo_masterSelectionGeneration == generation) {
+            [self apollo_refreshMasterSelection];
+        }
+    });
+    ApolloLog(@"[PaneSelection] tab %ld committed master selection source=%@ texture=%d",
+              (long)self.apollo_tabIndex,
+              NSStringFromClass(intent.sourceViewController.class), intent.textureBacked);
+}
+
+- (BOOL)apollo_shouldRetainMasterSelectionForSurface:(id)surface
+                                           indexPath:(NSIndexPath *)indexPath {
+    if (_apollo_mutatingMasterSelection || self.isCollapsed ||
+        !_apollo_masterSelectionIntent || !surface || !indexPath) return NO;
+    ApolloPaneMasterSelectionIntent *intent = _apollo_masterSelectionIntent;
+    UITableView *candidateTable = ApolloPaneMasterSelectionTable(surface);
+    UITableView *ownedTable = ApolloPaneMasterSelectionTable(intent.surface);
+    if (!candidateTable || candidateTable != ownedTable) return NO;
+    NSIndexPath *resolved = [self apollo_resolvedMasterSelectionPath:intent];
+    return resolved && [resolved isEqual:indexPath] &&
+        _apollo_masterSelectionDetailRoot == self.apollo_detailNav.viewControllers.firstObject &&
+        !self.apollo_detailIsEmpty;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self apollo_refreshMasterSelection];
+}
+
+- (void)apollo_setPrimaryViewControllers:(NSArray<UIViewController *> *)viewControllers {
+    ++_apollo_internalPrimaryStackMutationDepth;
+    @try {
+        [self.apollo_primaryNav setViewControllers:viewControllers animated:NO];
+    } @finally {
+        --_apollo_internalPrimaryStackMutationDepth;
+    }
+}
+
+- (void)apollo_primaryNavigationStackDidMutateExternally {
+    if (_apollo_internalPrimaryStackMutationDepth > 0) return;
+    ++_apollo_primaryNavigationMutationGeneration;
+    if (!_apollo_compactPrimaryRestoreInProgress) return;
+
+    // The expected stack describes only UIKit's transient showColumn merge.
+    // Once Apollo or the user performs a real public stack mutation, that
+    // intent owns the branch and every outstanding restore callback is stale.
+    ++_apollo_compactPrimaryRestoreGeneration;
+    _apollo_compactPrimaryRestoreInProgress = NO;
+    _apollo_expectedCompactPrimaryRestoreStack = nil;
+    _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+    _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+    _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+    _apollo_knownUIKitCompactPrimaryTransientStack = nil;
+    _apollo_expectUIKitExpansionPrimaryMutation = NO;
+    _apollo_compactPrimaryReturnStack = nil;
+    _apollo_postCollapsePrimaryBridgeStack = nil;
+    ApolloLog(@"[PaneSplit] tab %ld invalidated compact primary restore after navigation mutation",
+              (long)self.apollo_tabIndex);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self apollo_navigationTransitionDidSettle];
+    });
+}
+
+- (void)apollo_primaryNavigationPushDidMutateExternally:
+        (NSArray<UIViewController *> *)viewControllers {
+    if (_apollo_internalPrimaryStackMutationDepth > 0) return;
+    BOOL matchesInitialExpansionPrefix =
+        _apollo_expectUIKitCompactPrimaryStackReplacement &&
+        ApolloPaneStackIsStrictIdentityPrefix(
+            viewControllers, _apollo_expectedCompactPrimaryRestoreStack);
+    BOOL matchesKnownExpansionTransient =
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement &&
+        _apollo_knownUIKitCompactPrimaryTransientStack &&
+        ApolloPaneStacksIdentityEqual(
+            viewControllers, _apollo_knownUIKitCompactPrimaryTransientStack);
+    BOOL isAuthorizedExpansionNormalization =
+        _apollo_compactPrimaryRestoreInProgress &&
+        _apollo_expectUIKitExpansionPrimaryMutation &&
+        (matchesInitialExpansionPrefix || matchesKnownExpansionTransient);
+    if (isAuthorizedExpansionNormalization) {
+        // Apollo implements UIKit's expansion request by "pushing" the root
+        // already present in the stack, which normalizes [root, feed] to
+        // [root]. This exact expansion-owned prefix is system topology, while
+        // every real deeper push is immediate user/app intent and must win even
+        // if its own animated transition coordinator is still attached.
+        [self apollo_primaryNavigationStackWasReplacedExternally:viewControllers];
+        return;
+    }
+    ApolloLog(@"[PaneRestore] tab %ld rejected primary push depth=%lu expected=%lu "
+              @"expansion=%d initialMatch=%d lateMatch=%d top=%@",
+              (long)self.apollo_tabIndex, (unsigned long)viewControllers.count,
+              (unsigned long)_apollo_expectedCompactPrimaryRestoreStack.count,
+              _apollo_expectUIKitExpansionPrimaryMutation,
+              matchesInitialExpansionPrefix, matchesKnownExpansionTransient,
+              NSStringFromClass(viewControllers.lastObject.class));
+    [self apollo_primaryNavigationStackDidMutateExternally];
+}
+
+- (void)apollo_primaryNavigationStackWasReplacedExternally:
+        (NSArray<UIViewController *> *)viewControllers {
+    if (_apollo_internalPrimaryStackMutationDepth > 0) return;
+    BOOL hasUIKitTransitionProvenance = _apollo_pendingPrimaryPopToken != 0 ||
+        _apollo_performingCompactShowColumn || _apollo_topologyMutationInProgress ||
+        self.transitionCoordinator ||
+        [self apollo_navigationControllerIsTransitioning:self.apollo_primaryNav];
+    if (_apollo_expectUIKitCompactPrimaryStackReplacement &&
+        _apollo_compactPrimaryRestoreInProgress &&
+        (hasUIKitTransitionProvenance ||
+         _apollo_expectUIKitExpansionPrimaryMutation) &&
+        ApolloPaneStackIsStrictIdentityPrefix(
+            viewControllers, _apollo_expectedCompactPrimaryRestoreStack)) {
+        // `showColumn:Primary` or the subsequent expansion performs one public
+        // set-stack merge after we arm the restore token. Its final setter can
+        // arrive after UIKit has detached every observable coordinator, so the
+        // explicitly armed one-shot is itself the provenance. Retain only the
+        // exact strict-prefix identity it produced; public pop APIs still carry
+        // their own tokens and any different set invalidates the generation.
+        _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+        _apollo_expectUIKitExpansionPrimaryMutation = NO;
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = YES;
+        _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+        _apollo_knownUIKitCompactPrimaryTransientStack = [viewControllers copy];
+        ApolloLog(@"[PaneSplit] tab %ld captured UIKit compact primary transient depth %lu",
+                  (long)self.apollo_tabIndex, (unsigned long)viewControllers.count);
+        return;
+    }
+    if (_apollo_knownUIKitCompactPrimaryTransientStack &&
+        ApolloPaneStacksIdentityEqual(
+            viewControllers, _apollo_knownUIKitCompactPrimaryTransientStack) &&
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement) {
+        // Repeated writes while UIKit still owns the transition are part of
+        // the merge itself; they must not spend the one post-coordinator slot.
+        // Only a matching write after every transition signal disappears is
+        // the late replacement for which the stabilization lease exists.
+        if (hasUIKitTransitionProvenance) {
+            _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            return;
+        }
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+        _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+        return;
+    }
+    if (_apollo_compactPrimaryRestoreInProgress &&
+        _apollo_expectUIKitCompactPrimaryStackReplacement &&
+        hasUIKitTransitionProvenance) {
+        // UIKit may briefly publish a bridge-shaped stack before the strict
+        // prefix we capture. Keep the one system slot armed, but do not let a
+        // non-final intermediate shape cancel its own restore lease.
+        return;
+    }
+    if (_apollo_compactPrimaryRestoreInProgress &&
+        !ApolloPaneStacksIdentityEqual(
+            viewControllers, _apollo_expectedCompactPrimaryRestoreStack)) {
+        ApolloLog(@"[PaneRestore] tab %ld rejected primary set depth=%lu expected=%lu "
+                  @"provenance=%d expansion=%d initial=%d late=%d strictPrefix=%d top=%@",
+                  (long)self.apollo_tabIndex, (unsigned long)viewControllers.count,
+                  (unsigned long)_apollo_expectedCompactPrimaryRestoreStack.count,
+                  hasUIKitTransitionProvenance,
+                  _apollo_expectUIKitExpansionPrimaryMutation,
+                  _apollo_expectUIKitCompactPrimaryStackReplacement,
+                  _apollo_expectOneLateUIKitCompactPrimaryStackReplacement,
+                  ApolloPaneStackIsStrictIdentityPrefix(
+                      viewControllers, _apollo_expectedCompactPrimaryRestoreStack),
+                  NSStringFromClass(viewControllers.lastObject.class));
+        [self apollo_primaryNavigationStackDidMutateExternally];
+    }
+}
+
+- (NSUInteger)apollo_primaryNavigationPopWillBeginWithOperation:(NSString *)operation
+                                                        animated:(BOOL)animated {
+    NSUInteger token = ++_apollo_primaryPopSequence;
+    _apollo_pendingPrimaryPopToken = token;
+    _apollo_pendingPrimaryPopRestoreWasActive = _apollo_compactPrimaryRestoreInProgress;
+    _apollo_pendingPrimaryPopWasExpectedUIKitExpansion =
+        _apollo_expectUIKitExpansionPrimaryMutation;
+    _apollo_pendingPrimaryPopAnimated = animated;
+    _apollo_pendingPrimaryPopRestoreGeneration =
+        _apollo_compactPrimaryRestoreGeneration;
+    _apollo_pendingPrimaryPopRestoreLineage =
+        _apollo_compactPrimaryRestoreLineage;
+    _apollo_pendingPrimaryPopMutationGeneration =
+        _apollo_compactPrimaryRestoreMutationGeneration;
+    _apollo_pendingPrimaryPopExpectedRestoreStack =
+        [_apollo_expectedCompactPrimaryRestoreStack copy];
+    _apollo_pendingPrimaryPopOperation = [operation copy];
+    return token;
+}
+
+- (void)apollo_primaryNavigationPopDidSettle:(NSUInteger)token
+                                 beforeStack:(NSArray<UIViewController *> *)beforeStack
+                                    cancelled:(BOOL)cancelled {
+    if (token == 0 || token != _apollo_pendingPrimaryPopToken) return;
+    BOOL restoreWasActiveAtStart = _apollo_pendingPrimaryPopRestoreWasActive;
+    BOOL wasExpectedUIKitExpansion =
+        _apollo_pendingPrimaryPopWasExpectedUIKitExpansion;
+    BOOL popWasAnimated = _apollo_pendingPrimaryPopAnimated;
+    NSUInteger popRestoreGeneration = _apollo_pendingPrimaryPopRestoreGeneration;
+    NSUInteger popRestoreLineage = _apollo_pendingPrimaryPopRestoreLineage;
+    NSUInteger popMutationGeneration =
+        _apollo_pendingPrimaryPopMutationGeneration;
+    NSArray<UIViewController *> *popExpectedRestoreStack =
+        _apollo_pendingPrimaryPopExpectedRestoreStack;
+    NSString *popOperation = _apollo_pendingPrimaryPopOperation ?: @"unknown";
+    _apollo_pendingPrimaryPopToken = 0;
+    _apollo_pendingPrimaryPopRestoreWasActive = NO;
+    _apollo_pendingPrimaryPopWasExpectedUIKitExpansion = NO;
+    _apollo_pendingPrimaryPopAnimated = NO;
+    _apollo_pendingPrimaryPopRestoreGeneration = 0;
+    _apollo_pendingPrimaryPopRestoreLineage = 0;
+    _apollo_pendingPrimaryPopMutationGeneration = 0;
+    _apollo_pendingPrimaryPopExpectedRestoreStack = nil;
+    _apollo_pendingPrimaryPopOperation = nil;
+    BOOL committed = !cancelled && !ApolloPaneStacksIdentityEqual(
+        beforeStack, self.apollo_primaryNav.viewControllers);
+    NSArray<UIViewController *> *settled = self.apollo_primaryNav.viewControllers;
+    BOOL matchesInitialExpansionPrefix =
+        _apollo_expectUIKitCompactPrimaryStackReplacement &&
+        ApolloPaneStackIsStrictIdentityPrefix(
+            settled, _apollo_expectedCompactPrimaryRestoreStack);
+    BOOL matchesKnownExpansionTransient =
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement &&
+        _apollo_knownUIKitCompactPrimaryTransientStack &&
+        ApolloPaneStacksIdentityEqual(
+            settled, _apollo_knownUIKitCompactPrimaryTransientStack);
+    UIUserInterfaceSizeClass horizontalSizeClass =
+        self.traitCollection.horizontalSizeClass;
+    BOOL hasConcreteTopologyTrait =
+        horizontalSizeClass == UIUserInterfaceSizeClassCompact ||
+        horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+    BOOL isObservedUIKitTopologyPop = committed && restoreWasActiveAtStart &&
+        _apollo_compactPrimaryRestoreInProgress && popWasAnimated &&
+        [popOperation isEqualToString:@"popToViewController"] &&
+        hasConcreteTopologyTrait &&
+        popRestoreLineage != 0 &&
+        popRestoreLineage == _apollo_compactPrimaryRestoreLineage &&
+        popMutationGeneration == _apollo_compactPrimaryRestoreMutationGeneration &&
+        _apollo_primaryNavigationMutationGeneration ==
+            _apollo_compactPrimaryRestoreMutationGeneration &&
+        ApolloPaneStacksIdentityEqual(
+            popExpectedRestoreStack, _apollo_expectedCompactPrimaryRestoreStack) &&
+        (matchesInitialExpansionPrefix || matchesKnownExpansionTransient);
+    if (isObservedUIKitTopologyPop) {
+        // Simulator tracing on iPadOS 26 establishes that UIKit's final merge
+        // normalization is Apollo's animated popToViewController:, not the
+        // normal Back selector (popViewController:). It may settle immediately
+        // before or after the regular trait is installed, so accept either
+        // concrete topology trait—but never unspecified—and only with the same
+        // restore lineage and authorized identity shape.
+        if (matchesInitialExpansionPrefix) {
+            _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+            _apollo_knownUIKitCompactPrimaryTransientStack = [settled copy];
+        }
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = YES;
+        _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+        _apollo_expectUIKitExpansionPrimaryMutation = NO;
+        ApolloLog(@"[PaneRestore] tab %ld captured UIKit expansion popToViewController depth %lu",
+                  (long)self.apollo_tabIndex, (unsigned long)settled.count);
+        [self apollo_scheduleCompactPrimaryRestoreReconciliation:
+            _apollo_compactPrimaryRestoreGeneration observations:0];
+        return;
+    }
+    if (committed &&
+        (restoreWasActiveAtStart || !_apollo_compactPrimaryRestoreInProgress)) {
+        ApolloLog(@"[PaneRestore] tab %ld committed primary pop op=%@ animated=%d depth=%lu "
+                  @"expected=%lu restoreAtStart=%d restoreNow=%d expansion=%d generation=%lu/%lu",
+                  (long)self.apollo_tabIndex, popOperation, popWasAnimated,
+                  (unsigned long)settled.count,
+                  (unsigned long)_apollo_expectedCompactPrimaryRestoreStack.count,
+                  restoreWasActiveAtStart, _apollo_compactPrimaryRestoreInProgress,
+                  wasExpectedUIKitExpansion, (unsigned long)popRestoreGeneration,
+                  (unsigned long)_apollo_compactPrimaryRestoreGeneration);
+        [self apollo_primaryNavigationStackDidMutateExternally];
+        return;
+    }
+    // A cancelled/refused pop leaves the lease valid. A pane-owned compact
+    // Back begins before it creates the lease, so its later commit also lands
+    // here: the newly armed restore already describes the committed stack.
+    if (_apollo_compactPrimaryRestoreInProgress) {
+        if (committed && ApolloPaneStackIsStrictIdentityPrefix(
+                settled, _apollo_expectedCompactPrimaryRestoreStack)) {
+            _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+            _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = YES;
+            _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            _apollo_knownUIKitCompactPrimaryTransientStack = [settled copy];
+        }
+        [self apollo_scheduleCompactPrimaryRestoreReconciliation:
+            _apollo_compactPrimaryRestoreGeneration observations:0];
+    } else {
+        [self apollo_navigationTransitionDidSettle];
+    }
+}
+
+- (void)apollo_scheduleCompactPrimaryRestoreReconciliation:(NSUInteger)generation
+                                               observations:(NSUInteger)observations {
+    NSTimeInterval delay = observations < 120 ? 0.05 : 0.25;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (self->_apollo_compactPrimaryRestoreGeneration != generation ||
+            !self->_apollo_compactPrimaryRestoreInProgress) return;
+        BOOL transitionStillActive = self->_apollo_pendingPrimaryPopToken != 0 ||
+            self->_apollo_topologyMutationInProgress ||
+            self.apollo_activeTransitionCoordinator ||
+            [self apollo_navigationControllerIsTransitioning:self.apollo_primaryNav] ||
+            [self apollo_navigationControllerIsTransitioning:self.apollo_detailNav];
+        if (transitionStillActive) {
+            self->_apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            [self apollo_scheduleCompactPrimaryRestoreReconciliation:generation
+                                                         observations:observations + 1];
+            return;
+        }
+
+        // UIKit can publish one final copy of its compact merge after the
+        // transition coordinator has already detached. Give that explicitly
+        // granted write three stable samples to arrive, then revoke the grant
+        // and take one more sample before repairing. The post-revocation turn
+        // is important: a genuine app mutation after the grace period must go
+        // through the normal invalidation path instead of being mistaken for
+        // UIKit's late merge.
+        if (self->_apollo_expectUIKitCompactPrimaryStackReplacement ||
+            self->_apollo_expectOneLateUIKitCompactPrimaryStackReplacement) {
+            if (++self->_apollo_lateUIKitCompactPrimaryStableObservations < 3) {
+                [self apollo_scheduleCompactPrimaryRestoreReconciliation:generation
+                                                             observations:observations + 1];
+                return;
+            }
+            self->_apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+            self->_apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+            self->_apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            [self apollo_scheduleCompactPrimaryRestoreReconciliation:generation
+                                                         observations:observations + 1];
+            return;
+        }
+
+        NSArray<UIViewController *> *expected =
+            self->_apollo_expectedCompactPrimaryRestoreStack;
+        NSArray<UIViewController *> *settled = self.apollo_primaryNav.viewControllers;
+        BOOL settledIsExpected = ApolloPaneStacksIdentityEqual(settled, expected);
+        BOOL settledIsKnownUIKitTransient =
+            self->_apollo_knownUIKitCompactPrimaryTransientStack &&
+            ApolloPaneStacksIdentityEqual(
+                settled, self->_apollo_knownUIKitCompactPrimaryTransientStack);
+        @try {
+            if (!transitionStillActive && expected.count > 0 &&
+                settledIsKnownUIKitTransient) {
+                [self apollo_setPrimaryViewControllers:expected];
+                ApolloLog(@"[PaneSplit] tab %ld restored settled primary depth %lu -> %lu",
+                          (long)self.apollo_tabIndex, (unsigned long)settled.count,
+                          (unsigned long)expected.count);
+            } else if (!transitionStillActive && !settledIsExpected) {
+                ApolloLog(@"[PaneSplit] tab %ld left newer primary branch intact after restore settle",
+                          (long)self.apollo_tabIndex);
+            }
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PaneSplit] tab %ld compact primary restore failed safely: %@",
+                      (long)self.apollo_tabIndex, exception);
+        } @finally {
+            if (self->_apollo_compactPrimaryRestoreGeneration == generation) {
+                self->_apollo_compactPrimaryRestoreInProgress = NO;
+                self->_apollo_expectedCompactPrimaryRestoreStack = nil;
+                self->_apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+                self->_apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+                self->_apollo_lateUIKitCompactPrimaryStableObservations = 0;
+                self->_apollo_knownUIKitCompactPrimaryTransientStack = nil;
+                self->_apollo_expectUIKitExpansionPrimaryMutation = NO;
+                self->_apollo_compactPrimaryReturnStack = nil;
+                self->_apollo_postCollapsePrimaryBridgeStack = nil;
+                [self apollo_navigationTransitionDidSettle];
+            }
+        }
+    });
+}
 
 + (instancetype)paneControllerWithRootNavigationController:(UINavigationController *)rootNavigationController
                                                   tabIndex:(NSInteger)tabIndex {
@@ -376,8 +1374,124 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     ApolloPaneSplitViewController *pane =
         [[self alloc] initWithStyle:UISplitViewControllerStyleDoubleColumn];
     pane->_apollo_tabIndex = tabIndex;
-    [pane apollo_configureWithRootNavigationController:rootNavigationController];
-    return pane;
+    @try {
+        [pane apollo_configureWithRootNavigationController:rootNavigationController];
+        return pane;
+    } @catch (NSException *exception) {
+        // A factory failure must not leak owner-map registrations, gesture
+        // targets, or containment even when the caller itself later fails to
+        // complete its wider transaction.
+        @try {
+            [pane apollo_prepareForInstallationRollback];
+        } @catch (NSException *rollbackException) {
+            ApolloLog(@"[PaneSplit] tab %ld factory cleanup also threw: %@",
+                      (long)tabIndex, rollbackException);
+        }
+        @throw;
+    }
+}
+
+- (void)apollo_prepareForInstallationRollback {
+    [self apollo_removeShowPrimaryItem];
+    // Invalidate every delayed navigation/topology callback before releasing
+    // the staged hierarchy. Any already-enqueued block will observe a changed
+    // generation or an empty pending intent and become a no-op.
+    _apollo_pendingCrossColumnNavigation = nil;
+    _apollo_pendingCrossColumnSource = nil;
+    _apollo_pendingCrossColumnSemanticOwner = nil;
+    _apollo_pendingCrossColumnReason = nil;
+    _apollo_pendingPrimaryPopExpectedRestoreStack = nil;
+    _apollo_expectedCompactPrimaryRestoreStack = nil;
+    _apollo_compactPrimaryReturnStack = nil;
+    _apollo_postCollapsePrimaryBridgeStack = nil;
+    ++_apollo_crossColumnIntentSequence;
+    ++_apollo_topologyMutationGeneration;
+    ++_apollo_compactPrimaryRestoreGeneration;
+
+    NSMutableArray<UINavigationController *> *navigationControllers = [NSMutableArray array];
+    if (self.apollo_primaryNav) [navigationControllers addObject:self.apollo_primaryNav];
+    if (self.apollo_detailNav) [navigationControllers addObject:self.apollo_detailNav];
+    for (UINavigationController *navigationController in navigationControllers) {
+        NSMutableArray<UIGestureRecognizer *> *gestures = [NSMutableArray array];
+        if (navigationController.interactivePopGestureRecognizer) {
+            [gestures addObject:navigationController.interactivePopGestureRecognizer];
+        }
+        static const char *kNavigationGestureNames[] = {
+            "leftScreenEdgePanGestureRecognizer",
+            "rightScreenEdgePanGestureRecognizer",
+        };
+        for (size_t index = 0;
+             index < sizeof(kNavigationGestureNames) / sizeof(kNavigationGestureNames[0]);
+             index++) {
+            UIGestureRecognizer *gesture = ApolloPaneNavigationGesture(
+                navigationController, kNavigationGestureNames[index]);
+            if (gesture && ![gestures containsObject:gesture]) [gestures addObject:gesture];
+        }
+        for (UIGestureRecognizer *gesture in gestures) {
+            [gesture removeTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
+        }
+        ApolloPaneUnregisterNavigationController(navigationController);
+    }
+
+    self.delegate = nil;
+    // UISplitViewController owns column containment. Replace both columns with
+    // inert controllers before the stock tab bar reclaims the original nav;
+    // manually removing child views would bypass UIKit appearance bookkeeping.
+    [self setViewController:[UIViewController new]
+                  forColumn:UISplitViewControllerColumnPrimary];
+    [self setViewController:[UIViewController new]
+                  forColumn:UISplitViewControllerColumnSecondary];
+    self.apollo_primaryNav = nil;
+    self.apollo_detailNav = nil;
+    self.apollo_detailHost = nil;
+    ApolloLog(@"[PaneSplit] tab %ld detached for failed installation rollback",
+              (long)self.apollo_tabIndex);
+}
+
+- (BOOL)apollo_validateInstallationWithOriginalNavigationController:
+    (UINavigationController *)navigationController
+                                                        originalStack:
+    (NSArray<UIViewController *> *)originalStack {
+    if (!navigationController || self.apollo_primaryNav != navigationController) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: primary identity", (long)self.apollo_tabIndex);
+        return NO;
+    }
+    if ([self viewControllerForColumn:UISplitViewControllerColumnPrimary] != navigationController) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: primary column", (long)self.apollo_tabIndex);
+        return NO;
+    }
+    if (!self.apollo_detailNav || self.apollo_detailNav == navigationController) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: detail navigation", (long)self.apollo_tabIndex);
+        return NO;
+    }
+    if (!self.apollo_detailHost ||
+        [self viewControllerForColumn:UISplitViewControllerColumnSecondary] != self.apollo_detailHost ||
+        self.apollo_detailNav.parentViewController != self.apollo_detailHost) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: detail containment column=%@ "
+                  @"host=%@ navParent=%@",
+                  (long)self.apollo_tabIndex,
+                  [self viewControllerForColumn:UISplitViewControllerColumnSecondary],
+                  self.apollo_detailHost, self.apollo_detailNav.parentViewController);
+        return NO;
+    }
+    if (!ApolloPaneNavigationControllerIsRegisteredToSplit(navigationController, self) ||
+        !ApolloPaneNavigationControllerIsRegisteredToSplit(self.apollo_detailNav, self)) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: owner registration", (long)self.apollo_tabIndex);
+        return NO;
+    }
+
+    NSMutableArray<UIViewController *> *reconstructed =
+        [navigationController.viewControllers mutableCopy] ?: [NSMutableArray array];
+    if (!self.apollo_detailIsEmpty) {
+        [reconstructed addObjectsFromArray:self.apollo_detailNav.viewControllers];
+    }
+    BOOL stackMatches = ApolloPaneStacksIdentityEqual(reconstructed, originalStack);
+    if (!stackMatches) {
+        ApolloLog(@"[PaneSplit] tab %ld install validation failed: stack reconstruction %lu != %lu",
+                  (long)self.apollo_tabIndex, (unsigned long)reconstructed.count,
+                  (unsigned long)originalStack.count);
+    }
+    return stackMatches;
 }
 
 // WHY EVERY PANE IS TWO COLUMNS.
@@ -432,16 +1546,68 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 
     self.apollo_detailNav = [self apollo_makeNavigationControllerWithRoot:
         [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:message symbolName:symbol]];
+#if APOLLO_SIM_BUILD
+    ApolloPaneInstallSimCheckpoint(@"configure-detail", self.apollo_tabIndex);
+#endif
+    ApolloPaneRegisterNavigationController(self.apollo_primaryNav, self);
+    ApolloPaneRegisterNavigationController(self.apollo_detailNav, self);
+    for (UINavigationController *navigationController in
+            @[ self.apollo_primaryNav, self.apollo_detailNav ]) {
+        NSMutableArray<UIGestureRecognizer *> *gestures = [NSMutableArray array];
+        if (navigationController.interactivePopGestureRecognizer) {
+            [gestures addObject:navigationController.interactivePopGestureRecognizer];
+        }
+        static const char *kNavigationGestureNames[] = {
+            "leftScreenEdgePanGestureRecognizer",
+            "rightScreenEdgePanGestureRecognizer",
+        };
+        for (size_t index = 0;
+             index < sizeof(kNavigationGestureNames) / sizeof(kNavigationGestureNames[0]);
+             index++) {
+            UIGestureRecognizer *gesture = ApolloPaneNavigationGesture(
+                navigationController, kNavigationGestureNames[index]);
+            if (gesture && ![gestures containsObject:gesture]) [gestures addObject:gesture];
+        }
+        for (UIGestureRecognizer *gesture in gestures) {
+            [gesture addTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
+        }
+    }
     self.apollo_emptyMessage = message;
     self.apollo_emptySymbol = symbol;
 
+    // Apollo handles cold URLs, notification responses, Handoff/Siri, and
+    // restoration synchronously inside SceneDelegate's will-connect body. The
+    // pane installer deliberately runs after that body, so a cold destination
+    // can already be sitting in the original navigation stack by the time this
+    // controller is constructed. Apply the same edge-by-edge policy used by
+    // the live push router before either navigation controller is attached.
+    if (![self apollo_normalizePreinstalledPrimaryStack]) {
+        [NSException raise:@"ApolloPaneInstallationException"
+                    format:@"tab %ld could not normalize its preinstalled stack",
+                           (long)self.apollo_tabIndex];
+    }
+#if APOLLO_SIM_BUILD
+    ApolloPaneInstallSimCheckpoint(@"configure-normalize", self.apollo_tabIndex);
+#endif
+
+    _apollo_contextTrackingReady = YES;
+    if (!self.apollo_detailIsEmpty && !_apollo_detailContextOwner) {
+        [self apollo_recordDetailBranchFromPrimarySource:nil];
+    }
+
     [self setViewController:rootNav forColumn:UISplitViewControllerColumnPrimary];
+#if APOLLO_SIM_BUILD
+    ApolloPaneInstallSimCheckpoint(@"configure-primary", self.apollo_tabIndex);
+#endif
     // The secondary column is the full-width one the sidebar floats over, so it
     // is the one that needs the safe-area host (see ApolloPaneColumnHostViewController).
     // The primary column is already laid out as its own inset panel.
     self.apollo_detailHost =
         [[ApolloPaneColumnHostViewController alloc] initWithNavigationController:self.apollo_detailNav];
     [self setViewController:self.apollo_detailHost forColumn:UISplitViewControllerColumnSecondary];
+#if APOLLO_SIM_BUILD
+    ApolloPaneInstallSimCheckpoint(@"configure-secondary", self.apollo_tabIndex);
+#endif
 
     // Tile, never overlay: a detail pane that floats over the list re-creates
     // the blown-up-iPhone feel this layout exists to remove.
@@ -483,10 +1649,18 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     // Apollo installs its own screen-edge pans on every navigation controller
     // (left = interactive pop, right = "go forward", re-pushing from the per-nav
     // poppedViewControllers array — confirmed by RE, see the plan doc §2). Those
-    // sit on exactly the edges UIKit would use for the sidebar show/hide pan, so
-    // the split controller's own gesture is off and the toolbar button is the
-    // supported way to reveal the sidebar.
+    // sit on exactly the edges UIKit would use for primary show/hide, so keep the
+    // split gesture off. `isCollapsed == NO` does NOT prove this list is visible:
+    // constrained regular widths can resolve to SecondaryOnly. For column-style
+    // split views `displayModeButtonItem` is explicitly unsupported. UIKit's
+    // automatic column-style item would be installed on the wrapper host's
+    // navigation bar, which this layout intentionally hides; the visible inner
+    // detail navigation therefore owns one native UIBarButtonItem whose action
+    // calls the public showColumn: API.
     self.presentsWithGesture = NO;
+    if (@available(iOS 14.5, *)) {
+        self.displayModeButtonVisibility = UISplitViewControllerDisplayModeButtonVisibilityNever;
+    }
 
     // Keep the tab's original title/icon on the tab bar item: the tab bar reads
     // the child's tabBarItem, and the child is now this pane rather than the
@@ -519,11 +1693,85 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     // that the divider does anything, so the capability goes unnoticed.
     // A permanently visible grabber is the affordance.
     [self apollo_installColumnGrabber];
+    [self apollo_resolvedDisplayStateMayHaveChanged];
 
     ApolloLog(@"[PaneSplit] tab %ld configured listRoot=%@ depth=%lu",
               (long)self.apollo_tabIndex,
               NSStringFromClass([rootNav.viewControllers.firstObject class]),
               (unsigned long)rootNav.viewControllers.count);
+}
+
+// Splits a stock stack Apollo constructed before pane installation at its first
+// logical detail edge. Once a path reaches detail the shared policy is
+// rightward-only, so the entire remaining suffix belongs in the detail column.
+//
+// This is intentionally done while both navigation controllers are detached.
+// Moving already-visible controllers between attached parents during scene
+// connection produces transient double-parent warnings and broken appearance
+// callbacks on some iPadOS releases.
+- (BOOL)apollo_normalizePreinstalledPrimaryStack {
+    NSArray<UIViewController *> *originalPrimary = [self.apollo_primaryNav.viewControllers copy];
+    if (originalPrimary.count < 2) return YES;
+
+    NSUInteger detailStart = NSNotFound;
+    ApolloPaneColumn sourceColumn = ApolloPaneColumnPrimary;
+    for (NSUInteger index = 1; index < originalPrimary.count; index++) {
+        UIViewController *source = originalPrimary[index - 1];
+        UIViewController *destination = originalPrimary[index];
+        ApolloPaneColumn destinationColumn =
+            ApolloPaneResolveLogicalColumn(source, destination, sourceColumn, NULL);
+        if (destinationColumn == ApolloPaneColumnSecondary) {
+            detailStart = index;
+            break;
+        }
+        sourceColumn = destinationColumn;
+    }
+
+    if (detailStart == NSNotFound || detailStart == 0) return YES;
+
+    NSArray<UIViewController *> *primary =
+        [originalPrimary subarrayWithRange:NSMakeRange(0, detailStart)];
+    NSArray<UIViewController *> *detail =
+        [originalPrimary subarrayWithRange:NSMakeRange(detailStart,
+                                                       originalPrimary.count - detailStart)];
+    NSArray<UIViewController *> *originalDetail = [self.apollo_detailNav.viewControllers copy];
+    NSMutableArray<NSNumber *> *originalOpaqueFlags =
+        [NSMutableArray arrayWithCapacity:detail.count];
+    for (UIViewController *controller in detail) {
+        [originalOpaqueFlags addObject:@(controller.extendedLayoutIncludesOpaqueBars)];
+    }
+
+    @try {
+        [self apollo_setPrimaryViewControllers:primary];
+        for (UIViewController *controller in detail) {
+            controller.extendedLayoutIncludesOpaqueBars = YES;
+        }
+        [self.apollo_detailNav setViewControllers:detail animated:NO];
+        _apollo_detailContextOwner = ApolloPanePrimaryContextController(primary);
+        _apollo_detailSemanticOwner = _apollo_detailContextOwner;
+        _apollo_detailContextScope =
+            ApolloPanePrimaryContextScope(_apollo_detailContextOwner);
+        ApolloLog(@"[PaneSplit] tab %ld normalized cold stack primaryDepth=%lu detailDepth=%lu "
+                  @"detailRoot=%@",
+                  (long)self.apollo_tabIndex, (unsigned long)primary.count,
+                  (unsigned long)detail.count,
+                  NSStringFromClass(detail.firstObject.class));
+        return YES;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneSplit] tab %ld cold-stack normalization threw: %@; restoring stock stack",
+                  (long)self.apollo_tabIndex, exception);
+        @try {
+            [self.apollo_detailNav setViewControllers:originalDetail animated:NO];
+            [self apollo_setPrimaryViewControllers:originalPrimary];
+            for (NSUInteger index = 0; index < detail.count; index++) {
+                detail[index].extendedLayoutIncludesOpaqueBars = originalOpaqueFlags[index].boolValue;
+            }
+        } @catch (NSException *restoreException) {
+            ApolloLog(@"[PaneSplit] tab %ld cold-stack restore also threw: %@",
+                      (long)self.apollo_tabIndex, restoreException);
+        }
+        return NO;
+    }
 }
 
 // Prefer Apollo's own navigation controller subclass so the detail column
@@ -577,18 +1825,190 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     _apollo_grabber.backgroundColor = accent ?: UIColor.separatorColor;
 }
 
+static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
+    NSArray<UIBarButtonItem *> *items, UIBarButtonItem *removedItem) {
+    if (!removedItem || items.count == 0) return items ?: @[];
+    NSMutableArray<UIBarButtonItem *> *kept = [NSMutableArray arrayWithCapacity:items.count];
+    for (UIBarButtonItem *item in items) {
+        if (item != removedItem) [kept addObject:item];
+    }
+    return kept;
+}
+
+- (void)apollo_removeShowPrimaryItem {
+    UINavigationItem *owner = _apollo_showPrimaryOwner;
+    UIBarButtonItem *item = _apollo_showPrimaryItem;
+    if (owner && item) {
+        NSArray<UIBarButtonItem *> *left = ApolloPaneBarItemsByRemovingIdentity(
+            owner.leftBarButtonItems, item);
+        NSArray<UIBarButtonItem *> *right = ApolloPaneBarItemsByRemovingIdentity(
+            owner.rightBarButtonItems, item);
+        if (left.count != owner.leftBarButtonItems.count) {
+            owner.leftBarButtonItems = left.count > 0 ? left : nil;
+        }
+        if (right.count != owner.rightBarButtonItems.count) {
+            owner.rightBarButtonItems = right.count > 0 ? right : nil;
+        }
+    }
+    _apollo_showPrimaryOwner = nil;
+    _apollo_showPrimaryItemOnRight = NO;
+}
+
+- (UIBarButtonItem *)apollo_showPrimaryItem {
+    if (_apollo_showPrimaryItem) return _apollo_showPrimaryItem;
+    UIImage *image = [UIImage systemImageNamed:@"sidebar.leading"];
+    if (!image) image = [UIImage systemImageNamed:@"sidebar.left"];
+    if (!image) image = [UIImage systemImageNamed:@"list.bullet"];
+    UIBarButtonItem *item = image
+        ? [[UIBarButtonItem alloc] initWithImage:image
+                                           style:UIBarButtonItemStylePlain
+                                          target:self
+                                          action:@selector(apollo_showPrimaryItemActivated:)]
+        : [[UIBarButtonItem alloc] initWithTitle:@"Show List"
+                                           style:UIBarButtonItemStylePlain
+                                          target:self
+                                          action:@selector(apollo_showPrimaryItemActivated:)];
+    item.accessibilityIdentifier = @"ApolloPaneShowPrimary";
+    item.accessibilityLabel = @"Show List";
+    item.accessibilityHint = @"Shows the list column";
+    _apollo_showPrimaryItem = item;
+    return item;
+}
+
+- (void)apollo_refreshShowPrimaryItem {
+    _apollo_resolvedDisplayRefreshScheduled = NO;
+    BOOL needsRecovery = self.viewIfLoaded.window && !self.isCollapsed &&
+        !ApolloPaneSplitShowsPrimary(self);
+    UIViewController *top = self.apollo_detailNav.topViewController;
+    if (!needsRecovery || !top) {
+        [self apollo_removeShowPrimaryItem];
+        if (_apollo_showPrimaryItem) _apollo_showPrimaryItem.enabled = YES;
+        return;
+    }
+
+    UIBarButtonItem *item = [self apollo_showPrimaryItem];
+    UINavigationItem *navigationItem = top.navigationItem;
+    // At the detail root there is no native Back item to compete with, so the
+    // structural control belongs on the leading edge. A deeper detail screen
+    // keeps UIKit's Back policy untouched and receives the item at the trailing
+    // edge alongside (never replacing) its own actions.
+    BOOL placeOnRight = self.apollo_detailNav.viewControllers.count > 1;
+    NSArray<UIBarButtonItem *> *left = navigationItem.leftBarButtonItems ?: @[];
+    NSArray<UIBarButtonItem *> *right = navigationItem.rightBarButtonItems ?: @[];
+    NSUInteger leftCount = 0, rightCount = 0;
+    for (UIBarButtonItem *candidate in left) if (candidate == item) leftCount++;
+    for (UIBarButtonItem *candidate in right) if (candidate == item) rightCount++;
+    BOOL alreadyCorrect = _apollo_showPrimaryOwner == navigationItem &&
+        _apollo_showPrimaryItemOnRight == placeOnRight &&
+        (placeOnRight ? (rightCount == 1 && leftCount == 0)
+                      : (leftCount == 1 && rightCount == 0));
+    if (alreadyCorrect) {
+        item.enabled = ![self apollo_navigationOrTopologyTransitionIsActive];
+        return;
+    }
+
+    [self apollo_removeShowPrimaryItem];
+    NSArray<UIBarButtonItem *> *existing = placeOnRight
+        ? navigationItem.rightBarButtonItems : navigationItem.leftBarButtonItems;
+    NSMutableArray<UIBarButtonItem *> *merged =
+        [ApolloPaneBarItemsByRemovingIdentity(existing, item) mutableCopy];
+    if (placeOnRight) [merged insertObject:item atIndex:0];
+    else [merged addObject:item];
+    if (placeOnRight) navigationItem.rightBarButtonItems = merged;
+    else navigationItem.leftBarButtonItems = merged;
+    _apollo_showPrimaryOwner = navigationItem;
+    _apollo_showPrimaryItemOnRight = placeOnRight;
+    item.enabled = ![self apollo_navigationOrTopologyTransitionIsActive];
+    ApolloLog(@"[PaneDisplay] tab %ld installed Show List owner=%@ side=%@ mode=%ld",
+              (long)self.apollo_tabIndex, NSStringFromClass(top.class),
+              placeOnRight ? @"right" : @"left", (long)self.displayMode);
+}
+
+- (void)apollo_scheduleShowPrimaryItemRefresh {
+    if (_apollo_resolvedDisplayRefreshScheduled) return;
+    _apollo_resolvedDisplayRefreshScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self apollo_refreshShowPrimaryItem];
+    });
+}
+
+- (void)apollo_resolvedDisplayStateMayHaveChanged {
+    [self apollo_scheduleShowPrimaryItemRefresh];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self apollo_refreshMasterSelection];
+    });
+    [self.view setNeedsLayout];
+}
+
+- (void)apollo_showPrimaryItemActivated:(UIBarButtonItem *)sender {
+    if (self.isCollapsed || ApolloPaneSplitShowsPrimary(self)) {
+        [self apollo_resolvedDisplayStateMayHaveChanged];
+        return;
+    }
+    if ([self apollo_navigationOrTopologyTransitionIsActive]) {
+        sender.enabled = NO;
+        [self apollo_scheduleShowPrimaryItemRefresh];
+        return;
+    }
+
+    sender.enabled = NO;
+    ApolloLog(@"[PaneDisplay] tab %ld Show List activated mode=%ld behavior=%ld",
+              (long)self.apollo_tabIndex, (long)self.displayMode, (long)self.splitBehavior);
+    [self showColumn:UISplitViewControllerColumnPrimary];
+    id<UIViewControllerTransitionCoordinator> coordinator = self.transitionCoordinator;
+    __weak ApolloPaneSplitViewController *weakSelf = self;
+    if (coordinator) {
+        [coordinator animateAlongsideTransition:nil
+            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf apollo_resolvedDisplayStateMayHaveChanged];
+                });
+            }];
+    }
+    // UIKit is allowed to perform this transition without publishing a
+    // coordinator. The delayed idempotent refresh covers both that path and a
+    // coordinator completion that never fires because the action was ignored.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [weakSelf apollo_resolvedDisplayStateMayHaveChanged];
+    });
+}
+
+- (void)apollo_revealDetailAfterPrimarySelectionIfNeeded {
+    if (self.isCollapsed ||
+        self.displayMode != UISplitViewControllerDisplayModeOneOverSecondary) return;
+    ApolloLog(@"[PaneDisplay] tab %ld dismissing primary overlay after detail selection",
+              (long)self.apollo_tabIndex);
+    [self hideColumn:UISplitViewControllerColumnPrimary];
+    [self apollo_resolvedDisplayStateMayHaveChanged];
+}
+
 - (void)apollo_layoutColumnGrabber {
     UIViewController *list = [self viewControllerForColumn:UISplitViewControllerColumnPrimary];
-    if (!_apollo_grabber || !list.isViewLoaded || !list.view.superview || self.isCollapsed) {
+    UIView *detailView = self.apollo_detailNav.viewIfLoaded;
+    if (!_apollo_grabber || !list.isViewLoaded || !list.view.superview ||
+        !detailView.superview ||
+        !ApolloPaneSplitShowsTiledPrimary(self)) {
         _apollo_grabber.hidden = YES;
         return;
     }
     CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
-    if (CGRectIsEmpty(listFrame)) { _apollo_grabber.hidden = YES; return; }
+    CGRect detailFrame = [detailView.superview convertRect:detailView.frame toView:self.view];
+    CGRect visibleBounds = self.view.bounds;
+    BOOL listIntersects = CGRectIntersectsRect(listFrame, visibleBounds);
+    BOOL detailIntersects = CGRectIntersectsRect(detailFrame, visibleBounds);
+    BOOL primaryOnLeadingEdge = self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading;
+    CGFloat listBoundary = primaryOnLeadingEdge ? CGRectGetMaxX(listFrame) : CGRectGetMinX(listFrame);
+    CGFloat detailBoundary = primaryOnLeadingEdge ? CGRectGetMinX(detailFrame) : CGRectGetMaxX(detailFrame);
+    if (CGRectIsEmpty(listFrame) || CGRectIsEmpty(detailFrame) ||
+        !listIntersects || !detailIntersects || fabs(listBoundary - detailBoundary) > 32.0) {
+        _apollo_grabber.hidden = YES;
+        return;
+    }
 
     static const CGFloat kWidth = 5.0, kHeight = 44.0;
     _apollo_grabber.hidden = NO;
-    _apollo_grabber.frame = CGRectMake(CGRectGetMaxX(listFrame) - kWidth / 2.0,
+    _apollo_grabber.frame = CGRectMake(listBoundary - kWidth / 2.0,
                                        CGRectGetMidY(listFrame) - kHeight / 2.0,
                                        kWidth, kHeight);
     [self.view bringSubviewToFront:_apollo_grabber];
@@ -607,57 +2027,60 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previous {
     [super traitCollectionDidChange:previous];
+    BOOL beginsExpansion =
+        previous.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
+        self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+    BOOL ownsPendingCompactPrimaryRestore =
+        _apollo_compactPrimaryRestoreInProgress &&
+        _apollo_primaryNavigationMutationGeneration ==
+            _apollo_compactPrimaryRestoreMutationGeneration;
+    if (beginsExpansion && ownsPendingCompactPrimaryRestore) {
+        // The primary navigation controller can receive Apollo's
+        // push(existing-root) normalization before splitViewControllerDidExpand:
+        // is delivered. Arm the expansion-owned mutation slot at the trait
+        // boundary—the earliest supported topology signal—so that exact
+        // normalization is captured while a genuine deeper push still
+        // invalidates through the source-aware push reporter.
+        _apollo_expectUIKitExpansionPrimaryMutation = YES;
+        _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+        if (_apollo_knownUIKitCompactPrimaryTransientStack.count > 0) {
+            _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = YES;
+        } else {
+            _apollo_expectUIKitCompactPrimaryStackReplacement = YES;
+        }
+        ApolloLog(@"[PaneSplit] tab %ld armed compact primary restore at expansion trait boundary",
+                  (long)self.apollo_tabIndex);
+    }
     [self apollo_applyGroundTheme];
     [self apollo_applyGrabberTheme];
-}
-
-// Gives the reading pane the sidebar's width once there is something to read.
-//
-// The sidebar is a third region competing with two content columns: measured at
-// 1376pt landscape it takes 270 of them, leaving 480/616. Collapsing it to the
-// floating tab bar hands that 270 back — the same tab measures 480/886, a 44%
-// wider detail column — and the destinations stay one tap away in the tab bar,
-// so nothing becomes unreachable.
-//
-// Only ever fights the user once. If the sidebar's visibility is not what we
-// last set it to, the user changed it themselves through UIKit's own toggle, and
-// this stops managing it for the rest of the session — an auto-collapse that
-// keeps undoing a deliberate choice is worse than no auto-collapse at all.
-- (void)apollo_reconcileSidebarForDetailContent {
-    if (@available(iOS 18.0, *)) {
-        UITabBarController *tabBarController = self.tabBarController;
-        UITabBarControllerSidebar *sidebar = tabBarController.sidebar;
-        if (!sidebar || tabBarController.selectedViewController != self) return;
-        if (self.isCollapsed) return;
-
-        BOOL shouldHide = !self.apollo_detailIsEmpty;
-        if (sidebar.isHidden == shouldHide) return;
-
-        // The user moved it themselves since we last did; leave it alone.
-        if (_apollo_sidebarManaged && sidebar.isHidden != _apollo_sidebarWeSetHidden) return;
-
-        // ASYMMETRIC ON PURPOSE: only ever restore what we hid.
-        //
-        // UIKit persists the sidebar/tab-bar choice across launches, so a
-        // symmetric rule would force the sidebar back open on every launch with
-        // an empty detail column — overriding a preference the user set
-        // deliberately, using UIKit's own control, possibly sessions ago.
-        // Hiding is ours to do because the detail column filling is our event;
-        // showing is only ours to undo.
-        if (!shouldHide && !(_apollo_sidebarManaged && _apollo_sidebarWeSetHidden)) return;
-
-        sidebar.hidden = shouldHide;
-        _apollo_sidebarManaged = shouldHide;
-        _apollo_sidebarWeSetHidden = shouldHide;
-        ApolloLog(@"[PaneSplit] tab %ld sidebar %@ (detail %@)",
-                  (long)self.apollo_tabIndex, shouldHide ? @"hidden" : @"shown",
-                  shouldHide ? @"filled" : @"empty");
-    }
+    [self apollo_scheduleShowPrimaryItemRefresh];
 }
 
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     [self apollo_layoutColumnGrabber];
+    UIViewController *detailTop = self.apollo_detailNav.topViewController;
+    BOOL resolvedStateChanged = !_apollo_hasSampledResolvedDisplayState ||
+        _apollo_lastSampledDisplayMode != self.displayMode ||
+        _apollo_lastSampledSplitBehavior != self.splitBehavior ||
+        _apollo_lastSampledCollapsed != self.isCollapsed ||
+        _apollo_lastSampledDetailTop != detailTop;
+    if (resolvedStateChanged) {
+        _apollo_hasSampledResolvedDisplayState = YES;
+        _apollo_lastSampledDisplayMode = self.displayMode;
+        _apollo_lastSampledSplitBehavior = self.splitBehavior;
+        _apollo_lastSampledCollapsed = self.isCollapsed;
+        _apollo_lastSampledDetailTop = detailTop;
+        ApolloLog(@"[PaneDisplay] tab %ld resolved mode=%ld behavior=%ld collapsed=%d "
+                  @"primaryVisible=%d tiled=%d detailTop=%@",
+                  (long)self.apollo_tabIndex, (long)self.displayMode,
+                  (long)self.splitBehavior, self.isCollapsed,
+                  ApolloPaneSplitShowsPrimary(self), ApolloPaneSplitShowsTiledPrimary(self),
+                  NSStringFromClass(detailTop.class));
+        // Bar-item writes from layoutSubviews can recursively invalidate
+        // navigation layout. Defer the identity-based reconciliation instead.
+        [self apollo_scheduleShowPrimaryItemRefresh];
+    }
     if (_apollo_loggedResolvedLayout) return;
     if (CGRectIsEmpty(self.view.bounds)) return;
     _apollo_loggedResolvedLayout = YES;
@@ -668,10 +2091,11 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
     // A short pane means extendedLayoutIncludesOpaqueBars stopped taking effect
     // and the dead bottom strip is back.
     ApolloLog(@"[PaneSplit] tab %ld resolved displayMode=%ld splitBehavior=%ld size=%.0fx%.0f "
-              @"hostH=%.0f primaryW=%.0f",
+              @"hostH=%.0f primaryW=%.0f primaryVisible=%d tiled=%d",
               (long)self.apollo_tabIndex, (long)self.displayMode, (long)self.splitBehavior,
               self.view.bounds.size.width, self.view.bounds.size.height,
-              self.tabBarController.view.bounds.size.height, self.primaryColumnWidth);
+              self.tabBarController.view.bounds.size.height, self.primaryColumnWidth,
+              ApolloPaneSplitShowsPrimary(self), ApolloPaneSplitShowsTiledPrimary(self));
 }
 
 #pragma mark - Column access
@@ -697,28 +2121,1252 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 }
 
 - (UIViewController *)apollo_preferredContentColumnController {
-    // Collapsed, every column has merged into the primary's stack, so that is
-    // unambiguously where the user is looking.
-    if (self.isCollapsed) return self.apollo_primaryNav;
-    if (!self.apollo_detailIsEmpty) return self.apollo_detailNav;
-    return self.apollo_primaryNav;
+    UINavigationController *primary = self.apollo_primaryNav;
+    UINavigationController *detail = self.apollo_detailNav;
+    BOOL detailHasContent = !self.apollo_detailIsEmpty;
+    BOOL primaryAttached = ApolloPaneControllerIsAttached(primary);
+    BOOL detailAttached = ApolloPaneControllerIsAttached(detail);
+
+    if (self.isCollapsed) {
+        // A populated secondary can survive collapse through UIKit's bridge.
+        // Compact chrome is activated only for that outcome, and its hosted
+        // navigation controller remains attached even though the split reports
+        // one visible column. Returning primary here used to present alerts and
+        // share sheets from the feed hidden behind the comments screen.
+        if (_apollo_compactDetailChromeActive && detailHasContent && detailAttached) return detail;
+
+        // Empty compact panes, compact navigations that began after collapse,
+        // and the completed cross-column Back path all live on primary.
+        if (primaryAttached) return primary;
+        if (detailHasContent && detailAttached) return detail;
+        return _apollo_compactDetailChromeActive && detailHasContent ? detail : primary;
+    }
+
+    switch (self.displayMode) {
+        case UISplitViewControllerDisplayModeOneOverSecondary:
+            // The list is the foreground overlay even when populated detail
+            // remains attached behind its dimming view.
+            if (primaryAttached) return primary;
+            if (detailAttached) return detail;
+            break;
+        case UISplitViewControllerDisplayModeSecondaryOnly:
+            // The offscreen primary often remains loaded and parented. Present
+            // from the sole visible detail/placeholder column.
+            if (detailAttached) return detail;
+            if (primaryAttached) return primary;
+            break;
+        case UISplitViewControllerDisplayModeOneBesideSecondary:
+        default:
+            if (detailHasContent && detailAttached) return detail;
+            if (primaryAttached) return primary;
+            if (detailAttached) return detail;
+            break;
+    }
+    if (primaryAttached) return primary;
+    // Before the hierarchy has attached, preserve the semantic choice without
+    // forcing either navigation controller's view to load.
+    return detailHasContent ? detail : primary;
+}
+
+- (void)apollo_recordCompactViewController:(UIViewController *)viewController
+                              logicalColumn:(ApolloPaneColumn)column {
+    if (!viewController) return;
+    if (!_apollo_compactLogicalColumns) {
+        _apollo_compactLogicalColumns = [NSMapTable weakToStrongObjectsMapTable];
+    }
+    if (column == ApolloPaneColumnSecondary) {
+        [_apollo_compactLogicalColumns setObject:@(column) forKey:viewController];
+    } else {
+        [_apollo_compactLogicalColumns removeObjectForKey:viewController];
+    }
+}
+
+- (BOOL)apollo_compactViewControllerBelongsToDetail:(UIViewController *)viewController {
+    if (!viewController) return NO;
+    if ([self.apollo_detailNav.viewControllers containsObject:viewController]) return YES;
+    return [[_apollo_compactLogicalColumns objectForKey:viewController] integerValue] ==
+        ApolloPaneColumnSecondary;
+}
+
+- (NSArray<UIViewController *> *)apollo_logicalPrimaryControllers {
+    NSArray<UIViewController *> *stack = self.apollo_primaryNav.viewControllers;
+    NSUInteger detailStart = NSNotFound;
+    for (NSUInteger index = 0; index < stack.count; index++) {
+        if ([self apollo_compactViewControllerBelongsToDetail:stack[index]]) {
+            detailStart = index;
+            break;
+        }
+    }
+    return detailStart == NSNotFound ? stack :
+        [stack subarrayWithRange:NSMakeRange(0, detailStart)];
+}
+
+- (UIViewController *)apollo_primaryContextViewController {
+    if (_apollo_compactPrimaryRestoreInProgress &&
+        _apollo_expectedCompactPrimaryRestoreStack.count > 0) {
+        return ApolloPanePrimaryContextController(_apollo_expectedCompactPrimaryRestoreStack);
+    }
+    return ApolloPanePrimaryContextController(self.apollo_logicalPrimaryControllers);
+}
+
+- (BOOL)apollo_hasDetailBranchForContextTracking {
+    return !self.apollo_detailIsEmpty ||
+        self.apollo_logicalPrimaryControllers.count < self.apollo_primaryNav.viewControllers.count;
+}
+
+#pragma mark - Cross-column transition serialization
+
+- (BOOL)apollo_navigationControllerIsTransitioning:(UINavigationController *)navigationController {
+    if (!navigationController) return NO;
+    if (navigationController.transitionCoordinator) return YES;
+    if (ApolloPaneNavigationBoolFlag(navigationController, "pushing") ||
+        ApolloPaneNavigationBoolFlag(navigationController, "popping")) return YES;
+    if (ApolloPaneNavigationObjectIvar(navigationController, "interactionController")) return YES;
+    if (ApolloPaneGestureIsTransitioning(navigationController.interactivePopGestureRecognizer)) return YES;
+    if (ApolloPaneGestureIsTransitioning(
+            ApolloPaneNavigationGesture(navigationController,
+                                        "leftScreenEdgePanGestureRecognizer"))) return YES;
+    if (ApolloPaneGestureIsTransitioning(
+            ApolloPaneNavigationGesture(navigationController,
+                                        "rightScreenEdgePanGestureRecognizer"))) return YES;
+    return NO;
+}
+
+- (id<UIViewControllerTransitionCoordinator>)apollo_activeTransitionCoordinator {
+    id<UIViewControllerTransitionCoordinator> coordinator = self.apollo_primaryNav.transitionCoordinator;
+    if (!coordinator) coordinator = self.apollo_detailNav.transitionCoordinator;
+    if (!coordinator) coordinator = self.transitionCoordinator;
+    return coordinator;
+}
+
+- (BOOL)apollo_navigationOrTopologyTransitionIsActive {
+#if APOLLO_SIM_BUILD
+    if (_apollo_simCrossColumnNavigationBlocked) return YES;
+#endif
+    return _apollo_executingCrossColumnNavigation || _apollo_topologyMutationInProgress ||
+        _apollo_compactPrimaryRestoreInProgress || _apollo_pendingPrimaryPopToken != 0 ||
+        self.apollo_activeTransitionCoordinator ||
+        [self apollo_navigationControllerIsTransitioning:self.apollo_primaryNav] ||
+        [self apollo_navigationControllerIsTransitioning:self.apollo_detailNav];
+}
+
+- (void)apollo_scheduleCrossColumnNavigationDrain {
+    if (_apollo_crossColumnDrainScheduled || !_apollo_pendingCrossColumnNavigation) return;
+    _apollo_crossColumnDrainScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_apollo_crossColumnDrainScheduled = NO;
+        [self apollo_drainCrossColumnNavigationIfPossible];
+    });
+}
+
+- (BOOL)apollo_pendingCrossColumnSourceIsStillCurrent {
+    UIViewController *source = _apollo_pendingCrossColumnSource;
+    // A route whose weak source and semantic owner were both deallocated is
+    // stale, not equivalent to a deliberate source-less clear operation.
+    if (!source) return !_apollo_pendingCrossColumnHadSource;
+
+    NSArray<UIViewController *> *logicalPrimary = self.apollo_logicalPrimaryControllers;
+    if (_apollo_compactPrimaryRestoreInProgress &&
+        _apollo_expectedCompactPrimaryRestoreStack.count > 0) {
+        UIViewController *anticipatedOwner = ApolloPanePrimaryContextController(
+            _apollo_expectedCompactPrimaryRestoreStack);
+        if (source == anticipatedOwner &&
+            _apollo_pendingCrossColumnSemanticOwner == anticipatedOwner) {
+            NSString *capturedScope = _apollo_pendingCrossColumnSourceScope;
+            NSString *anticipatedScope = ApolloPanePrimaryContextScope(anticipatedOwner);
+            return !capturedScope ||
+                (anticipatedScope && [capturedScope isEqualToString:anticipatedScope]);
+        }
+    }
+    if (![logicalPrimary containsObject:source]) return NO;
+    if (!self.isCollapsed && !ApolloPaneSplitShowsPrimary(self)) return NO;
+    // UIKit may append a private bridge above the captured primary source while
+    // collapsing a populated pane. All compact pushes now coalesce through this
+    // queue, so a newer user navigation cannot hide above the source unnoticed;
+    // preserve the intent when semantic ownership still matches below.
+    if (logicalPrimary.lastObject != source && !self.isCollapsed) return NO;
+    UIViewController *semanticOwner = ApolloPanePrimaryContextController(logicalPrimary);
+    if (!semanticOwner || semanticOwner != _apollo_pendingCrossColumnSemanticOwner) return NO;
+
+    NSString *capturedScope = _apollo_pendingCrossColumnSourceScope;
+    NSString *currentScope = ApolloPanePrimaryContextScope(semanticOwner);
+    return !capturedScope || (currentScope && [capturedScope isEqualToString:currentScope]);
+}
+
+- (void)apollo_observeActiveTransitionForPendingNavigation {
+    id<UIViewControllerTransitionCoordinator> coordinator = self.apollo_activeTransitionCoordinator;
+    if (!coordinator || coordinator == _apollo_observedTransitionCoordinator) return;
+    _apollo_observedTransitionCoordinator = coordinator;
+    __weak ApolloPaneSplitViewController *weakSelf = self;
+    __weak id<UIViewControllerTransitionCoordinator> weakCoordinator = coordinator;
+    BOOL accepted = [coordinator animateAlongsideTransition:nil
+        completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            BOOL cancelled = context.isCancelled;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ApolloPaneSplitViewController *strongSelf = weakSelf;
+                if (!strongSelf) return;
+                if (strongSelf->_apollo_observedTransitionCoordinator == weakCoordinator) {
+                    strongSelf->_apollo_observedTransitionCoordinator = nil;
+                }
+                ApolloLog(@"[PaneTransition] tab %ld coordinator settled cancelled=%d",
+                          (long)strongSelf.apollo_tabIndex, cancelled);
+                [strongSelf apollo_navigationTransitionDidSettle];
+            });
+        }];
+    if (!accepted && _apollo_observedTransitionCoordinator == coordinator) {
+        _apollo_observedTransitionCoordinator = nil;
+        // Some UIKit coordinators reject late completion registration. Gesture
+        // terminal callbacks normally wake the queue, but a stock/programmatic
+        // coordinator may have no gesture at all. Resample at a bounded cadence
+        // until the coordinator detaches instead of stranding the latest intent.
+        if (!_apollo_transitionFallbackScheduled) {
+            _apollo_transitionFallbackScheduled = YES;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                self->_apollo_transitionFallbackScheduled = NO;
+                [self apollo_navigationTransitionDidSettle];
+            });
+        }
+    }
+}
+
+- (void)apollo_performCrossColumnNavigationTransaction:(dispatch_block_t)navigation {
+    if (!navigation) return;
+    BOOL ownsTransaction = !_apollo_executingCrossColumnNavigation;
+    if (ownsTransaction) _apollo_executingCrossColumnNavigation = YES;
+    @try {
+        navigation();
+    } @finally {
+        if (ownsTransaction) {
+            _apollo_executingCrossColumnNavigation = NO;
+            [self apollo_scheduleCrossColumnNavigationDrain];
+        }
+    }
+}
+
+- (void)apollo_drainCrossColumnNavigationIfPossible {
+    if (!_apollo_pendingCrossColumnNavigation || _apollo_executingCrossColumnNavigation) return;
+    if ([self apollo_navigationOrTopologyTransitionIsActive]) {
+        [self apollo_observeActiveTransitionForPendingNavigation];
+        return;
+    }
+
+    NSUInteger sequence = _apollo_pendingCrossColumnSequence;
+    NSString *reason = _apollo_pendingCrossColumnReason ?: @"cross-column navigation";
+    if (![self apollo_pendingCrossColumnSourceIsStillCurrent]) {
+        ApolloLog(@"[PaneTransition] tab %ld dropped stale intent %lu reason=%@",
+                  (long)self.apollo_tabIndex, (unsigned long)sequence, reason);
+        _apollo_pendingCrossColumnNavigation = nil;
+        _apollo_pendingCrossColumnSource = nil;
+        _apollo_pendingCrossColumnSemanticOwner = nil;
+        _apollo_pendingCrossColumnHadSource = NO;
+        _apollo_pendingCrossColumnSourceScope = nil;
+        _apollo_pendingCrossColumnReason = nil;
+        return;
+    }
+
+    dispatch_block_t navigation = _apollo_pendingCrossColumnNavigation;
+    _apollo_pendingCrossColumnNavigation = nil;
+    _apollo_pendingCrossColumnSource = nil;
+    _apollo_pendingCrossColumnSemanticOwner = nil;
+    _apollo_pendingCrossColumnHadSource = NO;
+    _apollo_pendingCrossColumnSourceScope = nil;
+    _apollo_pendingCrossColumnReason = nil;
+    _apollo_executingCrossColumnNavigation = YES;
+    ApolloLog(@"[PaneTransition] tab %ld applying settled intent %lu reason=%@",
+              (long)self.apollo_tabIndex, (unsigned long)sequence, reason);
+    @try {
+        navigation();
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneTransition] tab %ld intent %lu threw: %@",
+                  (long)self.apollo_tabIndex, (unsigned long)sequence, exception);
+    } @finally {
+        _apollo_executingCrossColumnNavigation = NO;
+    }
+    [self apollo_scheduleCrossColumnNavigationDrain];
+}
+
+- (BOOL)apollo_deferCrossColumnNavigationIfNeeded:(dispatch_block_t)navigation
+                              sourceViewController:(UIViewController *)sourceViewController
+                                            reason:(NSString *)reason {
+    if (!navigation) return NO;
+    if (!NSThread.isMainThread) {
+        __weak ApolloPaneSplitViewController *weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf apollo_deferCrossColumnNavigationIfNeeded:navigation
+                                            sourceViewController:sourceViewController
+                                                          reason:reason];
+        });
+        return YES;
+    }
+
+    BOOL alreadyPending = _apollo_pendingCrossColumnNavigation != nil;
+    if (!alreadyPending && ![self apollo_navigationOrTopologyTransitionIsActive]) return NO;
+
+    NSUInteger sequence = ++_apollo_crossColumnIntentSequence;
+    NSArray<UIViewController *> *logicalPrimary = self.apollo_logicalPrimaryControllers;
+    UIViewController *semanticOwner = nil;
+    if (sourceViewController) {
+        semanticOwner = [logicalPrimary containsObject:sourceViewController]
+            ? ApolloPanePrimaryContextController(logicalPrimary)
+            : sourceViewController;
+    }
+    _apollo_pendingCrossColumnNavigation = [navigation copy];
+    _apollo_pendingCrossColumnSource = sourceViewController;
+    _apollo_pendingCrossColumnSemanticOwner = semanticOwner;
+    _apollo_pendingCrossColumnHadSource = sourceViewController != nil;
+    _apollo_pendingCrossColumnSourceScope =
+        sourceViewController ? ApolloPanePrimaryContextScope(semanticOwner) : nil;
+    _apollo_pendingCrossColumnReason = [reason copy] ?: @"cross-column navigation";
+    _apollo_pendingCrossColumnSequence = sequence;
+    ApolloLog(@"[PaneTransition] tab %ld %@ intent %lu reason=%@",
+              (long)self.apollo_tabIndex, alreadyPending ? @"coalesced" : @"deferred",
+              (unsigned long)sequence, _apollo_pendingCrossColumnReason);
+    [self apollo_observeActiveTransitionForPendingNavigation];
+    [self apollo_scheduleCrossColumnNavigationDrain];
+    return YES;
+}
+
+- (void)apollo_navigationTransitionDidSettle {
+    _apollo_observedTransitionCoordinator = nil;
+    [self apollo_scheduleShowPrimaryItemRefresh];
+    [self apollo_scheduleCrossColumnNavigationDrain];
+    [self apollo_refreshMasterSelection];
+}
+
+- (void)apollo_navigationGestureStateChanged:(UIGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateEnded &&
+        gesture.state != UIGestureRecognizerStateCancelled &&
+        gesture.state != UIGestureRecognizerStateFailed) return;
+    ApolloLog(@"[PaneTransition] tab %ld navigation gesture terminal state=%ld",
+              (long)self.apollo_tabIndex, (long)gesture.state);
+    [self apollo_navigationTransitionDidSettle];
+}
+
+#if APOLLO_SIM_BUILD
+- (void)apollo_simSetCrossColumnNavigationBlocked:(BOOL)blocked {
+    _apollo_simCrossColumnNavigationBlocked = blocked;
+    ApolloLog(@"[PaneTransition] tab %ld simulator gate=%d",
+              (long)self.apollo_tabIndex, blocked);
+    if (!blocked) [self apollo_navigationTransitionDidSettle];
+}
+
+- (NSString *)apollo_simCrossColumnNavigationState {
+    return [NSString stringWithFormat:@"blocked=%d active=%d pending=%d sequence=%lu reason=%@",
+        _apollo_simCrossColumnNavigationBlocked,
+        [self apollo_navigationOrTopologyTransitionIsActive],
+        _apollo_pendingCrossColumnNavigation != nil,
+        (unsigned long)_apollo_pendingCrossColumnSequence,
+        _apollo_pendingCrossColumnReason ?: @"(nil)"];
+}
+
+- (void)apollo_simSetResolvedLayoutMode:(NSString *)mode {
+    NSString *normalized = mode.lowercaseString;
+    if ([normalized isEqualToString:@"regular"] ||
+        [normalized isEqualToString:@"tiled"] ||
+        [normalized isEqualToString:@"reset"]) {
+        self.preferredSplitBehavior = UISplitViewControllerSplitBehaviorTile;
+        self.preferredDisplayMode = UISplitViewControllerDisplayModeOneBesideSecondary;
+        [self showColumn:UISplitViewControllerColumnPrimary];
+    } else if ([normalized isEqualToString:@"overlay"]) {
+        self.preferredSplitBehavior = UISplitViewControllerSplitBehaviorOverlay;
+        self.preferredDisplayMode = UISplitViewControllerDisplayModeOneOverSecondary;
+        [self showColumn:UISplitViewControllerColumnPrimary];
+    } else if ([normalized isEqualToString:@"secondary"]) {
+        self.preferredSplitBehavior = UISplitViewControllerSplitBehaviorOverlay;
+        self.preferredDisplayMode = UISplitViewControllerDisplayModeSecondaryOnly;
+        [self hideColumn:UISplitViewControllerColumnPrimary];
+    } else {
+        ApolloLog(@"[PaneDisplayTest] unknown mode=%@", normalized);
+        return;
+    }
+    ApolloLog(@"[PaneDisplayTest] requested mode=%@ preferredMode=%ld preferredBehavior=%ld",
+              normalized, (long)self.preferredDisplayMode,
+              (long)self.preferredSplitBehavior);
+    [self apollo_resolvedDisplayStateMayHaveChanged];
+}
+
+- (NSString *)apollo_simResolvedLayoutState {
+    UIViewController *primary = [self viewControllerForColumn:UISplitViewControllerColumnPrimary];
+    CGRect primaryFrame = CGRectZero;
+    CGRect secondaryFrame = CGRectZero;
+    if (primary.isViewLoaded && primary.view.superview) {
+        primaryFrame = [primary.view.superview convertRect:primary.view.frame toView:self.view];
+    }
+    UIView *visibleSecondaryView = self.apollo_detailNav.viewIfLoaded;
+    if (visibleSecondaryView.superview) {
+        secondaryFrame = [visibleSecondaryView.superview
+            convertRect:visibleSecondaryView.frame toView:self.view];
+    }
+    BOOL primaryGeometry = primary.viewIfLoaded.window && !primary.view.hidden && primary.view.alpha > 0.01 &&
+        CGRectIntersectsRect(primaryFrame, self.view.bounds);
+    BOOL secondaryGeometry = visibleSecondaryView.window && !visibleSecondaryView.hidden && visibleSecondaryView.alpha > 0.01 &&
+        CGRectIntersectsRect(secondaryFrame, self.view.bounds);
+    BOOL secondaryAPI = YES;
+    if (@available(iOS 26.0, *)) {
+        secondaryAPI = [self isShowingColumn:UISplitViewControllerColumnSecondary];
+    }
+    NSUInteger showListCount = 0;
+    NSUInteger compactBackCount = 0;
+    for (UIViewController *controller in self.apollo_detailNav.viewControllers) {
+        for (UIBarButtonItem *item in controller.navigationItem.leftBarButtonItems ?: @[]) {
+            if (item == _apollo_showPrimaryItem) showListCount++;
+            if (item == _apollo_compactBackItem) compactBackCount++;
+        }
+        for (UIBarButtonItem *item in controller.navigationItem.rightBarButtonItems ?: @[]) {
+            if (item == _apollo_showPrimaryItem) showListCount++;
+            if (item == _apollo_compactBackItem) compactBackCount++;
+        }
+    }
+    return [NSString stringWithFormat:
+        @"hSize=%ld collapsed=%d preferredMode=%ld resolvedMode=%ld "
+         "preferredBehavior=%ld resolvedBehavior=%ld primaryAPI=%d primaryGeometry=%d "
+         "secondaryAPI=%d secondaryGeometry=%d primaryFrame=%@ secondaryFrame=%@ "
+         "showListCount=%lu showListEnabled=%d showListSide=%@ compactBackCount=%lu state={%@}",
+        (long)self.traitCollection.horizontalSizeClass, self.isCollapsed,
+        (long)self.preferredDisplayMode, (long)self.displayMode,
+        (long)self.preferredSplitBehavior, (long)self.splitBehavior,
+        ApolloPaneSplitShowsPrimary(self), primaryGeometry,
+        secondaryAPI, secondaryGeometry,
+        NSStringFromCGRect(primaryFrame), NSStringFromCGRect(secondaryFrame),
+        (unsigned long)showListCount, _apollo_showPrimaryItem.enabled,
+        _apollo_showPrimaryOwner ? (_apollo_showPrimaryItemOnRight ? @"right" : @"left") : @"none",
+        (unsigned long)compactBackCount, [self apollo_simCrossColumnNavigationState]];
+}
+
+- (BOOL)apollo_simActivateShowPrimaryItem {
+    if (!_apollo_showPrimaryOwner || !_apollo_showPrimaryItem.enabled) return NO;
+    [self apollo_showPrimaryItemActivated:_apollo_showPrimaryItem];
+    return YES;
+}
+
+- (NSString *)apollo_simMasterSelectionState {
+    [self apollo_refreshMasterSelection];
+    ApolloPaneMasterSelectionIntent *intent = _apollo_masterSelectionIntent;
+    UITableView *tableView = ApolloPaneMasterSelectionTable(intent.surface);
+    NSIndexPath *resolvedPath = intent ? [self apollo_resolvedMasterSelectionPath:intent] : nil;
+    UITableViewCell *cell = resolvedPath ? [tableView cellForRowAtIndexPath:resolvedPath] : nil;
+    NSUInteger selectedCount = tableView.indexPathsForSelectedRows.count;
+    BOOL pathSelected = resolvedPath &&
+        [tableView.indexPathsForSelectedRows containsObject:resolvedPath];
+    BOOL axSelected = cell && (cell.accessibilityTraits & UIAccessibilityTraitSelected) != 0;
+    BOOL detailMatches = intent && _apollo_masterSelectionDetailRoot &&
+        _apollo_masterSelectionDetailRoot == self.apollo_detailNav.viewControllers.firstObject;
+    BOOL expectsPhysical = intent && !self.isCollapsed && detailMatches;
+    BOOL passed = !intent
+        ? selectedCount == 0
+        : (!expectsPhysical || !resolvedPath
+            ? selectedCount == 0
+            : selectedCount == 1 && pathSelected && cell.selected && axSelected);
+    return [NSString stringWithFormat:
+        @"logical=%d source=%@ texture=%d keyHash=%lu cached=%@ resolved=%@ "
+         "detailMatch=%d collapsed=%d selectedCount=%lu pathSelected=%d "
+         "cellVisible=%d cellSelected=%d axSelected=%d pass=%d",
+        intent != nil, NSStringFromClass(intent.sourceViewController.class),
+        intent.textureBacked, (unsigned long)[intent.itemIdentifier hash],
+        intent.indexPath ?: @"(nil)", resolvedPath ?: @"(nil)", detailMatches,
+        self.isCollapsed, (unsigned long)selectedCount, pathSelected,
+        cell != nil, cell.selected, axSelected, passed];
+}
+
++ (void)apollo_simRunDeallocatedSourceProbe {
+    __block BOOL incorrectlyApplied = NO;
+    __block BOOL deferAccepted = NO;
+    __weak UIViewController *weakDisposable = nil;
+    __block ApolloPaneSplitViewController *probePane = nil;
+    @autoreleasepool {
+        __strong UIViewController *disposable = [UIViewController new];
+        disposable.title = @"Task 11 Disposable Source";
+        weakDisposable = disposable;
+        UINavigationController *navigationController =
+            [[UINavigationController alloc] initWithRootViewController:disposable];
+        probePane = [ApolloPaneSplitViewController
+            paneControllerWithRootNavigationController:navigationController tabIndex:99];
+        [probePane apollo_simSetCrossColumnNavigationBlocked:YES];
+        deferAccepted = [probePane apollo_deferCrossColumnNavigationIfNeeded:^{
+            incorrectlyApplied = YES;
+            ApolloLog(@"[PaneTransitionTest] ERROR applied deallocated-source intent");
+        } sourceViewController:disposable reason:@"sim deallocated source"];
+        [navigationController setViewControllers:@[ [UIViewController new] ] animated:NO];
+        disposable = nil;
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        BOOL sourceNil = weakDisposable == nil;
+        ApolloLog(@"[PaneTransitionTest] releasing deallocated-source intent accepted=%d sourceNil=%d%@",
+                  deferAccepted, sourceNil,
+                  deferAccepted && sourceNil ? @"" : @" ERROR inconclusive probe setup");
+        [probePane apollo_simSetCrossColumnNavigationBlocked:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSString *state = [probePane apollo_simCrossColumnNavigationState];
+            BOOL passed = deferAccepted && sourceNil && !incorrectlyApplied &&
+                [state containsString:@"pending=0"];
+            ApolloLog(@"[PaneTransitionTest] deallocated-source %@ applied=%d state={%@}",
+                      passed ? @"PASS" : @"ERROR", incorrectlyApplied, state);
+            probePane = nil;
+        });
+    });
+}
+#endif
+
+- (void)apollo_recordDetailBranchFromPrimarySource:(UIViewController *)sourceViewController {
+    NSArray<UIViewController *> *logicalPrimary = self.apollo_logicalPrimaryControllers;
+    UIViewController *semanticOwner = ApolloPanePrimaryContextController(logicalPrimary);
+    UIViewController *concreteOwner = sourceViewController;
+    if (!concreteOwner || ![logicalPrimary containsObject:concreteOwner]) {
+        concreteOwner = semanticOwner;
+    }
+    _apollo_detailContextOwner = concreteOwner;
+    _apollo_detailSemanticOwner = semanticOwner;
+    _apollo_detailContextScope = ApolloPanePrimaryContextScope(semanticOwner);
+    ApolloLog(@"[PaneContext] tab %ld recorded detail owner=%@ semantic=%@ scoped=%d",
+              (long)self.apollo_tabIndex, NSStringFromClass(concreteOwner.class),
+              NSStringFromClass(semanticOwner.class),
+              _apollo_detailContextScope != nil);
+}
+
+- (void)apollo_prepareForCompactPrimaryContextChange {
+    if (!self.isCollapsed || !_apollo_compactDetailChromeActive) return;
+    [self apollo_restoreCompactDetailNavigationItem];
+    [self apollo_stopTrackingCompactPrimaryPopGesture];
+    [self.apollo_primaryNav setNavigationBarHidden:_apollo_primaryNavBarWasHiddenBeforeCompact
+                                          animated:NO];
+    [self.apollo_detailNav setNavigationBarHidden:_apollo_detailNavBarWasHiddenBeforeCompact
+                                         animated:NO];
+    [self apollo_resetCompactDetailChromeState];
+    if (@available(iOS 14.0, *)) {
+        _apollo_performingCompactShowColumn = YES;
+        @try {
+            [self showColumn:UISplitViewControllerColumnPrimary];
+        } @finally {
+            _apollo_performingCompactShowColumn = NO;
+        }
+    }
+}
+
+- (void)apollo_reconcileDetailAfterPrimaryMutation:(NSString *)reason {
+    if (!_apollo_contextTrackingReady || _apollo_clearingContext ||
+        (![self apollo_hasDetailBranchForContextTracking] &&
+         !_apollo_pendingCrossColumnNavigation)) return;
+
+    // A delayed didShow/set-stack reconciliation from the previous navigation
+    // must not coalesce a valid newer selection into a Clear. The queued route
+    // owns its own source/scope token; keep it when that token still matches.
+    if (_apollo_pendingCrossColumnNavigation &&
+        [self apollo_pendingCrossColumnSourceIsStillCurrent]) {
+        ApolloLog(@"[PaneContext] tab %ld kept valid pending route during reconciliation reason=%@",
+                  (long)self.apollo_tabIndex, reason ?: @"primary mutation");
+        return;
+    }
+
+    NSArray<UIViewController *> *logicalPrimary = self.apollo_logicalPrimaryControllers;
+    UIViewController *current = ApolloPanePrimaryContextController(logicalPrimary);
+    UIViewController *owner = _apollo_detailContextOwner;
+    UIViewController *semanticOwner = _apollo_detailSemanticOwner;
+    NSString *currentScope = ApolloPanePrimaryContextScope(current);
+    BOOL ownerChanged = !owner || ![logicalPrimary containsObject:owner] ||
+        !semanticOwner || current != semanticOwner;
+    BOOL provenScopeChange = !ownerChanged && _apollo_detailContextScope && currentScope &&
+        ![_apollo_detailContextScope isEqualToString:currentScope];
+    if (!ownerChanged && !provenScopeChange) return;
+
+    ApolloLog(@"[PaneContext] tab %ld clearing detail reason=%@ ownerChanged=%d scopeChanged=%d",
+              (long)self.apollo_tabIndex, reason ?: @"primary mutation",
+              ownerChanged, provenScopeChange);
+    [self apollo_clearDetailColumn];
+}
+
+- (void)apollo_scheduleDetailReconciliationAfterPrimaryMutation:(NSString *)reason {
+    if (reason.length > 0) _apollo_pendingContextReconciliationReason = [reason copy];
+    if (_apollo_contextReconciliationScheduled) return;
+    _apollo_contextReconciliationScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_apollo_contextReconciliationScheduled = NO;
+        NSString *settledReason = self->_apollo_pendingContextReconciliationReason;
+        self->_apollo_pendingContextReconciliationReason = nil;
+        [self apollo_reconcileDetailAfterPrimaryMutation:settledReason ?: @"primary mutation settled"];
+    });
+}
+
+- (void)apollo_forcePrimaryContextChangedForViewController:(UIViewController *)viewController
+                                                    reason:(NSString *)reason {
+    if (!_apollo_contextTrackingReady || _apollo_clearingContext) return;
+    BOOL visibleOwner = viewController == _apollo_detailSemanticOwner ||
+        viewController == _apollo_detailContextOwner;
+    BOOL pendingOwner = _apollo_pendingCrossColumnNavigation &&
+        (viewController == _apollo_pendingCrossColumnSource ||
+         viewController == _apollo_pendingCrossColumnSemanticOwner);
+    if (!visibleOwner && !pendingOwner) return;
+    ApolloLog(@"[PaneContext] tab %ld clearing detail for forced in-place change reason=%@",
+              (long)self.apollo_tabIndex, reason ?: @"unknown");
+    [self apollo_clearDetailColumn];
+}
+
+- (void)apollo_accountContextDidChange {
+    if (!_apollo_contextTrackingReady || _apollo_clearingContext) return;
+    // Home, Inbox and Profile content is tied to the active Reddit account.
+    // Settings is not, and Search can remain a valid public query.
+    if (self.apollo_tabIndex < 0 || self.apollo_tabIndex > 2) return;
+    if (![self apollo_hasDetailBranchForContextTracking] &&
+        !_apollo_pendingCrossColumnNavigation) return;
+    ApolloLog(@"[PaneContext] tab %ld clearing account-scoped detail",
+              (long)self.apollo_tabIndex);
+    [self apollo_clearDetailColumn];
+}
+
+// A detail route opened while an EMPTY pane is already compact has to push on
+// the one visible primary navigation stack. On expansion, move the contiguous
+// logical-detail suffix back to the real detail navigation controller so the
+// feed remains on the left and the route the user opened remains on the right.
+- (void)apollo_migrateCompactLogicalStackIfNeeded {
+    NSArray<UIViewController *> *primaryStack = self.apollo_primaryNav.viewControllers;
+    NSUInteger detailStart = NSNotFound;
+    for (NSUInteger index = 0; index < primaryStack.count; index++) {
+        if ([self apollo_compactViewControllerBelongsToDetail:primaryStack[index]]) {
+            detailStart = index;
+            break;
+        }
+    }
+    if (detailStart == NSNotFound) return;
+    if (detailStart == 0) {
+        ApolloLog(@"[PaneSplit] tab %ld refused compact migration with no primary anchor",
+                  (long)self.apollo_tabIndex);
+        return;
+    }
+
+    NSArray<UIViewController *> *primaryControllers =
+        [primaryStack subarrayWithRange:NSMakeRange(0, detailStart)];
+    NSArray<UIViewController *> *detailControllers =
+        [primaryStack subarrayWithRange:NSMakeRange(detailStart, primaryStack.count - detailStart)];
+
+    // These controllers are changing physical owners. Any Forward entries in
+    // the destination detail nav belong to its previous branch, while entries
+    // left in the primary nav can only refer to logical-detail controllers
+    // popped during compact navigation (the first compact detail push already
+    // cleared older primary Forward state through Apollo's native push path).
+    // Move both stacks as one rollback-capable transaction. History and logical
+    // ownership are committed only after both UIKit mutations succeed.
+    NSArray<UIViewController *> *oldPrimary = self.apollo_primaryNav.viewControllers;
+    NSArray<UIViewController *> *oldDetail = self.apollo_detailNav.viewControllers;
+    @try {
+        [self apollo_setPrimaryViewControllers:primaryControllers];
+        [self.apollo_detailNav setViewControllers:detailControllers animated:NO];
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneSplit] tab %ld compact migration failed; rolling back: %@",
+                  (long)self.apollo_tabIndex, exception);
+        @try {
+            [self apollo_setPrimaryViewControllers:oldPrimary];
+            [self.apollo_detailNav setViewControllers:oldDetail animated:NO];
+        } @catch (NSException *rollbackException) {
+            ApolloLog(@"[PaneSplit] tab %ld compact migration rollback failed: %@",
+                      (long)self.apollo_tabIndex, rollbackException);
+        }
+        return;
+    }
+    ApolloPaneClearForwardHistory(self.apollo_detailNav);
+    ApolloPaneClearForwardHistory(self.apollo_primaryNav);
+    for (UIViewController *controller in detailControllers) {
+        [_apollo_compactLogicalColumns removeObjectForKey:controller];
+    }
+    ApolloLog(@"[PaneSplit] tab %ld expanded; migrated %lu compact detail controller(s), primary depth=%lu",
+              (long)self.apollo_tabIndex, (unsigned long)detailControllers.count,
+              (unsigned long)primaryControllers.count);
 }
 
 - (void)apollo_clearDetailColumn {
-    if (self.apollo_detailIsEmpty) return;
-    [self.apollo_detailNav setViewControllers:@[
-        [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:self.apollo_emptyMessage
-                                                               symbolName:self.apollo_emptySymbol]
-    ] animated:NO];
-    ApolloLog(@"[PaneSplit] tab %ld detail column cleared", (long)self.apollo_tabIndex);
-    [self apollo_detailContentDidChange];
+    if (_apollo_clearingContext) return;
+    if (!_apollo_executingCrossColumnNavigation) {
+        __weak ApolloPaneSplitViewController *weakSelf = self;
+        if ([self apollo_deferCrossColumnNavigationIfNeeded:^{
+                [weakSelf apollo_clearDetailColumn];
+            }
+                                  sourceViewController:nil
+                                                reason:@"clear detail"]) return;
+    }
+
+    _apollo_clearingContext = YES;
+    @try {
+        NSArray<UIViewController *> *oldPrimary = self.apollo_primaryNav.viewControllers;
+        NSArray<UIViewController *> *oldDetail = self.apollo_detailNav.viewControllers;
+        BOOL compactChromeWasActive = _apollo_compactDetailChromeActive;
+        NSArray<UIViewController *> *liveLogicalPrimary = self.apollo_logicalPrimaryControllers;
+        BOOL removesLogicalDetail = liveLogicalPrimary.count < oldPrimary.count &&
+            liveLogicalPrimary.count > 0;
+        NSArray<UIViewController *> *logicalDetail = removesLogicalDetail
+            ? [oldPrimary subarrayWithRange:NSMakeRange(liveLogicalPrimary.count,
+                                                       oldPrimary.count - liveLogicalPrimary.count)]
+            : @[];
+        NSArray<UIViewController *> *logicalPrimary = liveLogicalPrimary;
+        NSArray<UIViewController *> *capturedReturnStack = _apollo_compactPrimaryReturnStack;
+        BOOL capturedReturnMatchesAnchor = capturedReturnStack.count > 0 &&
+            capturedReturnStack.lastObject == _apollo_compactPrimaryAnchor;
+        BOOL liveIsTruncatedReturn = ApolloPaneStackIsStrictIdentityPrefix(
+            liveLogicalPrimary, capturedReturnStack);
+        BOOL liveIsExactCapturedBridgeStack = ApolloPaneStacksIdentityEqual(
+            liveLogicalPrimary, _apollo_postCollapsePrimaryBridgeStack);
+        BOOL restoresCapturedPrimary = compactChromeWasActive &&
+            capturedReturnMatchesAnchor &&
+            (liveIsTruncatedReturn || liveIsExactCapturedBridgeStack);
+        if (restoresCapturedPrimary) {
+            logicalPrimary = [capturedReturnStack copy];
+        }
+        BOOL writesPrimary = removesLogicalDetail || restoresCapturedPrimary;
+        BOOL replacesPhysicalDetail = !self.apollo_detailIsEmpty;
+        NSArray<UIViewController *> *placeholder = replacesPhysicalDetail ? @[
+            [[ApolloPaneDetailPlaceholderViewController alloc]
+                initWithMessage:self.apollo_emptyMessage symbolName:self.apollo_emptySymbol]
+        ] : oldDetail;
+
+        @try {
+            if (writesPrimary) {
+                [self apollo_setPrimaryViewControllers:logicalPrimary];
+                if (!ApolloPaneStacksIdentityEqual(self.apollo_primaryNav.viewControllers,
+                                                   logicalPrimary)) {
+                    @throw [NSException exceptionWithName:@"ApolloPanePrimaryClearPostcondition"
+                                                   reason:@"Primary navigation rejected compact recovery"
+                                                 userInfo:nil];
+                }
+            }
+            if (replacesPhysicalDetail) {
+                [self.apollo_detailNav setViewControllers:placeholder animated:NO];
+                if (!ApolloPaneStacksIdentityEqual(self.apollo_detailNav.viewControllers,
+                                                   placeholder)) {
+                    @throw [NSException exceptionWithName:@"ApolloPaneDetailClearPostcondition"
+                                                   reason:@"Detail navigation rejected placeholder"
+                                                 userInfo:nil];
+                }
+            }
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PaneSplit] tab %ld detail clear failed; rolling back: %@",
+                      (long)self.apollo_tabIndex, exception);
+            @try {
+                [self apollo_setPrimaryViewControllers:oldPrimary];
+                [self.apollo_detailNav setViewControllers:oldDetail animated:NO];
+            } @catch (NSException *rollbackException) {
+                ApolloLog(@"[PaneSplit] tab %ld detail clear rollback failed: %@",
+                          (long)self.apollo_tabIndex, rollbackException);
+            }
+            return;
+        }
+
+        NSArray<UIViewController *> *expectedPrimary = nil;
+        NSUInteger restoreGeneration = 0;
+        if (compactChromeWasActive && logicalPrimary.count > 0) {
+            expectedPrimary = [logicalPrimary copy];
+            restoreGeneration = ++_apollo_compactPrimaryRestoreGeneration;
+            _apollo_compactPrimaryRestoreMutationGeneration =
+                _apollo_primaryNavigationMutationGeneration;
+            ++_apollo_compactPrimaryRestoreLineage;
+            _apollo_expectedCompactPrimaryRestoreStack = expectedPrimary;
+            _apollo_compactPrimaryRestoreInProgress = YES;
+            _apollo_expectUIKitCompactPrimaryStackReplacement = YES;
+            _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+            _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            _apollo_knownUIKitCompactPrimaryTransientStack = nil;
+        }
+
+        // Compact chrome is coordinator-owned state too. Tear it down only
+        // after both stack writes succeed, so a UIKit exception leaves the old
+        // visible branch and its Back affordance fully usable. Arm the one-shot
+        // stack token first so the public set-stack call made by showColumn:
+        // can identify its exact transient shape synchronously.
+        [self apollo_prepareForCompactPrimaryContextChange];
+        // `showColumn:Primary` can repeat UIKit's compact merge policy and
+        // truncate [index, feed] to [index] asynchronously. The full captured
+        // stack was committed before showColumn: above; only revalidate/repair
+        // after that coordinator settles, never write during its setup.
+        if (expectedPrimary.count > 0) {
+            [self apollo_scheduleCompactPrimaryRestoreReconciliation:restoreGeneration
+                                                         observations:0];
+        }
+
+        // Commit bookkeeping only after UIKit accepted every required stack
+        // mutation. Even an already-visible placeholder may retain stale Forward
+        // history, so detail invalidation is unconditional.
+        ApolloPaneClearForwardHistory(self.apollo_detailNav);
+        if (writesPrimary) ApolloPaneClearForwardHistory(self.apollo_primaryNav);
+        for (UIViewController *controller in logicalDetail) {
+            [_apollo_compactLogicalColumns removeObjectForKey:controller];
+        }
+        _apollo_detailContextOwner = nil;
+        _apollo_detailSemanticOwner = nil;
+        _apollo_detailContextScope = nil;
+        [self apollo_clearMasterSelectionForReason:@"detail clear committed"];
+        if (!compactChromeWasActive || logicalPrimary.count == 0) {
+            _apollo_compactPrimaryReturnStack = nil;
+            _apollo_postCollapsePrimaryBridgeStack = nil;
+            _apollo_expectedCompactPrimaryRestoreStack = nil;
+            _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+            _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+            _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+            _apollo_knownUIKitCompactPrimaryTransientStack = nil;
+        }
+        if (restoresCapturedPrimary) {
+            ApolloLog(@"[PaneSplit] tab %ld restored captured compact primary depth %lu -> %lu",
+                      (long)self.apollo_tabIndex, (unsigned long)liveLogicalPrimary.count,
+                      (unsigned long)logicalPrimary.count);
+        }
+        if (removesLogicalDetail) {
+            ApolloLog(@"[PaneSplit] tab %ld removed %lu compact logical-detail controller(s)",
+                      (long)self.apollo_tabIndex, (unsigned long)logicalDetail.count);
+        }
+        ApolloLog(@"[PaneSplit] tab %ld detail column cleared and forward history invalidated",
+                  (long)self.apollo_tabIndex);
+        [self apollo_resolvedDisplayStateMayHaveChanged];
+    } @finally {
+        _apollo_clearingContext = NO;
+    }
 }
 
-- (void)apollo_detailContentDidChange {
-    [self apollo_reconcileSidebarForDetailContent];
+#pragma mark - Compact navigation chrome
+
+- (void)apollo_restoreCompactDetailNavigationItem {
+    UIViewController *root = _apollo_compactDetailRoot;
+    UIBarButtonItem *back = _apollo_compactBackItem;
+    if (!root || !back) return;
+
+    // Own only the item we inserted. Restoring an old snapshot of the entire
+    // array (and both Back booleans) can erase legitimate native changes made
+    // while compact, such as entering Edit mode or updating account actions.
+    NSMutableArray<UIBarButtonItem *> *current =
+        [root.navigationItem.leftBarButtonItems mutableCopy] ?: [NSMutableArray array];
+    NSUInteger index = [current indexOfObjectIdenticalTo:back];
+    if (index == NSNotFound) return;
+    [current removeObjectAtIndex:index];
+    root.navigationItem.leftBarButtonItems = current.count > 0 ? current : nil;
+}
+
+- (void)apollo_stopTrackingCompactPrimaryPopGesture {
+    UIGestureRecognizer *primaryPop = self.apollo_primaryNav.interactivePopGestureRecognizer;
+    if (_apollo_trackingCompactPrimaryPopGesture) {
+        [primaryPop removeTarget:self action:@selector(apollo_compactPrimaryPopGestureChanged:)];
+        primaryPop.enabled = _apollo_primaryPopGestureWasEnabled;
+        _apollo_trackingCompactPrimaryPopGesture = NO;
+    }
+    self.apollo_detailNav.interactivePopGestureRecognizer.enabled = _apollo_detailPopGestureWasEnabled;
+    if (_apollo_primaryApolloBackGesture) {
+        _apollo_primaryApolloBackGesture.enabled = _apollo_primaryApolloBackGestureWasEnabled;
+        _apollo_primaryApolloBackGesture = nil;
+    }
+    if (_apollo_detailApolloBackGesture) {
+        _apollo_detailApolloBackGesture.enabled = _apollo_detailApolloBackGestureWasEnabled;
+        _apollo_detailApolloBackGesture = nil;
+    }
+    if (_apollo_compactBackEdgeGesture) {
+        [_apollo_compactBackEdgeGesture.view removeGestureRecognizer:_apollo_compactBackEdgeGesture];
+        _apollo_compactBackEdgeGesture.delegate = nil;
+        _apollo_compactBackEdgeGesture = nil;
+    }
+}
+
+- (void)apollo_resetCompactDetailChromeState {
+    [self apollo_restoreCompactDetailNavigationItem];
+    [self apollo_stopTrackingCompactPrimaryPopGesture];
+    _apollo_compactDetailChromeActive = NO;
+    _apollo_compactPrimaryAnchor = nil;
+    _apollo_compactDetailRoot = nil;
+    _apollo_compactBackItem = nil;
+}
+
+- (void)apollo_activateCompactDetailChrome {
+    [self apollo_removeShowPrimaryItem];
+    if (_apollo_compactDetailChromeActive || self.apollo_detailIsEmpty) return;
+
+    UINavigationController *primary = self.apollo_primaryNav;
+    UINavigationController *detail = self.apollo_detailNav;
+    UIViewController *root = detail.viewControllers.firstObject;
+    if (!primary || !detail || !root || !_apollo_compactPrimaryAnchor) {
+        ApolloLog(@"[PaneSplit] tab %ld compact chrome unavailable (primary=%d detail=%d root=%d anchor=%d)",
+                  (long)self.apollo_tabIndex, primary != nil, detail != nil, root != nil,
+                  _apollo_compactPrimaryAnchor != nil);
+        return;
+    }
+
+    _apollo_primaryNavBarWasHiddenBeforeCompact = primary.navigationBarHidden;
+    _apollo_detailNavBarWasHiddenBeforeCompact = detail.navigationBarHidden;
+    _apollo_compactDetailRoot = root;
+
+    UIBarButtonItem *back = [[UIBarButtonItem alloc]
+        initWithImage:[UIImage systemImageNamed:@"chevron.backward"]
+                style:UIBarButtonItemStylePlain
+               target:self
+               action:@selector(apollo_compactBackToPrimary:)];
+    back.accessibilityLabel = self.tabBarItem.title.length > 0
+        ? [NSString stringWithFormat:@"Back to %@", self.tabBarItem.title]
+        : @"Back";
+    back.accessibilityIdentifier = @"ApolloPaneCompactBack";
+    _apollo_compactBackItem = back;
+    NSArray<UIBarButtonItem *> *existing = root.navigationItem.leftBarButtonItems ?: @[];
+    root.navigationItem.leftBarButtonItems = [@[ back ] arrayByAddingObjectsFromArray:existing];
+
+    // The primary bar contains only UIKit's cross-column Back item. Apollo's
+    // inner detail bar already owns the useful title/actions, so keeping both
+    // wastes 54pt and looks like a navigation controller embedded in another.
+    [primary setNavigationBarHidden:YES animated:NO];
+    if (_apollo_detailNavBarWasHiddenBeforeCompact) {
+        [detail setNavigationBarHidden:NO animated:NO];
+    }
+
+    UIGestureRecognizer *popGesture = primary.interactivePopGestureRecognizer;
+    if (popGesture) {
+        _apollo_primaryPopGestureWasEnabled = popGesture.enabled;
+        [popGesture addTarget:self action:@selector(apollo_compactPrimaryPopGestureChanged:)];
+        // This recognizer lives above a nested navigation controller after the
+        // split collapse and loses the touch arbitration in practice. Disable
+        // it while compact and replace it with a root-only edge recognizer on
+        // the view the user is actually touching. The target remains attached
+        // defensively in case UIKit completes a programmatic interactive pop.
+        popGesture.enabled = NO;
+        _apollo_trackingCompactPrimaryPopGesture = YES;
+    }
+
+    UIGestureRecognizer *detailPopGesture = detail.interactivePopGestureRecognizer;
+    _apollo_detailPopGestureWasEnabled = detailPopGesture.enabled;
+    detailPopGesture.enabled = NO;
+
+    // ApolloNavigationController does not use the UIKit recognizer above for
+    // its interactive transitions. Its own left-edge pan on the collapsed
+    // primary can pop UIKit's column bridge without telling this coordinator,
+    // leaving the list visible while the detail column still claims to be
+    // populated. Disable both nested Apollo recognizers while compact and
+    // restore their exact prior state on Back or expansion.
+    _apollo_primaryApolloBackGesture =
+        ApolloPaneNavigationGesture(primary, "leftScreenEdgePanGestureRecognizer");
+    _apollo_detailApolloBackGesture =
+        ApolloPaneNavigationGesture(detail, "leftScreenEdgePanGestureRecognizer");
+    _apollo_primaryApolloBackGestureWasEnabled = _apollo_primaryApolloBackGesture.enabled;
+    _apollo_detailApolloBackGestureWasEnabled = _apollo_detailApolloBackGesture.enabled;
+    _apollo_primaryApolloBackGesture.enabled = NO;
+    _apollo_detailApolloBackGesture.enabled = NO;
+
+    UIPanGestureRecognizer *edge = [[UIPanGestureRecognizer alloc]
+        initWithTarget:self action:@selector(apollo_compactBackEdgeGestureChanged:)];
+    UIUserInterfaceLayoutDirection direction = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:
+        detail.view.semanticContentAttribute];
+    _apollo_compactBackUsesRightEdge = direction == UIUserInterfaceLayoutDirectionRightToLeft;
+    edge.minimumNumberOfTouches = 1;
+    edge.maximumNumberOfTouches = 1;
+    edge.delegate = self;
+    // Attach above UIKit's collapsed-column bridge. The hosted detail view is
+    // visible through that bridge but is not the reliable recipient of a touch
+    // that begins at the physical window edge.
+    [self.view addGestureRecognizer:edge];
+    _apollo_compactBackEdgeGesture = edge;
+    _apollo_compactDetailChromeActive = YES;
+    ApolloLog(@"[PaneSplit] tab %ld compact detail chrome active; primary bar hidden, detail Back installed",
+              (long)self.apollo_tabIndex);
+}
+
+- (void)apollo_refreshCompactDetailChromeAfterRootReplacement {
+    if (!self.isCollapsed || !_apollo_compactDetailChromeActive) return;
+    UIViewController *anchor = _apollo_compactPrimaryAnchor;
+    BOOL restorePrimaryHidden = _apollo_primaryNavBarWasHiddenBeforeCompact;
+    BOOL restoreDetailHidden = _apollo_detailNavBarWasHiddenBeforeCompact;
+    [self apollo_resetCompactDetailChromeState];
+    _apollo_compactPrimaryAnchor = anchor;
+    [self apollo_activateCompactDetailChrome];
+    // Activation samples compact's temporary bar visibility. Retain the actual
+    // pre-collapse values for Back/expansion restoration.
+    _apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+    _apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+}
+
+- (void)apollo_finishCompactBackToPrimary {
+    if (!_apollo_compactDetailChromeActive || _apollo_compactBackInProgress) return;
+    if (!_apollo_executingCrossColumnNavigation) {
+        __weak ApolloPaneSplitViewController *weakSelf = self;
+        if ([self apollo_deferCrossColumnNavigationIfNeeded:^{
+                [weakSelf apollo_finishCompactBackToPrimary];
+            }
+                                  sourceViewController:nil
+                                                reason:@"compact Back"]) return;
+    }
+    _apollo_compactBackInProgress = YES;
+
+    UINavigationController *primary = self.apollo_primaryNav;
+    UINavigationController *detail = self.apollo_detailNav;
+    UIViewController *anchor = _apollo_compactPrimaryAnchor;
+    UIViewController *detailRoot = _apollo_compactDetailRoot;
+    BOOL restorePrimaryHidden = _apollo_primaryNavBarWasHiddenBeforeCompact;
+    BOOL restoreDetailHidden = _apollo_detailNavBarWasHiddenBeforeCompact;
+
+    [self apollo_restoreCompactDetailNavigationItem];
+    [self apollo_stopTrackingCompactPrimaryPopGesture];
+
+    // During the cross-column pop, show exactly the primary bar that owns the
+    // transition and temporarily hide the detail bar. Restoring both at once
+    // would reintroduce the two-bar frame for the duration of the animation.
+    [detail setNavigationBarHidden:YES animated:NO];
+    [primary setNavigationBarHidden:restorePrimaryHidden animated:NO];
+
+    void (^complete)(void) = ^{
+        if (detail.viewControllers.firstObject != detailRoot) {
+            self->_apollo_compactBackInProgress = NO;
+            UIViewController *currentRoot = detail.viewControllers.firstObject;
+            if (self.isCollapsed && !self.apollo_detailIsEmpty) {
+                // A replacement may have rebuilt chrome while the old Back
+                // animation was settling. Preserve that new ownership; if it
+                // did not, rebuild against the new root now.
+                if (!self->_apollo_compactDetailChromeActive ||
+                    self->_apollo_compactDetailRoot != currentRoot) {
+                    [self apollo_resetCompactDetailChromeState];
+                    self->_apollo_compactPrimaryAnchor = anchor;
+                    self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+                    self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+                    [self apollo_activateCompactDetailChrome];
+                    self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+                    self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+                } else {
+                    [primary setNavigationBarHidden:YES animated:NO];
+                    [detail setNavigationBarHidden:NO animated:NO];
+                }
+                ApolloLog(@"[PaneSplit] tab %ld compact Back kept replacement detail chrome",
+                          (long)self.apollo_tabIndex);
+            } else {
+                [primary setNavigationBarHidden:restorePrimaryHidden animated:NO];
+                [detail setNavigationBarHidden:restoreDetailHidden animated:NO];
+                [self apollo_resetCompactDetailChromeState];
+                ApolloLog(@"[PaneSplit] tab %ld compact Back settled after branch/topology changed",
+                          (long)self.apollo_tabIndex);
+            }
+            return;
+        }
+        // This clear is the commit phase of the already-started Back action.
+        // Execute it directly so it cannot coalesce over a newer user route
+        // that arrived during the pop. The central clear transaction restores
+        // the captured primary return stack before discarding this branch.
+        [self apollo_performCrossColumnNavigationTransaction:^{
+            [self apollo_clearDetailColumn];
+        }];
+        if (!self.apollo_detailIsEmpty) {
+            self->_apollo_compactBackInProgress = NO;
+            [primary setNavigationBarHidden:YES animated:NO];
+            [detail setNavigationBarHidden:NO animated:NO];
+            [self apollo_resetCompactDetailChromeState];
+            self->_apollo_compactPrimaryAnchor = anchor;
+            self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+            self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+            [self apollo_activateCompactDetailChrome];
+            self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+            self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+            ApolloLog(@"[PaneSplit] tab %ld compact Back clear failed; retained detail for retry",
+                      (long)self.apollo_tabIndex);
+            return;
+        }
+        self->_apollo_compactBackInProgress = NO;
+        ApolloLog(@"[PaneSplit] tab %ld compact Back returned to primary and cleared detail",
+                  (long)self.apollo_tabIndex);
+    };
+    void (^restoreCancelled)(void) = ^{
+        self->_apollo_compactBackInProgress = NO;
+        if (!self.isCollapsed || self.apollo_detailIsEmpty) {
+            [primary setNavigationBarHidden:restorePrimaryHidden animated:NO];
+            [detail setNavigationBarHidden:restoreDetailHidden animated:NO];
+            [self apollo_resetCompactDetailChromeState];
+            ApolloLog(@"[PaneSplit] tab %ld compact Back cancellation settled after topology changed",
+                      (long)self.apollo_tabIndex);
+            return;
+        }
+        [primary setNavigationBarHidden:YES animated:NO];
+        [detail setNavigationBarHidden:NO animated:NO];
+        // We removed only coordinator-owned chrome and gestures above. Rebuild
+        // them from the still-valid detail branch when UIKit refuses or cancels
+        // the native pop; the detail stack and context remain untouched.
+        [self apollo_resetCompactDetailChromeState];
+        self->_apollo_compactPrimaryAnchor = anchor;
+        self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+        self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+        [self apollo_activateCompactDetailChrome];
+        // Activation samples the temporary compact visibility we just restored;
+        // retain the real pre-collapse values for the eventual successful Back
+        // or expansion.
+        self->_apollo_primaryNavBarWasHiddenBeforeCompact = restorePrimaryHidden;
+        self->_apollo_detailNavBarWasHiddenBeforeCompact = restoreDetailHidden;
+        ApolloLog(@"[PaneSplit] tab %ld compact Back cancelled/refused; restored %@ detail chrome",
+                  (long)self.apollo_tabIndex,
+                  detail.viewControllers.firstObject == detailRoot ? @"original" : @"replacement");
+    };
+
+    if (anchor && [primary.viewControllers containsObject:anchor] && primary.topViewController != anchor) {
+        NSArray<UIViewController *> *popped = [primary popToViewController:anchor animated:YES];
+        if (popped.count == 0) {
+            restoreCancelled();
+            return;
+        }
+        __block BOOL backResolutionFinished = NO;
+        void (^resolveBack)(BOOL) = ^(BOOL cancelled) {
+            if (backResolutionFinished) return;
+            backResolutionFinished = YES;
+            if (!cancelled && primary.topViewController == anchor) complete();
+            else restoreCancelled();
+        };
+        id<UIViewControllerTransitionCoordinator> coordinator = primary.transitionCoordinator;
+        if (coordinator) {
+            [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                BOOL cancelled = context.isCancelled;
+                dispatch_async(dispatch_get_main_queue(), ^{ resolveBack(cancelled); });
+            }];
+        }
+        // Registration can be rejected when UIKit hands the coordinator off,
+        // and an accepted coordinator is not contractually required to call a
+        // late completion. Poll to the terminal stack as an idempotent watchdog
+        // rather than leaving compact chrome permanently half-torn-down.
+        __block dispatch_block_t pollBackSettlement = nil;
+        pollBackSettlement = ^{
+            if (backResolutionFinished) {
+                pollBackSettlement = nil;
+                return;
+            }
+            if ([self apollo_navigationControllerIsTransitioning:primary]) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                    (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(),
+                    pollBackSettlement);
+                return;
+            }
+            BOOL committed = primary.topViewController == anchor;
+            dispatch_block_t retainedPoll = pollBackSettlement;
+            pollBackSettlement = nil;
+            resolveBack(!committed);
+            (void)retainedPoll;
+        };
+        dispatch_async(dispatch_get_main_queue(), pollBackSettlement);
+    } else {
+        complete();
+    }
+}
+
+- (void)apollo_compactBackToPrimary:(UIBarButtonItem *)sender {
+    [self apollo_finishCompactBackToPrimary];
+}
+
+- (BOOL)accessibilityPerformEscape {
+    if (!_apollo_compactDetailChromeActive) return [super accessibilityPerformEscape];
+    ApolloLog(@"[PaneSplit] tab %ld compact accessibility escape accepted",
+              (long)self.apollo_tabIndex);
+    [self apollo_finishCompactBackToPrimary];
+    return YES;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer != _apollo_compactBackEdgeGesture) return YES;
+    if (!_apollo_compactDetailChromeActive || !self.isCollapsed ||
+        self.apollo_detailNav.viewControllers.count != 1) return NO;
+    UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
+    CGPoint location = [pan locationInView:pan.view];
+    CGPoint translation = [pan translationInView:pan.view];
+    CGFloat initialX = location.x - translation.x;
+    CGFloat width = pan.view.bounds.size.width;
+    BOOL startsAtEdge = _apollo_compactBackUsesRightEdge
+        ? initialX >= width - 24.0 : initialX <= 24.0;
+    CGPoint velocity = [pan velocityInView:pan.view];
+    CGFloat backVelocity = velocity.x * (_apollo_compactBackUsesRightEdge ? -1.0 : 1.0);
+    BOOL shouldBegin = startsAtEdge && backVelocity > 0.0 && fabs(velocity.x) > fabs(velocity.y);
+    ApolloLog(@"[PaneSplit] tab %ld compact edge Back begin=%d initialX=%.0f velocity=(%.0f,%.0f)",
+              (long)self.apollo_tabIndex, shouldBegin, initialX, velocity.x, velocity.y);
+    return shouldBegin;
+}
+
+- (void)apollo_compactBackEdgeGestureChanged:(UIPanGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateEnded) return;
+    CGFloat direction = _apollo_compactBackUsesRightEdge ? -1.0 : 1.0;
+    CGFloat distance = [gesture translationInView:gesture.view].x * direction;
+    CGFloat velocity = [gesture velocityInView:gesture.view].x * direction;
+    CGFloat threshold = MAX(72.0, gesture.view.bounds.size.width * 0.18);
+    if (distance >= threshold || velocity >= 500.0) {
+        ApolloLog(@"[PaneSplit] tab %ld compact edge Back accepted distance=%.0f velocity=%.0f",
+                  (long)self.apollo_tabIndex, distance, velocity);
+        [self apollo_finishCompactBackToPrimary];
+    } else {
+        ApolloLog(@"[PaneSplit] tab %ld compact edge Back cancelled distance=%.0f velocity=%.0f",
+                  (long)self.apollo_tabIndex, distance, velocity);
+    }
+}
+
+- (void)apollo_compactPrimaryPopGestureChanged:(UIGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateEnded &&
+        gesture.state != UIGestureRecognizerStateCancelled &&
+        gesture.state != UIGestureRecognizerStateFailed) return;
+
+    void (^inspectSettledStack)(BOOL) = ^(BOOL cancelled) {
+        if (!self->_apollo_compactDetailChromeActive) return;
+        if (cancelled) {
+            ApolloLog(@"[PaneSplit] tab %ld native compact pop cancelled; kept detail",
+                      (long)self.apollo_tabIndex);
+            return;
+        }
+        if (self.apollo_primaryNav.topViewController != self->_apollo_compactPrimaryAnchor) return;
+        [self apollo_performCrossColumnNavigationTransaction:^{
+            [self apollo_clearDetailColumn];
+        }];
+        ApolloLog(@"[PaneSplit] tab %ld compact edge Back returned to primary and cleared detail",
+                  (long)self.apollo_tabIndex);
+    };
+    id<UIViewControllerTransitionCoordinator> coordinator = self.apollo_primaryNav.transitionCoordinator;
+    if (coordinator) {
+        [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            inspectSettledStack(context.isCancelled);
+        }];
+    } else {
+        // Non-interactive/programmatic paths can deliver the recognizer terminal
+        // state after the coordinator has already detached.
+        dispatch_async(dispatch_get_main_queue(), ^{ inspectSettledStack(NO); });
+    }
 }
 
 #pragma mark - UISplitViewControllerDelegate
+
+- (void)splitViewController:(UISplitViewController *)svc
+    willChangeToDisplayMode:(UISplitViewControllerDisplayMode)displayMode {
+    ApolloLog(@"[PaneDisplay] tab %ld display transition %ld -> %ld collapsed=%d",
+              (long)self.apollo_tabIndex, (long)self.displayMode,
+              (long)displayMode, self.isCollapsed);
+    // Remove a no-longer-valid recovery item synchronously. The item for a new
+    // SecondaryOnly state is installed only after UIKit resolves the transition,
+    // so it cannot be tapped while columns are still moving.
+    if (displayMode != UISplitViewControllerDisplayModeSecondaryOnly) {
+        [self apollo_removeShowPrimaryItem];
+    }
+    __weak ApolloPaneSplitViewController *weakSelf = self;
+    id<UIViewControllerTransitionCoordinator> coordinator = svc.transitionCoordinator;
+    if (coordinator) {
+        [coordinator animateAlongsideTransition:nil
+            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf apollo_resolvedDisplayStateMayHaveChanged];
+                });
+            }];
+    } else {
+        [self apollo_scheduleShowPrimaryItemRefresh];
+    }
+}
+
+- (void)apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:(NSUInteger)generation
+                                             nilObservations:(NSUInteger)nilObservations {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (!self->_apollo_topologyMutationInProgress ||
+            self->_apollo_topologyMutationGeneration != generation) return;
+        // A real collapse/expansion delegate callback clears this in @finally.
+        // If a split coordinator is still alive, wait for it rather than
+        // mistaking an ordinary child-navigation coordinator for topology.
+        if (self.transitionCoordinator) {
+            [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:generation
+                                                        nilObservations:0];
+            return;
+        }
+        // UIKit can ask for policy just before attaching its coordinator. Two
+        // consecutive coordinator-free samples avoid releasing the gate in
+        // that hand-off gap, while still recovering an abandoned policy call.
+        if (nilObservations == 0) {
+            [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:generation
+                                                        nilObservations:1];
+            return;
+        }
+        self->_apollo_topologyMutationInProgress = NO;
+        ApolloLog(@"[PaneTransition] tab %ld released abandoned topology gate collapsed=%d",
+                  (long)self.apollo_tabIndex, self.isCollapsed);
+        [self apollo_navigationTransitionDidSettle];
+    });
+}
 
 // Collapsing to compact (Slide Over, a narrow Stage Manager window, portrait on
 // a small iPad) must land on today's single-stack app. Surface the detail
@@ -726,12 +3374,36 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 // collapse into a "No Post Selected" screen with their feed hidden behind it.
 - (UISplitViewControllerColumn)splitViewController:(UISplitViewController *)svc
         topColumnForCollapsingToProposedTopColumn:(UISplitViewControllerColumn)proposedTopColumn {
+    _apollo_topologyMutationInProgress = YES;
+    NSUInteger topologyGeneration = ++_apollo_topologyMutationGeneration;
+    // If UIKit asks for a collapse policy but abandons the transition, neither
+    // didCollapse nor didExpand is guaranteed. Release an orphaned gate once the
+    // next run-loop observes no split coordinator and no collapsed topology.
+    [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:topologyGeneration
+                                                nilObservations:0];
+    _apollo_preCollapsePrimaryStack = [self.apollo_primaryNav.viewControllers copy];
+    _apollo_postCollapsePrimaryBridgeStack = nil;
     // Land on the deepest column the user has actually reached, so collapsing
     // feels like the single stack they navigated rather than a jump backwards.
     if (!self.apollo_detailIsEmpty) {
+        // Capture the last real list controller before UIKit appends its bridge
+        // controller. It is the native target for compact cross-column Back.
+        _apollo_compactPrimaryAnchor = self.apollo_primaryNav.topViewController;
+        _apollo_compactPrimaryReturnStack = [_apollo_preCollapsePrimaryStack copy];
         ApolloLog(@"[PaneSplit] tab %ld collapsing onto secondary", (long)self.apollo_tabIndex);
         return UISplitViewControllerColumnSecondary;
     }
+    _apollo_compactPrimaryAnchor = nil;
+    _apollo_compactPrimaryReturnStack = nil;
+    _apollo_postCollapsePrimaryBridgeStack = nil;
+    _apollo_expectedCompactPrimaryRestoreStack = nil;
+    _apollo_compactPrimaryRestoreInProgress = NO;
+    _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+    _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+    _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+    _apollo_knownUIKitCompactPrimaryTransientStack = nil;
+    _apollo_expectUIKitExpansionPrimaryMutation = NO;
+    ++_apollo_compactPrimaryRestoreGeneration;
     ApolloLog(@"[PaneSplit] tab %ld collapsing onto primary", (long)self.apollo_tabIndex);
     return UISplitViewControllerColumnPrimary;
 }
@@ -740,6 +3412,8 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
 // placeholder along with them. Strip it afterwards rather than trying to
 // predict the merge: the result is the same whichever way UIKit combines them.
 - (void)splitViewControllerDidCollapse:(UISplitViewController *)svc {
+    [self apollo_removeShowPrimaryItem];
+    @try {
     // UIKit merges onto whichever navigation controller survived as the top
     // column, which is not necessarily the primary one.
     UINavigationController *nav = self.apollo_primaryNav;
@@ -756,18 +3430,148 @@ static BOOL ApolloPaneStackIsPlaceholderOnly(UINavigationController *nav) {
         ApolloLog(@"[PaneSplit] tab %ld collapsed; stripped %lu placeholder(s)",
                   (long)self.apollo_tabIndex, (unsigned long)(stack.count - cleaned.count));
     }
+
+    // With an empty secondary, iPadOS 26 sometimes resets a primary navigation
+    // stack such as [RedditList, Posts] to [RedditList] during its column merge.
+    // Restore only a strict captured prefix: a different live shape represents
+    // real application navigation and must win.
+    NSArray<UIViewController *> *capturedPrimary = _apollo_preCollapsePrimaryStack;
+    NSArray<UIViewController *> *livePrimary = self.apollo_primaryNav.viewControllers;
+    BOOL liveIsCapturedPrefix = livePrimary.count < capturedPrimary.count;
+    for (NSUInteger index = 0; liveIsCapturedPrefix && index < livePrimary.count; index++) {
+        liveIsCapturedPrefix = livePrimary[index] == capturedPrimary[index];
+    }
+    if (self.apollo_detailIsEmpty && liveIsCapturedPrefix) {
+        @try {
+            [self apollo_setPrimaryViewControllers:capturedPrimary];
+            ApolloLog(@"[PaneSplit] tab %ld collapsed; restored primary depth %lu -> %lu",
+                      (long)self.apollo_tabIndex, (unsigned long)livePrimary.count,
+                      (unsigned long)capturedPrimary.count);
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PaneSplit] tab %ld failed restoring collapsed primary stack: %@",
+                      (long)self.apollo_tabIndex, exception);
+        }
+    }
+    if (!self.apollo_detailIsEmpty) {
+        NSArray<UIViewController *> *capturedReturn = _apollo_compactPrimaryReturnStack;
+        NSArray<UIViewController *> *postCollapsePrimary = self.apollo_primaryNav.viewControllers;
+        if (capturedReturn.count > 0 && postCollapsePrimary.count > capturedReturn.count &&
+            ApolloPaneStackStartsWithIdentityStack(postCollapsePrimary, capturedReturn)) {
+            // Capture UIKit's exact bridge identity before user navigation can
+            // append anything. Clear may remove this precise shape later, but
+            // must never mistake an arbitrary newer suffix for bridge chrome.
+            _apollo_postCollapsePrimaryBridgeStack = [postCollapsePrimary copy];
+        }
+        [self apollo_activateCompactDetailChrome];
+    }
+    // The snapshot exists only to repair UIKit's synchronous collapse result.
+    // Keeping it for the entire compact session would retain controllers the
+    // user subsequently pops or replaces.
+        _apollo_preCollapsePrimaryStack = nil;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneSplit] tab %ld collapse reconciliation failed safely: %@",
+                  (long)self.apollo_tabIndex, exception);
+    } @finally {
+        _apollo_topologyMutationInProgress = NO;
+        [self apollo_scheduleShowPrimaryItemRefresh];
+        [self apollo_navigationTransitionDidSettle];
+    }
 }
 
 // Expanding back to regular width. The detail column may have been emptied
 // entirely by the collapse merge, so restore its placeholder; without a root
 // view controller the column renders as a black rectangle.
 - (void)splitViewControllerDidExpand:(UISplitViewController *)svc {
+    // A compact Back/clear may have already committed the full primary stack,
+    // while UIKit's asynchronous showColumn: merge is still temporarily
+    // presenting only a prefix. Expanding in that narrow window invalidates the
+    // compact-only callback below, so carry its exact expected stack into this
+    // reconciliation instead of discarding the only copy of the user's path.
+    BOOL ownsPendingCompactPrimaryRestore = _apollo_compactPrimaryRestoreInProgress &&
+        _apollo_primaryNavigationMutationGeneration ==
+            _apollo_compactPrimaryRestoreMutationGeneration;
+    NSArray<UIViewController *> *pendingCompactPrimaryRestore =
+        ownsPendingCompactPrimaryRestore
+            ? [_apollo_expectedCompactPrimaryRestoreStack copy] : nil;
+    ++_apollo_topologyMutationGeneration;
+    NSUInteger expansionRestoreGeneration = ++_apollo_compactPrimaryRestoreGeneration;
+    _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+    BOOL settlesPendingCompactRestore = pendingCompactPrimaryRestore.count > 0;
+    _apollo_compactPrimaryRestoreInProgress = settlesPendingCompactRestore;
+    _apollo_expectedCompactPrimaryRestoreStack = settlesPendingCompactRestore
+        ? pendingCompactPrimaryRestore : nil;
+    _apollo_expectUIKitExpansionPrimaryMutation = settlesPendingCompactRestore;
+    if (settlesPendingCompactRestore &&
+        _apollo_knownUIKitCompactPrimaryTransientStack.count > 0) {
+        // Expansion is a fresh UIKit topology transaction. Even if the old
+        // generation had just revoked its late-write grace and was waiting for
+        // the final repair sample, this generation can publish the same merge
+        // once more after its own coordinator detaches. Re-arm the exact-only
+        // grant for that new owner instead of misclassifying its write as app
+        // navigation.
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = YES;
+    } else if (settlesPendingCompactRestore) {
+        // The old generation may have reached its post-grace final-sample
+        // window before ever seeing UIKit's first merge. Expansion creates a
+        // new topology owner, so re-arm the bounded initial strict-prefix slot
+        // as well; otherwise its first ambient-signal-free setter is mistaken
+        // for app navigation and the list column collapses to its root.
+        _apollo_expectUIKitCompactPrimaryStackReplacement = YES;
+    }
+    if (!settlesPendingCompactRestore) {
+        _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+        _apollo_lateUIKitCompactPrimaryStableObservations = 0;
+        _apollo_knownUIKitCompactPrimaryTransientStack = nil;
+    }
+    _apollo_topologyMutationInProgress = YES;
+    @try {
+    if (_apollo_compactDetailChromeActive) {
+        [self.apollo_primaryNav setNavigationBarHidden:_apollo_primaryNavBarWasHiddenBeforeCompact animated:NO];
+        [self.apollo_detailNav setNavigationBarHidden:_apollo_detailNavBarWasHiddenBeforeCompact animated:NO];
+        [self apollo_resetCompactDetailChromeState];
+        ApolloLog(@"[PaneSplit] tab %ld expanded; restored regular column chrome",
+                  (long)self.apollo_tabIndex);
+    } else {
+        _apollo_compactPrimaryAnchor = nil;
+    }
+    [self apollo_migrateCompactLogicalStackIfNeeded];
     if (self.apollo_detailNav.viewControllers.count == 0) {
         [self.apollo_detailNav setViewControllers:@[
             [[ApolloPaneDetailPlaceholderViewController alloc] initWithMessage:self.apollo_emptyMessage
                                                                    symbolName:self.apollo_emptySymbol]
         ] animated:NO];
         ApolloLog(@"[PaneSplit] tab %ld expanded; restored detail placeholder", (long)self.apollo_tabIndex);
+    }
+        _apollo_preCollapsePrimaryStack = nil;
+        _apollo_compactPrimaryReturnStack = nil;
+        _apollo_postCollapsePrimaryBridgeStack = nil;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PaneSplit] tab %ld expansion reconciliation failed safely: %@",
+                  (long)self.apollo_tabIndex, exception);
+        if (self.apollo_detailNav.viewControllers.count == 0) {
+            @try {
+                [self.apollo_detailNav setViewControllers:@[
+                    [[ApolloPaneDetailPlaceholderViewController alloc]
+                        initWithMessage:self.apollo_emptyMessage symbolName:self.apollo_emptySymbol]
+                ] animated:NO];
+            } @catch (NSException *recoveryException) {
+                ApolloLog(@"[PaneSplit] tab %ld expansion placeholder recovery failed: %@",
+                          (long)self.apollo_tabIndex, recoveryException);
+            }
+        }
+    } @finally {
+        _apollo_preCollapsePrimaryStack = nil;
+        _apollo_compactPrimaryReturnStack = nil;
+        _apollo_postCollapsePrimaryBridgeStack = nil;
+        _apollo_topologyMutationInProgress = NO;
+        [self apollo_scheduleShowPrimaryItemRefresh];
+        if (settlesPendingCompactRestore) {
+            [self apollo_scheduleCompactPrimaryRestoreReconciliation:
+                expansionRestoreGeneration observations:0];
+        } else {
+            [self apollo_navigationTransitionDidSettle];
+        }
     }
 }
 


### PR DESCRIPTION
Keep list/detail ownership and forward history coherent across compact transitions, external stack mutations, and scene entry points. Add atomic installation rollback and route adapters.

Stacked on `je/ipad-02-containers`; review this PR against that base.

Validation: Simulator target compiled and linked. Compact migration and cross-column routing are intentionally reviewed together because they share ownership state.

Part of the replacement stack for #886. The complete runtime stack remains experimental and opt-in. These draft slices are for review in order; do not ship an intermediate navigation implementation. Foldable/resizable-phone support is a separate follow-up. Existing device-only and performance validation gaps remain recorded in the validation PR.

Review order: #1053 → #1054 → #1055 → #1056 → #1057 → #1058; resizable iPhone support: #1059.
