### PR TITLE
iPad panes 3/4: selection, lazy loading and tab coordination

### DIFF
--- a/src/ApolloAutoHideTabBar.h
+++ b/src/ApolloAutoHideTabBar.h
@@ -1,0 +1,12 @@
+// ApolloAutoHideTabBar.h
+//
+// The shipping module has no public API. Simulator builds expose one bounded
+// scan probe so the allocation-free tab-navigation fast paths can be verified
+// without putting diagnostics in production scroll callbacks.
+
+#import <Foundation/Foundation.h>
+
+#if APOLLO_SIM_BUILD
+NSString *ApolloAutoHideTabBarSimScanStatus(NSUInteger iterations);
+NSString *ApolloAutoHideTabBarSimSetPolicy(BOOL enabled);
+#endif

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -3,9 +3,12 @@
 #import <math.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import "ApolloAutoHideTabBar.h"
 #import "ApolloCommon.h"
 #import "ApolloListLayoutSupport.h"
 #import "ApolloState.h"
+#import "ipad/ApolloPaneLayout.h"
+#import "ipad/ApolloPaneSplitViewController.h"
 #import "UserDefaultConstants.h"
 
 // MARK: - Tab Bar Auto-Hide Reveal Fix
@@ -278,18 +281,135 @@ static BOOL ApolloNavWantsNativeTabBarMinimize(UINavigationController *nav) {
     return nav.hidesBarsOnSwipe;
 }
 
-static BOOL ApolloTabBarControllerWantsNativeMinimize(UITabBarController *tbc) {
-    if (!tbc) return NO;
-    for (UIViewController *child in tbc.viewControllers) {
-        // Every column, not just one: with the iPad pane layout a tab holds
-        // more than one navigation controller, and any of them wanting the
-        // native minimize behavior is enough.
+// This predicate sits directly in UIScrollView.setContentOffset: while Mode B
+// is enabled. The generic shared enumerator returns a newly-created NSArray for
+// every tab child, which previously meant at least one autoreleased allocation
+// per content-offset update on iPhone and several mutable/immutable arrays per
+// update on iPad. Keep the two real app topologies allocation-free and reserve
+// the generic enumerator for an unrelated UISplitViewController fallback.
+#if APOLLO_SIM_BUILD
+static NSUInteger sApolloAutoHideDirectTabScans = 0;
+static NSUInteger sApolloAutoHidePaneTabScans = 0;
+static NSUInteger sApolloAutoHideGenericFallbackScans = 0;
+#endif
+
+static BOOL ApolloTabChildWantsNativeMinimize(UIViewController *child) {
+    if (!child) return NO;
+
+    if ([child isKindOfClass:[UINavigationController class]]) {
+#if APOLLO_SIM_BUILD
+        sApolloAutoHideDirectTabScans++;
+#endif
+        return ApolloNavWantsNativeTabBarMinimize((UINavigationController *)child);
+    }
+
+    if (ApolloPaneLayoutActive() &&
+        [child isKindOfClass:[ApolloPaneSplitViewController class]]) {
+#if APOLLO_SIM_BUILD
+        sApolloAutoHidePaneTabScans++;
+#endif
+        ApolloPaneSplitViewController *pane = (ApolloPaneSplitViewController *)child;
+        UINavigationController *primary =
+            [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+        if (ApolloNavWantsNativeTabBarMinimize(primary)) return YES;
+        UINavigationController *detail =
+            [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+        return detail != primary && ApolloNavWantsNativeTabBarMinimize(detail);
+    }
+
+    if ([child isKindOfClass:[UISplitViewController class]]) {
+#if APOLLO_SIM_BUILD
+        sApolloAutoHideGenericFallbackScans++;
+#endif
         for (UINavigationController *nav in ApolloAllNavigationControllersForTabChild(child)) {
             if (ApolloNavWantsNativeTabBarMinimize(nav)) return YES;
         }
+        return NO;
+    }
+
+    // Plain tab children are rare in Apollo, but this preserves the shared
+    // helper's stock fallback without creating a one-element array.
+    UINavigationController *nav = child.navigationController;
+#if APOLLO_SIM_BUILD
+    sApolloAutoHideDirectTabScans++;
+#endif
+    return ApolloNavWantsNativeTabBarMinimize(nav);
+}
+
+static BOOL ApolloTabBarControllerWantsNativeMinimize(UITabBarController *tbc) {
+    if (!tbc) return NO;
+    for (UIViewController *child in tbc.viewControllers) {
+        if (ApolloTabChildWantsNativeMinimize(child)) return YES;
     }
     return NO;
 }
+
+#if APOLLO_SIM_BUILD
+NSString *ApolloAutoHideTabBarSimScanStatus(NSUInteger iterations) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UITabBarController *tbc = [controller isKindOfClass:[UITabBarController class]]
+        ? (UITabBarController *)controller : nil;
+    if (!tbc) return @"no tab bar controller pass=0";
+
+    iterations = MIN(MAX(iterations, 1), 100000);
+    sApolloAutoHideDirectTabScans = 0;
+    sApolloAutoHidePaneTabScans = 0;
+    sApolloAutoHideGenericFallbackScans = 0;
+    CFTimeInterval started = CACurrentMediaTime();
+    BOOL wanted = NO;
+    for (NSUInteger index = 0; index < iterations; index++) {
+        wanted = ApolloTabBarControllerWantsNativeMinimize(tbc);
+    }
+    CFTimeInterval elapsed = CACurrentMediaTime() - started;
+    BOOL pane = ApolloPaneLayoutActive();
+    BOOL pass = sApolloAutoHideGenericFallbackScans == 0 &&
+        (pane ? sApolloAutoHidePaneTabScans > 0 : sApolloAutoHideDirectTabScans > 0);
+    return [NSString stringWithFormat:
+        @"iterations=%lu pane=%d directScans=%lu paneScans=%lu "
+         "genericFallbackArrayScans=%lu elapsedMs=%.3f checksum=%d pass=%d",
+        (unsigned long)iterations, pane,
+        (unsigned long)sApolloAutoHideDirectTabScans,
+        (unsigned long)sApolloAutoHidePaneTabScans,
+        (unsigned long)sApolloAutoHideGenericFallbackScans,
+        elapsed * 1000.0, wanted, pass];
+}
+
+NSString *ApolloAutoHideTabBarSimSetPolicy(BOOL enabled) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UITabBarController *tbc = [controller isKindOfClass:[UITabBarController class]]
+        ? (UITabBarController *)controller : nil;
+    if (!tbc) return @"policy unavailable pass=0";
+    for (UIViewController *child in tbc.viewControllers) {
+        if ([child isKindOfClass:[UINavigationController class]]) {
+            ((UINavigationController *)child).hidesBarsOnSwipe = enabled;
+            continue;
+        }
+        if (ApolloPaneLayoutActive() &&
+            [child isKindOfClass:[ApolloPaneSplitViewController class]]) {
+            ApolloPaneSplitViewController *pane = (ApolloPaneSplitViewController *)child;
+            UINavigationController *primary =
+                [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+            UINavigationController *detail =
+                [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+            primary.hidesBarsOnSwipe = enabled;
+            if (detail != primary) detail.hidesBarsOnSwipe = enabled;
+            continue;
+        }
+        for (UINavigationController *navigationController in
+                ApolloAllNavigationControllersForTabChild(child)) {
+            navigationController.hidesBarsOnSwipe = enabled;
+        }
+    }
+    BOOL wanted = ApolloTabBarControllerWantsNativeMinimize(tbc);
+    NSInteger behavior = ApolloCurrentMinimizeBehavior(tbc);
+    BOOL pass = wanted == enabled && behavior == (enabled
+        ? ApolloTabBarMinimizeBehaviorOnScrollDown
+        : ApolloTabBarMinimizeBehaviorNever);
+    return [NSString stringWithFormat:
+        @"enabled=%d wanted=%d behavior=%ld pane=%d pass=%d", enabled, wanted,
+        (long)behavior, ApolloPaneLayoutActive(), pass];
+}
+#endif
 
 BOOL ApolloTabBarIsHideOnScrollPresentationOwned(UITabBar *tabBar) {
     return [objc_getAssociatedObject(tabBar,

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -169,6 +169,11 @@ BOOL ApolloNavTransitionInFlight(void);
 // UI is still coming up (e.g. cold launch from a URL) — callers should retry.
 UIViewController *ApolloMainTabBarController(void);
 
+// Scene-scoped form for actions that originate from a UIScene callback or a
+// view already attached to a window. Passing nil uses the same deterministic
+// foreground/key-scene selection as ApolloMainTabBarController().
+UIViewController *ApolloMainTabBarControllerForScene(UIWindowScene *scene);
+
 // The navigation controller holding a tab's root stack.
 //
 // In the stock layout this is the identity function — a UITabBarController's

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1315,23 +1315,72 @@ static UIViewController *ApolloTabBarControllerIvarOn(id object) {
     }
 }
 
-UIViewController *ApolloMainTabBarController(void) {
-    UIApplication *application = UIApplication.sharedApplication;
+static UIViewController *ApolloTabBarControllerForWindowScene(UIWindowScene *scene) {
+    if (![scene isKindOfClass:UIWindowScene.class]) return nil;
 
-    for (UIScene *scene in application.connectedScenes) {
-        if (![scene isKindOfClass:UIWindowScene.class]) continue;
+    UIViewController *fromDelegate = ApolloTabBarControllerIvarOn(scene.delegate);
+    if (fromDelegate) return fromDelegate;
 
-        UIViewController *fromDelegate = ApolloTabBarControllerIvarOn([(UIWindowScene *)scene delegate]);
-        if (fromDelegate) return fromDelegate;
-
-        for (UIWindow *window in [(UIWindowScene *)scene windows]) {
-            UIViewController *root = window.rootViewController;
-            if ([root isKindOfClass:UITabBarController.class]) return root;
-            if ([root.presentedViewController isKindOfClass:UITabBarController.class]) return root.presentedViewController;
+    // Prefer the key window, then visible normal-level windows. A scene may
+    // also own transient keyboard/alert windows whose roots are unrelated to
+    // Apollo's tab hierarchy.
+    NSMutableArray<UIWindow *> *ordered = [NSMutableArray array];
+    for (UIWindow *window in scene.windows) if (window.isKeyWindow) [ordered addObject:window];
+    for (UIWindow *window in scene.windows) {
+        if (![ordered containsObject:window] && !window.hidden &&
+            window.windowLevel == UIWindowLevelNormal) [ordered addObject:window];
+    }
+    for (UIWindow *window in scene.windows) {
+        if (![ordered containsObject:window]) [ordered addObject:window];
+    }
+    for (UIWindow *window in ordered) {
+        UIViewController *root = window.rootViewController;
+        if ([root isKindOfClass:UITabBarController.class]) return root;
+        if ([root.presentedViewController isKindOfClass:UITabBarController.class]) {
+            return root.presentedViewController;
         }
     }
+    return nil;
+}
 
+UIViewController *ApolloMainTabBarControllerForScene(UIWindowScene *originatingScene) {
+    UIViewController *originating = ApolloTabBarControllerForWindowScene(originatingScene);
+    if (originating) return originating;
+
+    UIApplication *application = UIApplication.sharedApplication;
+    NSArray<UIScene *> *scenes = application.connectedScenes.allObjects;
+
+    // Prefer a foreground-active scene with a key window. Enumerating the
+    // connectedScenes set directly is unordered and can send an action into a
+    // background or external-display window when more than one scene exists.
+    for (UIScene *candidate in scenes) {
+        if (![candidate isKindOfClass:UIWindowScene.class] ||
+            candidate.activationState != UISceneActivationStateForegroundActive) continue;
+        UIWindowScene *windowScene = (UIWindowScene *)candidate;
+        BOOL hasKeyWindow = NO;
+        for (UIWindow *window in windowScene.windows) {
+            if (window.isKeyWindow) { hasKeyWindow = YES; break; }
+        }
+        if (!hasKeyWindow) continue;
+        UIViewController *controller = ApolloTabBarControllerForWindowScene(windowScene);
+        if (controller) return controller;
+    }
+    for (UIScene *candidate in scenes) {
+        if (![candidate isKindOfClass:UIWindowScene.class] ||
+            candidate.activationState != UISceneActivationStateForegroundActive) continue;
+        UIViewController *controller = ApolloTabBarControllerForWindowScene((UIWindowScene *)candidate);
+        if (controller) return controller;
+    }
+    for (UIScene *candidate in scenes) {
+        if (![candidate isKindOfClass:UIWindowScene.class]) continue;
+        UIViewController *controller = ApolloTabBarControllerForWindowScene((UIWindowScene *)candidate);
+        if (controller) return controller;
+    }
     return ApolloTabBarControllerIvarOn(application.delegate);
+}
+
+UIViewController *ApolloMainTabBarController(void) {
+    return ApolloMainTabBarControllerForScene(nil);
 }
 
 // ApolloCommon is included by nearly every file, so it must not import the pane

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -234,6 +234,25 @@ static void PiPClaimMixablePlaybackSession(void) {
     [session setActive:YES withOptions:0 error:nil];
 }
 
+// Return the top edge of a view only when it is actually visible and occludes
+// the bottom edge of the app window at the video's horizontal midpoint. A tab
+// bar can stay attached to a window while hidden, translated away, or
+// repurposed as iPadOS's top/side tab sidebar; testing `tabBar.window` alone
+// therefore subtracts phantom chrome. Testing the x coordinate also prevents a
+// vertical sidebar that reaches the bottom from shrinking the whole window.
+static BOOL PiPBottomOcclusionTopForView(UIView *view, UIWindow *window,
+                                         CGFloat horizontalPoint, CGFloat *topOut) {
+    if (!view || !window || view.window != window || view.hidden || view.alpha <= 0.01) return NO;
+    CGRect frame = [view convertRect:view.bounds toView:window];
+    CGRect visible = CGRectIntersection(frame, window.bounds);
+    if (CGRectIsNull(visible) || CGRectIsEmpty(visible)) return NO;
+    CGFloat windowBottom = CGRectGetMaxY(window.bounds);
+    if (CGRectGetMaxY(visible) < windowBottom - 1.0) return NO;
+    if (!CGRectContainsPoint(visible, CGPointMake(horizontalPoint, windowBottom - 0.5))) return NO;
+    if (topOut) *topOut = CGRectGetMinY(visible);
+    return YES;
+}
+
 // Did the user turn this player's sound on? player.muted alone can't answer:
 // Apollo's fresh comments/fullscreen players keep AVPlayer's default
 // muted == NO (silenced by the Ambient session), so a muted-sounding video can
@@ -269,9 +288,8 @@ static BOOL PiPIsVideoMidpointVisible(id videoNode, id cellNode) {
     UIViewController *rootVC = window.rootViewController;
     if ([rootVC isKindOfClass:[UITabBarController class]]) {
         UITabBarController *tab = (UITabBarController *)rootVC;
-        if (tab.tabBar.window) {
-            bottomY -= tab.tabBar.bounds.size.height;
-        }
+        CGFloat tabBarTop = 0.0;
+        if (PiPBottomOcclusionTopForView(tab.tabBar, window, mid.x, &tabBarTop)) bottomY = tabBarTop;
         // Unwraps the iPad pane layout's split view controller; identity
         // otherwise. Any column's bar gives the same top inset — they are laid
         // out at the same y — so the primary column's is enough.

--- a/src/ApolloQuickActions.xm
+++ b/src/ApolloQuickActions.xm
@@ -137,15 +137,16 @@ static BOOL ApolloQuickActionsOpenHomeFeed(id tabBarController) {
     }
 }
 
-static BOOL ApolloQuickActionsPerformNow(NSString *action) {
-    id tabBarController = ApolloMainTabBarController();
+static BOOL ApolloQuickActionsPerformNow(NSString *action, UIWindowScene *originatingScene) {
+    id tabBarController = ApolloMainTabBarControllerForScene(originatingScene);
     if (!tabBarController) {
         return NO;
     }
 
     // "settings/<route-id>" pushes a Reborn settings screen (deep link).
     if ([action hasPrefix:@"settings/"]) {
-        return ApolloSettingsRouteOpenNow([action substringFromIndex:@"settings/".length]);
+        return ApolloSettingsRouteOpenNowInScene([action substringFromIndex:@"settings/".length],
+                                                  originatingScene);
     }
 
     // "home" opens the actual front-page feed (posts), not the picker list.
@@ -181,8 +182,9 @@ static BOOL ApolloQuickActionsPerformNow(NSString *action) {
     return YES;
 }
 
-static BOOL ApolloQuickActionsOpenModernMailboxNow(NSDictionary<NSString *, NSString *> *route) {
-    id tabBarController = ApolloMainTabBarController();
+static BOOL ApolloQuickActionsOpenModernMailboxNow(NSDictionary<NSString *, NSString *> *route,
+                                                    UIWindowScene *originatingScene) {
+    id tabBarController = ApolloMainTabBarControllerForScene(originatingScene);
     if (!tabBarController) return NO;
 
     if ([tabBarController respondsToSelector:@selector(goToInboxTab)]) {
@@ -217,36 +219,38 @@ static BOOL ApolloQuickActionsOpenModernMailboxNow(NSDictionary<NSString *, NSSt
     return YES;
 }
 
-static void ApolloQuickActionsPerformWithRetry(NSString *action, NSUInteger attempt) {
-    if (ApolloQuickActionsPerformNow(action)) return;
+static void ApolloQuickActionsPerformWithRetry(NSString *action, UIWindowScene *originatingScene,
+                                               NSUInteger attempt) {
+    if (ApolloQuickActionsPerformNow(action, originatingScene)) return;
     if (attempt >= 8) {
         ApolloLog(@"[QuickActions] Gave up performing %@", action);
         return;
     }
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        ApolloQuickActionsPerformWithRetry(action, attempt + 1);
+        ApolloQuickActionsPerformWithRetry(action, originatingScene, attempt + 1);
     });
 }
 
 static void ApolloQuickActionsOpenModernMailboxWithRetry(NSDictionary<NSString *, NSString *> *route,
+                                                         UIWindowScene *originatingScene,
                                                          NSUInteger attempt) {
-    if (ApolloQuickActionsOpenModernMailboxNow(route)) return;
+    if (ApolloQuickActionsOpenModernMailboxNow(route, originatingScene)) return;
     if (attempt >= 8) {
         ApolloLog(@"[QuickActions] Gave up opening modern mailbox notification destination");
         return;
     }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        ApolloQuickActionsOpenModernMailboxWithRetry(route, attempt + 1);
+        ApolloQuickActionsOpenModernMailboxWithRetry(route, originatingScene, attempt + 1);
     });
 }
 
-static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
+static BOOL ApolloQuickActionsHandleURL(NSURL *url, UIWindowScene *originatingScene) {
     NSDictionary<NSString *, NSString *> *mailboxRoute = ApolloModernMailboxRouteFromURL(url);
     if (mailboxRoute) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            ApolloQuickActionsOpenModernMailboxWithRetry(mailboxRoute, 0);
+            ApolloQuickActionsOpenModernMailboxWithRetry(mailboxRoute, originatingScene, 0);
         });
         return YES;
     }
@@ -255,7 +259,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
     if (!action) return NO;
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        ApolloQuickActionsPerformWithRetry(action, 0);
+        ApolloQuickActionsPerformWithRetry(action, originatingScene, 0);
     });
     return YES;
 }
@@ -263,7 +267,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
 %hook _TtC6Apollo11AppDelegate
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options {
-    if (ApolloQuickActionsHandleURL(url)) {
+    if (ApolloQuickActionsHandleURL(url, nil)) {
         return YES;
     }
     return %orig(application, url, options);
@@ -280,7 +284,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
     }
 
     NSURL *url = rawURL.length > 0 ? [NSURL URLWithString:rawURL] : nil;
-    if (ApolloQuickActionsHandleURL(url)) {
+    if (ApolloQuickActionsHandleURL(url, nil)) {
         ApolloLog(@"[QuickActions] Handled modern mailbox APNs destination");
         if (completionHandler) completionHandler();
         return;
@@ -303,7 +307,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
     // The async hop makes this independent of Logos hook ordering: pane
     // installation will have completed before the first attempt runs.
     for (UIOpenURLContext *context in connectionOptions.URLContexts) {
-        if (ApolloQuickActionsHandleURL(context.URL)) {
+        if (ApolloQuickActionsHandleURL(context.URL, (UIWindowScene *)scene)) {
             ApolloLog(@"[QuickActions] Queued Reborn cold URL route");
         }
     }
@@ -315,7 +319,8 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
     if (!rawURL.length && [userInfo[@"url"] isKindOfClass:[NSString class]]) {
         rawURL = userInfo[@"url"];
     }
-    if (rawURL.length > 0 && ApolloQuickActionsHandleURL([NSURL URLWithString:rawURL])) {
+    if (rawURL.length > 0 && ApolloQuickActionsHandleURL([NSURL URLWithString:rawURL],
+                                                          (UIWindowScene *)scene)) {
         ApolloLog(@"[QuickActions] Queued Reborn cold notification route");
     }
 
@@ -323,7 +328,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
     NSString *injectedURL =
         NSProcessInfo.processInfo.environment[@"APOLLO_SIM_COLD_REBORN_URL"];
     if (injectedURL.length > 0 &&
-        ApolloQuickActionsHandleURL([NSURL URLWithString:injectedURL])) {
+        ApolloQuickActionsHandleURL([NSURL URLWithString:injectedURL], (UIWindowScene *)scene)) {
         ApolloLog(@"[QuickActions] Queued simulator-injected Reborn cold route");
     }
 #endif
@@ -343,7 +348,7 @@ static BOOL ApolloQuickActionsHandleURL(NSURL *url) {
             ApolloLog(@"[QuickActions] Failed reading URL context: %@", exception);
         }
 
-        if (ApolloQuickActionsHandleURL(url)) {
+        if (ApolloQuickActionsHandleURL(url, (UIWindowScene *)scene)) {
             handledAny = YES;
         } else if (context) {
             [unhandledContexts addObject:context];

--- a/src/ApolloThemeGalleryViewController.m
+++ b/src/ApolloThemeGalleryViewController.m
@@ -316,26 +316,32 @@ typedef void (^ApolloThemeGalleryAction)(NSString *slug);
 // Mirrors ApolloThemeManagerViewController's applyThemeTint/applyThemeToCell:
 // so the gallery browser reads as part of the same app the active theme is
 // painting, rather than a plain system-styled list dropped on top of it.
-// When no Apollo-Reborn custom theme is running, inherit the ambient Apollo
-// theme (stock themes like Solarized/Outrun included) by sampling the
-// presenting settings table — the same approach as the base
-// ApolloSettingsTableViewController / the Apollo Reborn settings screen —
-// instead of dropping to plain grey/black system colours.
+// When no Apollo-Reborn custom theme is running, use the canonical stock-theme
+// helpers first. Source-table inheritance alone is insufficient in the iPad
+// pane layout because a routed destination can be the root of a detail stack
+// and therefore have no themed table behind it.
 - (UIColor *)galleryThemeColorForToken:(ApolloThemeToken)token fallback:(UIColor *)fallback {
     UIColor *runtimeColor = ApolloThemeRuntimeColor(token);
     if (runtimeColor) return runtimeColor;
 
     switch (token) {
         case ApolloThemeTokenBackground: {
+            UIColor *effective = ApolloThemePageBackgroundColor();
+            if (effective) return effective;
             UITableView *source = ApolloInheritedSettingsThemeSourceTableView(self);
             return source.backgroundColor ?: fallback;
         }
         case ApolloThemeTokenSecondaryBackground:
         case ApolloThemeTokenTertiaryBackground:
-        case ApolloThemeTokenElevatedBackground:
+        case ApolloThemeTokenElevatedBackground: {
+            UIColor *effective = ApolloThemeCardBackgroundColor();
+            if (effective) return effective;
             return [self apollo_themeCellBackgroundColor];
+        }
         case ApolloThemeTokenSeparator:
         case ApolloThemeTokenOpaqueSeparator: {
+            UIColor *effective = ApolloThemeSeparatorColor();
+            if (effective) return effective;
             UITableView *source = ApolloInheritedSettingsThemeSourceTableView(self);
             return source.separatorColor ?: fallback;
         }

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -417,28 +417,33 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
         return ApolloThemeUIColorFromRGB([compiled rgbForToken:token mode:CurrentAppearanceMode(self.traitCollection)]);
     }
 
-    // No Apollo-Reborn custom theme active. Instead of hard-coding system
-    // colours (which would leave this screen grey/black even when a *stock*
-    // Apollo theme like Solarized or Outrun is applied), inherit the ambient
-    // Apollo theme the same way ApolloSettingsTableViewController /
-    // CustomAPIViewController do: sample the presenting Appearance settings
-    // table (which Apollo itself themes). This makes the Theme Manager and
-    // Gallery match the rest of Apollo's settings under any theme, stock or
-    // custom. Surface tokens come from the sampled table; text tokens keep
-    // system-semantic fallbacks, which adapt correctly on top of the inherited
-    // background — exactly as CustomAPIViewController uses labelColor /
-    // secondaryLabelColor.
+    // No Apollo-Reborn custom theme active. Prefer the canonical stock-theme
+    // helpers before sampling the previous navigation controller. In the iPad
+    // pane layout Theme Manager is the ROOT of the detail stack, so its
+    // predecessor is the blank detail placeholder rather than Appearance's
+    // table; source-only inheritance therefore fell through to UIKit's dark
+    // systemGroupedBackgroundColor (pure black) while the cards correctly used
+    // Apollo's dark grey. The helpers work regardless of which column owns the
+    // controller. Keep the source lookup as a fallback for an unknown/future
+    // stock theme.
     switch (token) {
         case ApolloThemeTokenBackground: {
+            UIColor *effective = ApolloThemePageBackgroundColor();
+            if (effective) return effective;
             UITableView *source = ApolloInheritedSettingsThemeSourceTableView(self);
             return source.backgroundColor ?: fallback;
         }
         case ApolloThemeTokenSecondaryBackground:
         case ApolloThemeTokenTertiaryBackground:
-        case ApolloThemeTokenElevatedBackground:
+        case ApolloThemeTokenElevatedBackground: {
+            UIColor *effective = ApolloThemeCardBackgroundColor();
+            if (effective) return effective;
             return [self apollo_themeCellBackgroundColor];
+        }
         case ApolloThemeTokenSeparator:
         case ApolloThemeTokenOpaqueSeparator: {
+            UIColor *effective = ApolloThemeSeparatorColor();
+            if (effective) return effective;
             UITableView *source = ApolloInheritedSettingsThemeSourceTableView(self);
             return source.separatorColor ?: fallback;
         }

--- a/src/ApolloVisionOSMultiwindow.xm
+++ b/src/ApolloVisionOSMultiwindow.xm
@@ -284,6 +284,25 @@ static NSURL *ApolloActiveDeepLink(void) {
 
 #pragma mark - New-window delivery
 
+// Diagnostics must describe the route without retaining subreddit names,
+// post IDs, comment IDs, usernames, or arbitrary query strings. Those values
+// are necessary for delivery but not for understanding whether scene routing
+// succeeded.
+static NSString *ApolloPrivateDestinationKind(NSURL *url) {
+    NSString *host = url.host.lowercaseString ?: @"";
+    NSArray<NSString *> *components = url.pathComponents;
+    if ([host hasSuffix:@"reddit.com"]) {
+        if ([components containsObject:@"comments"]) return @"reddit-post";
+        if ([components containsObject:@"r"]) return @"reddit-community";
+        if ([components containsObject:@"user"] || [components containsObject:@"u"]) {
+            return @"reddit-profile";
+        }
+        return @"reddit-root";
+    }
+    return [url.scheme.lowercaseString isEqualToString:@"apollo"]
+        ? @"apollo-route" : @"external-web";
+}
+
 // Hand a URL to a scene through Apollo's handoff entry point. The activity type
 // is the Foundation browsing-web constant, which is the type Apollo's activity
 // handler gates its webpageURL branch on.
@@ -297,7 +316,8 @@ static void ApolloDeliverURLToScene(UIWindowScene *scene, NSURL *url) {
     NSUserActivity *activity =
         [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
     activity.webpageURL = url;
-    ApolloLog(@"[VisionOSMultiwindow] handing %@ to the new scene", url.absoluteString);
+    ApolloLog(@"[VisionOSMultiwindow] handing destination=%@ to the new scene",
+              ApolloPrivateDestinationKind(url));
     [delegate scene:scene continueUserActivity:activity];
 }
 
@@ -306,8 +326,8 @@ static void ApolloDeliverURLToScene(UIWindowScene *scene, NSURL *url) {
 // unreliable; polling connectedScenes cannot miss.
 static void ApolloAwaitNewScene(NSHashTable<UIScene *> *existing, NSURL *url, int attemptsLeft) {
     if (attemptsLeft <= 0) {
-        ApolloLog(@"[VisionOSMultiwindow] no new scene appeared within 8s; %@ not delivered",
-                  url.absoluteString);
+        ApolloLog(@"[VisionOSMultiwindow] no new scene appeared within 8s; destination=%@ not delivered",
+                  ApolloPrivateDestinationKind(url));
         return;
     }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),

--- a/src/ipad/ApolloPaneInstall.xm
+++ b/src/ipad/ApolloPaneInstall.xm
@@ -396,9 +396,9 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     // Had this required `tabs`, the alternative would have been rebuilding
     // Apollo's tab model by hand, which is a far larger and more fragile change.
     //
-    // iOS 17 and earlier have no tab sidebar. Those keep the floating tab bar
-    // beside the two-column panes, which is a coherent, if less native, layout —
-    // the feature degrades rather than becoming unavailable.
+    // ApolloPaneLayoutSupported() gates production installation to iPadOS 18+
+    // so the experiment always gets this navigation model. Keep the fallback
+    // for defensive safety if this function is ever invoked directly.
     if (@available(iOS 18.0, *)) {
         UITabBarControllerMode originalMode = tabBarController.mode;
         @try {

--- a/src/ipad/ApolloPaneLayout.h
+++ b/src/ipad/ApolloPaneLayout.h
@@ -81,6 +81,17 @@ BOOL ApolloPaneNavigationControllerIsRegisteredToSplit(
     UINavigationController *navigationController,
     UISplitViewController *splitViewController);
 
+// Preserve a native UITableView row as the semantic owner of the detail route
+// that its selection is about to push. Most Apollo screens are captured by the
+// pane router's delegate hooks. A screen-specific owner that handles an
+// injected row and returns before calling Apollo's implementation must use this
+// handoff immediately before its push so the router can claim the same intent.
+// This is a no-op unless `sourceViewController` is in a live primary column.
+void ApolloPaneStageMasterTableSelectionIfNeeded(
+    UIViewController *sourceViewController,
+    UITableView *tableView,
+    NSIndexPath *indexPath);
+
 #if APOLLO_SIM_BUILD
 // Launch-time fault injection for the atomic installer. The implementation is
 // simulator-only, so production builds cannot accidentally acquire a failure

--- a/src/ipad/ApolloPaneLayout.m
+++ b/src/ipad/ApolloPaneLayout.m
@@ -16,6 +16,13 @@ BOOL ApolloPaneLayoutSupported(void) {
     static BOOL supported = NO;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
+        // The experiment's navigation model depends on UIKit's system tab
+        // sidebar. Earlier iPadOS releases can render the split columns, but
+        // retain Apollo's tab bar alongside them, which does not match the UI
+        // promised by the setting and has not received the same test coverage.
+        // Keep the production opt-in honest and conservative: iPadOS 18 is the
+        // first supported release, while Apollo's normal layout remains
+        // untouched everywhere else.
         if (@available(iOS 18.0, *)) {
             supported = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad);
         }
@@ -83,4 +90,23 @@ BOOL ApolloPaneNavigationControllerIsRegisteredToSplit(
     UISplitViewController *splitViewController) {
     if (!navigationController || !splitViewController || !sPaneNavigationOwners) return NO;
     return [sPaneNavigationOwners objectForKey:navigationController] == splitViewController;
+}
+
+void ApolloPaneStageMasterTableSelectionIfNeeded(
+    UIViewController *sourceViewController,
+    UITableView *tableView,
+    NSIndexPath *indexPath) {
+    if (!ApolloPaneLayoutActive() || !sourceViewController || !tableView || !indexPath) return;
+    ApolloPaneSplitViewController *pane =
+        (ApolloPaneSplitViewController *)ApolloPaneSplitControllerFor(sourceViewController);
+    UINavigationController *primary =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    if (!pane || sourceViewController.navigationController != primary) return;
+
+    id intent = [pane apollo_masterSelectionIntentFromSource:sourceViewController
+                                                     surface:tableView
+                                                   indexPath:indexPath
+                                              itemIdentifier:nil
+                                               identityOwner:nil];
+    [pane apollo_stageMasterSelectionIntent:intent];
 }

--- a/src/ipad/ApolloPaneRouter.xm
+++ b/src/ipad/ApolloPaneRouter.xm
@@ -297,6 +297,11 @@ static BOOL ApolloPaneReplaceDetailRoot(ApolloPaneSplitViewController *pane,
     }];
     if (!replacementSucceeded) return NO;
 
+    // Readable-width settings/forms must have their final safe-area insets
+    // before the first detail frame is committed. The ordinary pane geometry
+    // refresh is intentionally deferred and otherwise produces a visible
+    // full-width -> centered-width snap.
+    [pane apollo_prepareDetailControllerForDisplay:viewController];
     ApolloPaneClearForwardHistory(destination);
     [pane apollo_recordDetailBranchFromPrimarySource:sourceViewController];
     [pane apollo_commitMasterSelectionIntent:masterSelectionIntent
@@ -725,6 +730,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
         }
         if (pushSucceeded) {
             ApolloPaneApplyPostPushNavigationPolicy(navigationController, viewController, column);
+            if (navigationController ==
+                [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+                [pane apollo_prepareDetailControllerForDisplay:viewController];
+            }
         }
         ApolloLog(@"[PaneRouter] compact push %@ logicalColumn=%ld sourceDetail=%d succeeded=%d tab=%ld",
                   NSStringFromClass(viewController.class), (long)column, sourceBelongsToDetail,
@@ -761,6 +770,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
         // Unknown composers, login screens, settings descendants and modal-like
         // screens keep their exact native leading-item policy.
         ApolloPaneApplyPostPushNavigationPolicy(navigationController, viewController, column);
+        if (navigationController ==
+            [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+            [pane apollo_prepareDetailControllerForDisplay:viewController];
+        }
         return;
     }
 
@@ -771,6 +784,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
     if (!destination || destination == navigationController) {
         UIViewController *beforeTop = navigationController.topViewController;
         %orig;
+        if (column == ApolloPaneColumnSecondary &&
+            navigationController.topViewController == viewController) {
+            [pane apollo_prepareDetailControllerForDisplay:viewController];
+        }
         // Apollo rejects duplicate pushes. Reconcile after the call so a no-op
         // intent cannot erase detail whose primary context never changed.
         if (column != ApolloPaneColumnSecondary &&
@@ -869,6 +886,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
                                        beforeStack:beforeStack
                                           cancelled:YES];
     }
+    if (popped && navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        [pane apollo_prepareDetailControllerForDisplay:navigationController.topViewController];
+    }
     return popped;
 }
 
@@ -905,6 +926,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
                                        beforeStack:beforeStack
                                           cancelled:YES];
     }
+    if (popped.count > 0 && navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        [pane apollo_prepareDetailControllerForDisplay:navigationController.topViewController];
+    }
     return popped;
 }
 
@@ -940,6 +965,10 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
                                        beforeStack:beforeStack
                                           cancelled:YES];
     }
+    if (popped.count > 0 && navigationController ==
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        [pane apollo_prepareDetailControllerForDisplay:navigationController.topViewController];
+    }
     return popped;
 }
 
@@ -954,6 +983,9 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
         [pane apollo_primaryNavigationStackWasReplacedExternally:
             navigationController.viewControllers];
         [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:@"primary stack replacement"];
+    } else if (navigationController ==
+               [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        [pane apollo_prepareDetailControllerForDisplay:navigationController.topViewController];
     }
 }
 
@@ -968,6 +1000,9 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
         [pane apollo_primaryNavigationStackWasReplacedExternally:
             navigationController.viewControllers];
         [pane apollo_scheduleDetailReconciliationAfterPrimaryMutation:@"primary stack replacement"];
+    } else if (navigationController ==
+               [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+        [pane apollo_prepareDetailControllerForDisplay:navigationController.topViewController];
     }
 }
 

--- a/src/ipad/ApolloPaneSplitViewController.h
+++ b/src/ipad/ApolloPaneSplitViewController.h
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)apollo_performCrossColumnNavigationTransaction:(dispatch_block_t)navigation;
 - (void)apollo_navigationTransitionDidSettle;
 - (void)apollo_resolvedDisplayStateMayHaveChanged;
+- (void)apollo_prepareDetailControllerForDisplay:(UIViewController *)viewController;
 - (void)apollo_revealDetailAfterPrimarySelectionIfNeeded;
 
 // A selected row is part of the semantic primary -> detail branch on iPad.
@@ -136,6 +137,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)apollo_simResolvedLayoutState;
 - (BOOL)apollo_simActivateShowPrimaryItem;
 - (NSString *)apollo_simMasterSelectionState;
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset;
+- (void)apollo_simSetPreferredPrimaryColumnWidth:(CGFloat)width;
+- (NSString *)apollo_simPreferredPrimaryColumnWidthState;
+- (BOOL)apollo_simAdjustDivider:(NSString *)operation;
+- (NSString *)apollo_simThemeState;
 + (void)apollo_simRunDeallocatedSourceProbe;
 #endif
 

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -123,6 +123,9 @@ static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
 // fallbacks for the stock (no custom theme) case.
 @interface ApolloPaneDetailPlaceholderViewController : UIViewController
 - (instancetype)initWithMessage:(NSString *)message symbolName:(NSString *)symbolName;
+#if APOLLO_SIM_BUILD
+- (UIColor *)apollo_simIconTintColor;
+#endif
 @end
 
 @implementation ApolloPaneDetailPlaceholderViewController {
@@ -222,6 +225,12 @@ static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
     _iconView.tintColor = [accent colorWithAlphaComponent:0.45];
     _label.textColor = UIColor.secondaryLabelColor;
 }
+
+#if APOLLO_SIM_BUILD
+- (UIColor *)apollo_simIconTintColor {
+    return _iconView.tintColor;
+}
+#endif
 
 @end
 
@@ -327,11 +336,30 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
 @interface ApolloPaneColumnHostViewController : UIViewController
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
 @property (nonatomic, strong, readonly) UINavigationController *hostedNavigationController;
+- (void)apollo_scheduleListColumnGeometryRefresh;
+- (void)apollo_prepareReadableWidthForTopController;
+#if APOLLO_SIM_BUILD
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset;
+#endif
 @end
 
 @implementation ApolloPaneColumnHostViewController {
     NSLayoutConstraint *_topConstraint;
     NSLayoutConstraint *_bottomConstraint;
+    BOOL _geometryRefreshScheduled;
+    BOOL _geometryRefreshWaitingForTransition;
+    BOOL _hasResolvedGeometry;
+    CGFloat _lastResolvedTop;
+    CGFloat _lastResolvedBottom;
+    __weak UIViewController *_readableWidthViewController;
+    CGFloat _readableWidthBaseLeft;
+    CGFloat _readableWidthBaseRight;
+    CGFloat _readableWidthAppliedInset;
+#if APOLLO_SIM_BUILD
+    NSUInteger _simLayoutPassCount;
+    NSUInteger _simGeometryRefreshCount;
+    NSUInteger _simGeometryWriteCount;
+#endif
 }
 
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController {
@@ -355,8 +383,19 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
         // screen with a band of background under it.
         self.edgesForExtendedLayout = UIRectEdgeAll;
         self.extendedLayoutIncludesOpaqueBars = YES;
+
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(apollo_contentSizeCategoryDidChange:)
+                   name:UIContentSizeCategoryDidChangeNotification
+                 object:nil];
     }
     return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self apollo_restoreReadableWidthInsets];
 }
 
 - (void)viewDidLoad {
@@ -447,6 +486,7 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
     if (self.navigationController && !self.navigationController.navigationBarHidden) {
         [self.navigationController setNavigationBarHidden:YES animated:NO];
     }
+    [self apollo_scheduleListColumnGeometryRefresh];
 }
 
 // Lines the detail column up with the list column exactly, top and bottom.
@@ -469,19 +509,258 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
 // removes it, and matching is more robust than any constant since it tracks
 // whatever inset the platform applies to that column.
 //
-// Both values are read from the real frame every layout pass, and written only
-// when they actually change, so this cannot oscillate.
+// Constraint writes must not originate from viewDidLayoutSubviews: even a
+// value-checked write there can invalidate the same layout transaction during
+// rotation or continuous window resize. Safe-area and transition callbacks
+// coalesce into one post-layout sample instead.
+- (void)viewSafeAreaInsetsDidChange {
+    [super viewSafeAreaInsetsDidChange];
+    [self apollo_scheduleListColumnGeometryRefresh];
+
+    ApolloPaneSplitViewController *pane =
+        [self.splitViewController isKindOfClass:[ApolloPaneSplitViewController class]]
+            ? (ApolloPaneSplitViewController *)self.splitViewController : nil;
+    [pane apollo_resolvedDisplayStateMayHaveChanged];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak ApolloPaneColumnHostViewController *weakSelf = self;
+    [coordinator animateAlongsideTransition:nil
+        completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+            [weakSelf apollo_scheduleListColumnGeometryRefresh];
+        }];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self apollo_scheduleListColumnGeometryRefresh];
+}
+
+- (void)apollo_contentSizeCategoryDidChange:(NSNotification *)notification {
+    (void)notification;
+    [self apollo_scheduleListColumnGeometryRefresh];
+}
+
+- (UITableView *)apollo_tableInView:(UIView *)view depth:(NSUInteger)depth {
+    if (!view || depth > 10) return nil;
+    if ([view isKindOfClass:[UITableView class]]) return (UITableView *)view;
+    for (UIView *subview in view.subviews) {
+        UITableView *table = [self apollo_tableInView:subview depth:depth + 1];
+        if (table) return table;
+    }
+    return nil;
+}
+
+- (id)apollo_firstCommentsHeaderNode:(UIViewController *)controller {
+    if (!controller.isViewLoaded) return nil;
+    UITableView *table = [self apollo_tableInView:controller.view depth:0];
+    SEL backingNodeSelector = NSSelectorFromString(@"asyncdisplaykit_node");
+    id tableNode = table && [table respondsToSelector:backingNodeSelector]
+        ? ((id (*)(id, SEL))objc_msgSend)(table, backingNodeSelector) : nil;
+    SEL rowNodeSelector = NSSelectorFromString(@"nodeForRowAtIndexPath:");
+    if (!tableNode || ![tableNode respondsToSelector:rowNodeSelector]) return nil;
+    @try {
+        return ((id (*)(id, SEL, id))objc_msgSend)(
+            tableNode, rowNodeSelector, [NSIndexPath indexPathForRow:0 inSection:0]);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+// Only screens whose primary purpose is reading prose opt into the cap. A
+// blanket secondary-column constraint would also narrow media viewers, web
+// content, profiles, feeds, and every future destination that inherits detail
+// ownership from a thread.
+- (BOOL)apollo_topControllerWantsReadableWidth:(UIViewController *)controller {
+    if (!controller) return NO;
+
+    ApolloPaneSplitViewController *pane =
+        [self.splitViewController isKindOfClass:[ApolloPaneSplitViewController class]]
+            ? (ApolloPaneSplitViewController *)self.splitViewController : nil;
+    UIViewController *primaryRoot =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]
+            .viewControllers.firstObject;
+    if ([NSStringFromClass(primaryRoot.class) hasSuffix:@"SettingsViewController"]) {
+        // Settings destinations are predominantly forms and table screens.
+        // Limit the policy to that concrete surface so a future gallery, web
+        // view, or other intentionally full-width child of Settings does not
+        // inherit prose geometry merely because of its tab.
+        return controller.isViewLoaded &&
+            [self apollo_tableInView:controller.view depth:0] != nil;
+    }
+
+    Class commentsClass = objc_getClass("_TtC6Apollo22CommentsViewController");
+    if (!commentsClass || ![controller isKindOfClass:commentsClass]) return NO;
+
+    // A media post's header shares the Comments ASTableView with the prose
+    // rows. Insetting that table would visibly letterbox the image/video too,
+    // so media threads remain full width. Self posts are the text-heavy case
+    // where constraining the whole table is both useful and internally
+    // consistent. Apollo's Swift Optional `link` storage is not reliably
+    // readable through the ObjC runtime, so prefer it when available and then
+    // identify the already-realized first Texture row: CommentsHeaderCellNode
+    // is prose, RichMediaHeaderCellNode is media. Fail open when neither signal
+    // is available rather than guessing that an unknown header is safe to
+    // narrow.
+    Ivar linkIvar = class_getInstanceVariable(controller.class, "link");
+    id link = nil;
+    @try {
+        const char *linkType = linkIvar ? ivar_getTypeEncoding(linkIvar) : NULL;
+        if (linkType && linkType[0] == '@') {
+            link = object_getIvar(controller, linkIvar);
+        }
+    } @catch (__unused NSException *exception) {}
+    SEL isSelfPostSelector = NSSelectorFromString(@"isSelfPost");
+    BOOL isSelfPost = link && [link respondsToSelector:isSelfPostSelector] &&
+        ((BOOL (*)(id, SEL))objc_msgSend)(link, isSelfPostSelector);
+    id headerNode = nil;
+    if (!link) {
+        headerNode = [self apollo_firstCommentsHeaderNode:controller];
+        NSString *headerClass = NSStringFromClass([headerNode class]);
+        if ([headerClass containsString:@"RichMediaHeaderCellNode"]) return NO;
+        if ([headerClass containsString:@"CommentsHeaderCellNode"]) isSelfPost = YES;
+    }
+#if APOLLO_SIM_BUILD
+    ApolloLog(@"[PaneReadableTest] classified comments link=%@ header=%@ selfPost=%d",
+              NSStringFromClass([link class]), NSStringFromClass([headerNode class]), isSelfPost);
+#endif
+    return isSelfPost;
+}
+
+- (void)apollo_restoreReadableWidthInsets {
+    UIViewController *controller = _readableWidthViewController;
+    if (controller) {
+        UIEdgeInsets additional = controller.additionalSafeAreaInsets;
+        additional.left = _readableWidthBaseLeft;
+        additional.right = _readableWidthBaseRight;
+        controller.additionalSafeAreaInsets = additional;
+    }
+    _readableWidthViewController = nil;
+    _readableWidthBaseLeft = 0.0;
+    _readableWidthBaseRight = 0.0;
+    _readableWidthAppliedInset = 0.0;
+}
+
+- (void)apollo_applyReadableWidthIfNeeded {
+    UIViewController *top = self.hostedNavigationController.topViewController;
+    BOOL wantsReadableWidth = _readableWidthViewController == top ||
+        [self apollo_topControllerWantsReadableWidth:top];
+    if (_readableWidthViewController != top || !wantsReadableWidth) {
+        [self apollo_restoreReadableWidthInsets];
+    }
+    if (!wantsReadableWidth || !top.isViewLoaded) return;
+
+    if (_readableWidthViewController != top) {
+        _readableWidthViewController = top;
+        _readableWidthBaseLeft = top.additionalSafeAreaInsets.left;
+        _readableWidthBaseRight = top.additionalSafeAreaInsets.right;
+    }
+
+    CGFloat width = CGRectGetWidth(top.view.bounds);
+    // A controller installed into a visible navigation stack has not always
+    // received its first bounds assignment yet. The navigation controller is
+    // already constrained to the real detail column, so its width is the exact
+    // pre-display fallback we need. Waiting for top.view.bounds to become
+    // nonzero would allow one unconstrained frame to reach the screen.
+    if (width <= 0.0 && self.hostedNavigationController.isViewLoaded) {
+        width = CGRectGetWidth(self.hostedNavigationController.view.bounds);
+    }
+    if (width <= 0.0) return;
+
+    // 680pt is close to UIKit's familiar readable measure while still leaving
+    // room for nested comment indentation. At accessibility text sizes the cap
+    // relaxes to 760pt so larger glyphs do not turn every sentence into a tall,
+    // narrow column. The nav bar and table/background remain full width; only
+    // safe-area-following cell content is inset.
+    UIContentSizeCategory category = top.traitCollection.preferredContentSizeCategory;
+    CGFloat maximumWidth = UIContentSizeCategoryIsAccessibilityCategory(category) ? 760.0 : 680.0;
+    UIEdgeInsets current = top.additionalSafeAreaInsets;
+    CGFloat systemLeft = MAX(0.0, top.view.safeAreaInsets.left - current.left);
+    CGFloat systemRight = MAX(0.0, top.view.safeAreaInsets.right - current.right);
+    CGFloat naturalWidth = MAX(0.0, width - systemLeft - systemRight -
+                               _readableWidthBaseLeft - _readableWidthBaseRight);
+    CGFloat inset = MAX(0.0, floor((naturalWidth - maximumWidth) / 2.0));
+    if (fabs(_readableWidthAppliedInset - inset) <= 0.5 &&
+        fabs(current.left - (_readableWidthBaseLeft + inset)) <= 0.5 &&
+        fabs(current.right - (_readableWidthBaseRight + inset)) <= 0.5) return;
+
+    _readableWidthAppliedInset = inset;
+    current.left = _readableWidthBaseLeft + inset;
+    current.right = _readableWidthBaseRight + inset;
+    top.additionalSafeAreaInsets = current;
+    ApolloLog(@"[PaneReadable] %@ width=%.0f max=%.0f inset=%.0f accessibility=%d",
+              NSStringFromClass(top.class), naturalWidth, maximumWidth, inset,
+              UIContentSizeCategoryIsAccessibilityCategory(category));
+}
+
+- (void)apollo_prepareReadableWidthForTopController {
+    UIViewController *top = self.hostedNavigationController.topViewController;
+    if (!top) {
+        [self apollo_restoreReadableWidthInsets];
+        return;
+    }
+
+    // This destination is about to become visible, so loading it here does not
+    // defeat the pane's lazy offscreen-tab policy. It does let us classify its
+    // table surface and install additionalSafeAreaInsets before Core Animation
+    // commits the navigation transaction's first frame.
+    [top loadViewIfNeeded];
+#if APOLLO_SIM_BUILD
+    ApolloLog(@"[PaneReadablePrepare] %@ topWidth=%.0f navWidth=%.0f table=%d window=%d",
+              NSStringFromClass(top.class), CGRectGetWidth(top.view.bounds),
+              CGRectGetWidth(self.hostedNavigationController.viewIfLoaded.bounds),
+              [self apollo_tableInView:top.view depth:0] != nil,
+              top.view.window != nil);
+#endif
+    [self apollo_applyReadableWidthIfNeeded];
+}
+
+#if APOLLO_SIM_BUILD
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
-    [self apollo_matchListColumnGeometry];
+    _simLayoutPassCount++;
+}
+#endif
+
+- (void)apollo_scheduleListColumnGeometryRefresh {
+    if (!self.isViewLoaded || _geometryRefreshScheduled) return;
+
+    id<UIViewControllerTransitionCoordinator> coordinator =
+        self.splitViewController.transitionCoordinator;
+    if (coordinator) {
+        if (_geometryRefreshWaitingForTransition) return;
+        _geometryRefreshWaitingForTransition = YES;
+        __weak ApolloPaneColumnHostViewController *weakSelf = self;
+        [coordinator animateAlongsideTransition:nil
+            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                ApolloPaneColumnHostViewController *strongSelf = weakSelf;
+                if (!strongSelf) return;
+                strongSelf->_geometryRefreshWaitingForTransition = NO;
+                [strongSelf apollo_scheduleListColumnGeometryRefresh];
+            }];
+        return;
+    }
+
+    _geometryRefreshScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_geometryRefreshScheduled = NO;
+        [self apollo_matchListColumnGeometry];
+    });
 }
 
 - (void)apollo_matchListColumnGeometry {
     UINavigationController *nav = self.hostedNavigationController;
     if (!nav.isViewLoaded || !_topConstraint || !_bottomConstraint) return;
+#if APOLLO_SIM_BUILD
+    _simGeometryRefreshCount++;
+#endif
 
     CGFloat height = self.view.bounds.size.height;
     if (height <= 0.0) return;
+
+    [self apollo_applyReadableWidthIfNeeded];
 
     // Fall back to the safe area whenever the list column cannot be measured —
     // collapsed, mid-transition, or not yet loaded.
@@ -518,9 +797,46 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
         }
     }
 
-    if (fabs(_topConstraint.constant - top) > 0.5) _topConstraint.constant = top;
-    if (fabs(_bottomConstraint.constant - bottom) > 0.5) _bottomConstraint.constant = bottom;
+    BOOL changed = !_hasResolvedGeometry ||
+        fabs(_lastResolvedTop - top) > 0.5 ||
+        fabs(_lastResolvedBottom - bottom) > 0.5;
+    if (!changed) return;
+
+    _hasResolvedGeometry = YES;
+    _lastResolvedTop = top;
+    _lastResolvedBottom = bottom;
+    BOOL wroteConstraint = NO;
+    if (fabs(_topConstraint.constant - top) > 0.5) {
+        _topConstraint.constant = top;
+        wroteConstraint = YES;
+    }
+    if (fabs(_bottomConstraint.constant - bottom) > 0.5) {
+        _bottomConstraint.constant = bottom;
+        wroteConstraint = YES;
+    }
+#if APOLLO_SIM_BUILD
+    if (wroteConstraint) _simGeometryWriteCount++;
+#else
+    (void)wroteConstraint;
+#endif
 }
+
+#if APOLLO_SIM_BUILD
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset {
+    NSString *state = [NSString stringWithFormat:
+        @"hostPasses=%lu hostRefreshes=%lu hostWrites=%lu top=%.1f bottom=%.1f",
+        (unsigned long)_simLayoutPassCount,
+        (unsigned long)_simGeometryRefreshCount,
+        (unsigned long)_simGeometryWriteCount,
+        _topConstraint.constant, _bottomConstraint.constant];
+    if (reset) {
+        _simLayoutPassCount = 0;
+        _simGeometryRefreshCount = 0;
+        _simGeometryWriteCount = 0;
+    }
+    return state;
+}
+#endif
 
 // The hosted navigation controller owns the chrome; forwarding these keeps the
 // host transparent to UIKit rather than having it answer for an empty view.
@@ -639,9 +955,26 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     }
 }
 
+#pragma mark - Shared divider width
+
+static const CGFloat kApolloPaneMinimumPrimaryWidth = 340.0;
+static const CGFloat kApolloPaneMaximumPrimaryWidth = 480.0;
+static const CGFloat kApolloPaneDefaultPrimaryWidthFraction = 0.42;
+static NSString *const kApolloPanePrimaryWidthsDefaultsKey =
+    @"ApolloRebornIPadPanePrimaryWidthsByScene";
+static char kApolloPaneScenePreferredWidthKey;
+
+@class ApolloPaneDividerControl;
+
 @interface ApolloPaneSplitViewController () <UISplitViewControllerDelegate, UIGestureRecognizerDelegate> {
     BOOL _apollo_loggedResolvedLayout;
-    UIView *_apollo_grabber;
+    ApolloPaneDividerControl *_apollo_grabber;
+    BOOL _apollo_geometryRefreshScheduled;
+    BOOL _apollo_geometryRefreshWaitingForTransition;
+    BOOL _apollo_hasGrabberGeometry;
+    BOOL _apollo_lastGrabberHidden;
+    CGRect _apollo_lastGrabberFrame;
+    BOOL _apollo_navigationGestureObserversInstalled;
 
     // Compact-mode chrome. UIKit stacks the secondary column's wrapper onto the
     // primary navigation controller when a double-column split collapses. Left
@@ -736,6 +1069,14 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     __weak UIViewController *_apollo_lastSampledDetailTop;
     BOOL _apollo_hasSampledResolvedDisplayState;
 
+    // One preferred width belongs to the UIWindowScene, not to a tab. UIKit is
+    // still free to resolve a narrower actual column in portrait, Slide Over,
+    // or another constrained window; those resolutions never feed back into
+    // this value. Only the pane-owned divider, keyboard commands, or its
+    // accessibility-adjustable actions publish a new intentional preference.
+    CGFloat _apollo_dividerPanStartWidth;
+    CGFloat _apollo_lastAppliedPreferredPrimaryWidth;
+
     // Pane-owned master selection. The opaque intent retains only copied
     // identity while its controller and list surface references remain weak.
     // This cannot keep an inactive tab's view hierarchy alive.
@@ -747,6 +1088,10 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     NSUInteger _apollo_stagedMasterSelectionGeneration;
 #if APOLLO_SIM_BUILD
     BOOL _apollo_simCrossColumnNavigationBlocked;
+    NSUInteger _apollo_simLayoutPassCount;
+    NSUInteger _apollo_simGeometryRefreshCount;
+    NSUInteger _apollo_simGeometryWriteCount;
+    NSUInteger _apollo_simThemeNotificationCount;
 #endif
 }
 @property (nonatomic, strong) UINavigationController *apollo_primaryNav;   // the list column
@@ -769,9 +1114,160 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
 - (nullable NSIndexPath *)apollo_resolvedMasterSelectionPath:
     (ApolloPaneMasterSelectionIntent *)intent;
 - (void)apollo_deselectMasterSelectionIntent:(ApolloPaneMasterSelectionIntent *)intent;
+- (void)apollo_installNavigationGestureObservers;
+- (void)apollo_removeNavigationGestureObservers;
+- (void)apollo_scheduleResolvedGeometryRefresh;
+- (void)apollo_applyResolvedGeometry;
+- (void)apollo_synchronizePreferredPrimaryWidth;
+- (void)apollo_publishPreferredPrimaryWidth:(CGFloat)width persist:(BOOL)persist;
+- (void)apollo_applyScenePreferredPrimaryWidth:(CGFloat)width;
+- (void)apollo_dividerPanChanged:(UIPanGestureRecognizer *)gesture;
+- (void)apollo_nudgePreferredPrimaryWidth:(CGFloat)delta;
+- (NSString *)apollo_primaryWidthAccessibilityValue;
 @end
 
+@interface ApolloPaneDividerControl : UIControl <UIPointerInteractionDelegate>
+- (instancetype)initWithPane:(ApolloPaneSplitViewController *)pane;
+- (void)refreshAccessibilityValue;
+- (UIColor *)markerColor;
+@end
+
+@implementation ApolloPaneDividerControl {
+    __weak ApolloPaneSplitViewController *_pane;
+    UIView *_pill;
+}
+
+- (instancetype)initWithPane:(ApolloPaneSplitViewController *)pane {
+    self = [super initWithFrame:CGRectZero];
+    if (!self) return nil;
+
+    _pane = pane;
+    self.backgroundColor = UIColor.clearColor;
+    self.isAccessibilityElement = YES;
+    self.accessibilityLabel = @"Column Divider";
+    self.accessibilityHint = @"Adjusts the width of the list column";
+    self.accessibilityTraits = UIAccessibilityTraitAdjustable;
+
+    _pill = [[UIView alloc] initWithFrame:CGRectZero];
+    _pill.translatesAutoresizingMaskIntoConstraints = NO;
+    _pill.userInteractionEnabled = NO;
+    _pill.layer.cornerRadius = 2.5;
+    _pill.alpha = 0.55;
+    [self addSubview:_pill];
+    [NSLayoutConstraint activateConstraints:@[
+        [_pill.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+        [_pill.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [_pill.widthAnchor constraintEqualToConstant:5.0],
+        [_pill.heightAnchor constraintEqualToConstant:44.0],
+    ]];
+
+    UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc]
+        initWithTarget:pane action:@selector(apollo_dividerPanChanged:)];
+    pan.cancelsTouchesInView = NO;
+    pan.delegate = pane;
+    [self addGestureRecognizer:pan];
+
+    if (@available(iOS 13.4, *)) {
+        [self addInteraction:[[UIPointerInteraction alloc] initWithDelegate:self]];
+    }
+    [self refreshAccessibilityValue];
+    return self;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {
+    // The control itself must remain transparent so its 44pt hit target does
+    // not look like a bar. Existing pane theming writes the accent here; route
+    // that color to the centred 5pt visual marker instead.
+    if (_pill) {
+        _pill.backgroundColor = backgroundColor;
+        [super setBackgroundColor:UIColor.clearColor];
+    } else {
+        [super setBackgroundColor:backgroundColor];
+    }
+}
+
+- (void)refreshAccessibilityValue {
+    self.accessibilityValue = [_pane apollo_primaryWidthAccessibilityValue];
+}
+
+- (UIColor *)markerColor {
+    return _pill.backgroundColor;
+}
+
+- (void)accessibilityIncrement {
+    [_pane apollo_nudgePreferredPrimaryWidth:20.0];
+}
+
+- (void)accessibilityDecrement {
+    [_pane apollo_nudgePreferredPrimaryWidth:-20.0];
+}
+
+- (UIPointerStyle *)pointerInteraction:(UIPointerInteraction *)interaction
+                         styleForRegion:(UIPointerRegion *)region API_AVAILABLE(ios(13.4)) {
+    UITargetedPreview *preview = [[UITargetedPreview alloc] initWithView:_pill];
+    return [UIPointerStyle styleWithEffect:[UIPointerHighlightEffect effectWithPreview:preview]
+                                     shape:nil];
+}
+
+@end
+
+static CGFloat ApolloPaneClampedPreferredPrimaryWidth(CGFloat width) {
+    if (!isfinite(width)) width = 0.0;
+    return MIN(kApolloPaneMaximumPrimaryWidth,
+               MAX(kApolloPaneMinimumPrimaryWidth, width));
+}
+
+static NSString *ApolloPaneWidthPersistenceSceneKey(UIWindowScene *scene) {
+    NSString *identifier = scene.session.persistentIdentifier;
+    return identifier.length > 0 ? identifier : nil;
+}
+
+static NSNumber *ApolloPanePersistedPrimaryWidth(UIWindowScene *scene) {
+    NSString *sceneKey = ApolloPaneWidthPersistenceSceneKey(scene);
+    if (!sceneKey) return nil;
+    NSDictionary *widths = [NSUserDefaults.standardUserDefaults
+        dictionaryForKey:kApolloPanePrimaryWidthsDefaultsKey];
+    NSNumber *width = [widths[sceneKey] isKindOfClass:[NSNumber class]] ? widths[sceneKey] : nil;
+    CGFloat value = width.doubleValue;
+    return value >= kApolloPaneMinimumPrimaryWidth &&
+        value <= kApolloPaneMaximumPrimaryWidth ? @(value) : nil;
+}
+
+static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
+    NSString *sceneKey = ApolloPaneWidthPersistenceSceneKey(scene);
+    if (!sceneKey) return;
+    NSMutableDictionary *widths = [[NSUserDefaults.standardUserDefaults
+        dictionaryForKey:kApolloPanePrimaryWidthsDefaultsKey] mutableCopy] ?: [NSMutableDictionary dictionary];
+    widths[sceneKey] = @(ApolloPaneClampedPreferredPrimaryWidth(width));
+    [NSUserDefaults.standardUserDefaults setObject:widths
+                                            forKey:kApolloPanePrimaryWidthsDefaultsKey];
+}
+
 @implementation ApolloPaneSplitViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Construction runs for all five tab children during the atomic install,
+    // but UIKit should materialize only the selected tab. Keep every operation
+    // that touches a view or view-owned gesture here so merely wrapping an
+    // offscreen navigation stack does not pre-load its entire pane hierarchy.
+    [self apollo_installNavigationGestureObservers];
+    [self apollo_applyGroundTheme];
+    [self apollo_installColumnGrabber];
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(apollo_activeThemeChanged:)
+                                               name:@"com.christianselig.ApolloSpecificThemeChanged"
+                                             object:nil];
+    [self apollo_resolvedDisplayStateMayHaveChanged];
+    ApolloLog(@"[PaneLoad] tab %ld loaded pane hierarchy primaryLoaded=%d detailLoaded=%d",
+              (long)self.apollo_tabIndex, self.apollo_primaryNav.isViewLoaded,
+              self.apollo_detailNav.isViewLoaded);
+}
+
+- (void)dealloc {
+    [NSNotificationCenter.defaultCenter removeObserver:self];
+}
 
 - (id)apollo_masterSelectionIntentFromSource:(UIViewController *)sourceViewController
                                       surface:(id)surface
@@ -1021,7 +1517,9 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+    [self apollo_synchronizePreferredPrimaryWidth];
     [self apollo_refreshMasterSelection];
+    [self apollo_scheduleResolvedGeometryRefresh];
 }
 
 - (void)apollo_setPrimaryViewControllers:(NSArray<UIViewController *> *)viewControllers {
@@ -1408,28 +1906,11 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     ++_apollo_topologyMutationGeneration;
     ++_apollo_compactPrimaryRestoreGeneration;
 
+    [self apollo_removeNavigationGestureObservers];
     NSMutableArray<UINavigationController *> *navigationControllers = [NSMutableArray array];
     if (self.apollo_primaryNav) [navigationControllers addObject:self.apollo_primaryNav];
     if (self.apollo_detailNav) [navigationControllers addObject:self.apollo_detailNav];
     for (UINavigationController *navigationController in navigationControllers) {
-        NSMutableArray<UIGestureRecognizer *> *gestures = [NSMutableArray array];
-        if (navigationController.interactivePopGestureRecognizer) {
-            [gestures addObject:navigationController.interactivePopGestureRecognizer];
-        }
-        static const char *kNavigationGestureNames[] = {
-            "leftScreenEdgePanGestureRecognizer",
-            "rightScreenEdgePanGestureRecognizer",
-        };
-        for (size_t index = 0;
-             index < sizeof(kNavigationGestureNames) / sizeof(kNavigationGestureNames[0]);
-             index++) {
-            UIGestureRecognizer *gesture = ApolloPaneNavigationGesture(
-                navigationController, kNavigationGestureNames[index]);
-            if (gesture && ![gestures containsObject:gesture]) [gestures addObject:gesture];
-        }
-        for (UIGestureRecognizer *gesture in gestures) {
-            [gesture removeTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
-        }
         ApolloPaneUnregisterNavigationController(navigationController);
     }
 
@@ -1464,14 +1945,23 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
         ApolloLog(@"[PaneSplit] tab %ld install validation failed: detail navigation", (long)self.apollo_tabIndex);
         return NO;
     }
-    if (!self.apollo_detailHost ||
-        [self viewControllerForColumn:UISplitViewControllerColumnSecondary] != self.apollo_detailHost ||
-        self.apollo_detailNav.parentViewController != self.apollo_detailHost) {
+    ApolloPaneColumnHostViewController *detailHost =
+        [self.apollo_detailHost isKindOfClass:[ApolloPaneColumnHostViewController class]]
+            ? (ApolloPaneColumnHostViewController *)self.apollo_detailHost : nil;
+    BOOL detailContainmentValid = detailHost &&
+        detailHost.hostedNavigationController == self.apollo_detailNav &&
+        (detailHost.isViewLoaded
+            ? self.apollo_detailNav.parentViewController == detailHost
+            : self.apollo_detailNav.parentViewController == nil);
+    if (!detailHost ||
+        [self viewControllerForColumn:UISplitViewControllerColumnSecondary] != detailHost ||
+        !detailContainmentValid) {
         ApolloLog(@"[PaneSplit] tab %ld install validation failed: detail containment column=%@ "
-                  @"host=%@ navParent=%@",
+                  @"host=%@ hostLoaded=%d storedNav=%@ navParent=%@",
                   (long)self.apollo_tabIndex,
                   [self viewControllerForColumn:UISplitViewControllerColumnSecondary],
-                  self.apollo_detailHost, self.apollo_detailNav.parentViewController);
+                  detailHost, detailHost.isViewLoaded, detailHost.hostedNavigationController,
+                  self.apollo_detailNav.parentViewController);
         return NO;
     }
     if (!ApolloPaneNavigationControllerIsRegisteredToSplit(navigationController, self) ||
@@ -1551,27 +2041,6 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
 #endif
     ApolloPaneRegisterNavigationController(self.apollo_primaryNav, self);
     ApolloPaneRegisterNavigationController(self.apollo_detailNav, self);
-    for (UINavigationController *navigationController in
-            @[ self.apollo_primaryNav, self.apollo_detailNav ]) {
-        NSMutableArray<UIGestureRecognizer *> *gestures = [NSMutableArray array];
-        if (navigationController.interactivePopGestureRecognizer) {
-            [gestures addObject:navigationController.interactivePopGestureRecognizer];
-        }
-        static const char *kNavigationGestureNames[] = {
-            "leftScreenEdgePanGestureRecognizer",
-            "rightScreenEdgePanGestureRecognizer",
-        };
-        for (size_t index = 0;
-             index < sizeof(kNavigationGestureNames) / sizeof(kNavigationGestureNames[0]);
-             index++) {
-            UIGestureRecognizer *gesture = ApolloPaneNavigationGesture(
-                navigationController, kNavigationGestureNames[index]);
-            if (gesture && ![gestures containsObject:gesture]) [gestures addObject:gesture];
-        }
-        for (UIGestureRecognizer *gesture in gestures) {
-            [gesture addTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
-        }
-    }
     self.apollo_emptyMessage = message;
     self.apollo_emptySymbol = symbol;
 
@@ -1642,9 +2111,9 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     // area. On a 13" iPad that is roughly 780pt in portrait and 1115pt in
     // landscape, landing the list near its 340pt floor in portrait and around
     // 470pt in landscape, with the detail column always the larger share.
-    self.preferredPrimaryColumnWidthFraction = 0.42;
-    self.minimumPrimaryColumnWidth = 340.0;
-    self.maximumPrimaryColumnWidth = 480.0;
+    self.preferredPrimaryColumnWidthFraction = kApolloPaneDefaultPrimaryWidthFraction;
+    self.minimumPrimaryColumnWidth = kApolloPaneMinimumPrimaryWidth;
+    self.maximumPrimaryColumnWidth = kApolloPaneMaximumPrimaryWidth;
 
     // Apollo installs its own screen-edge pans on every navigation controller
     // (left = interactive pop, right = "go forward", re-pushing from the per-nav
@@ -1686,19 +2155,59 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
     self.tabBarItem = rootNav.tabBarItem;
 
     self.delegate = self;
-    [self apollo_applyGroundTheme];
-
-    // The columns are resizable by dragging the separator, but UIKit only
-    // reveals a grabber on pointer HOVER — with touch there is no hint at all
-    // that the divider does anything, so the capability goes unnoticed.
-    // A permanently visible grabber is the affordance.
-    [self apollo_installColumnGrabber];
-    [self apollo_resolvedDisplayStateMayHaveChanged];
 
     ApolloLog(@"[PaneSplit] tab %ld configured listRoot=%@ depth=%lu",
               (long)self.apollo_tabIndex,
               NSStringFromClass([rootNav.viewControllers.firstObject class]),
               (unsigned long)rootNav.viewControllers.count);
+}
+
+- (NSArray<UIGestureRecognizer *> *)apollo_navigationGesturesForController:
+    (UINavigationController *)navigationController {
+    if (!navigationController) return @[];
+    NSMutableArray<UIGestureRecognizer *> *gestures = [NSMutableArray array];
+    if (navigationController.interactivePopGestureRecognizer) {
+        [gestures addObject:navigationController.interactivePopGestureRecognizer];
+    }
+    static const char *kNavigationGestureNames[] = {
+        "leftScreenEdgePanGestureRecognizer",
+        "rightScreenEdgePanGestureRecognizer",
+    };
+    for (size_t index = 0;
+         index < sizeof(kNavigationGestureNames) / sizeof(kNavigationGestureNames[0]);
+         index++) {
+        UIGestureRecognizer *gesture = ApolloPaneNavigationGesture(
+            navigationController, kNavigationGestureNames[index]);
+        if (gesture && ![gestures containsObject:gesture]) [gestures addObject:gesture];
+    }
+    return gestures;
+}
+
+- (void)apollo_installNavigationGestureObservers {
+    if (_apollo_navigationGestureObserversInstalled) return;
+    for (UINavigationController *navigationController in
+            @[ self.apollo_primaryNav, self.apollo_detailNav ]) {
+        for (UIGestureRecognizer *gesture in
+                [self apollo_navigationGesturesForController:navigationController]) {
+            [gesture addTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
+        }
+    }
+    _apollo_navigationGestureObserversInstalled = YES;
+}
+
+- (void)apollo_removeNavigationGestureObservers {
+    // Do not inspect a navigation controller's gesture properties during an
+    // install rollback unless this pane actually loaded and attached targets;
+    // cleanup itself must not defeat offscreen lazy loading.
+    if (!_apollo_navigationGestureObserversInstalled) return;
+    for (UINavigationController *navigationController in
+            @[ self.apollo_primaryNav, self.apollo_detailNav ]) {
+        for (UIGestureRecognizer *gesture in
+                [self apollo_navigationGesturesForController:navigationController]) {
+            [gesture removeTarget:self action:@selector(apollo_navigationGestureStateChanged:)];
+        }
+    }
+    _apollo_navigationGestureObserversInstalled = NO;
 }
 
 // Splits a stock stack Apollo constructed before pane installation at its first
@@ -1806,17 +2315,18 @@ static void ApolloPaneMasterSelectionSetAccessibilitySelected(UITableViewCell *c
 // the divider so touches pass straight through to the real thing.
 //
 // The divider's own view is private and re-created across layouts, so the
-// grabber is positioned in viewDidLayoutSubviews against the list column's
-// trailing edge instead of being added as its subview.
+// grabber belongs to the pane root. Its geometry is refreshed from stable
+// safe-area/transition callbacks rather than from viewDidLayoutSubviews.
 - (void)apollo_installColumnGrabber {
     if (_apollo_grabber) return;
 
-    UIView *grabber = [[UIView alloc] initWithFrame:CGRectZero];
-    grabber.userInteractionEnabled = NO;
-    grabber.layer.cornerRadius = 2.5;
-    grabber.alpha = 0.55;
+    ApolloPaneDividerControl *grabber =
+        [[ApolloPaneDividerControl alloc] initWithPane:self];
+    grabber.layer.zPosition = 1000.0;
+    grabber.hidden = YES;
     [self.view addSubview:grabber];
     _apollo_grabber = grabber;
+    _apollo_lastGrabberHidden = YES;
     [self apollo_applyGrabberTheme];
 }
 
@@ -1937,7 +2447,26 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     dispatch_async(dispatch_get_main_queue(), ^{
         [self apollo_refreshMasterSelection];
     });
-    [self.view setNeedsLayout];
+    [self apollo_scheduleResolvedGeometryRefresh];
+}
+
+- (void)apollo_prepareDetailControllerForDisplay:(UIViewController *)viewController {
+    if (!viewController || self.isCollapsed ||
+        self.apollo_detailNav.topViewController != viewController) return;
+
+    // goToSettingsTab updates selectedViewController synchronously, but UIKit
+    // may defer attaching and sizing that pane until the next run-loop turn.
+    // Finish only that already-requested layout now; otherwise a cold settings
+    // route sees the navigation controller's stale full-window width and the
+    // readable inset cannot be computed until after a visible frame.
+    UITabBarController *tabs = self.tabBarController;
+    if (tabs.selectedViewController == self) {
+        [tabs.view layoutIfNeeded];
+        [self.view layoutIfNeeded];
+        [self.apollo_detailHost.view layoutIfNeeded];
+    }
+    [(ApolloPaneColumnHostViewController *)self.apollo_detailHost
+        apollo_prepareReadableWidthForTopController];
 }
 
 - (void)apollo_showPrimaryItemActivated:(UIBarButtonItem *)sender {
@@ -1986,12 +2515,12 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
 - (void)apollo_layoutColumnGrabber {
     UIViewController *list = [self viewControllerForColumn:UISplitViewControllerColumnPrimary];
     UIView *detailView = self.apollo_detailNav.viewIfLoaded;
-    if (!_apollo_grabber || !list.isViewLoaded || !list.view.superview ||
+    BOOL hidden = !_apollo_grabber || !list.isViewLoaded || !list.view.superview ||
         !detailView.superview ||
-        !ApolloPaneSplitShowsTiledPrimary(self)) {
-        _apollo_grabber.hidden = YES;
-        return;
-    }
+        !ApolloPaneSplitShowsTiledPrimary(self);
+    CGRect resolvedFrame = CGRectZero;
+    if (hidden) goto apply;
+
     CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
     CGRect detailFrame = [detailView.superview convertRect:detailView.frame toView:self.view];
     CGRect visibleBounds = self.view.bounds;
@@ -2002,16 +2531,177 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     CGFloat detailBoundary = primaryOnLeadingEdge ? CGRectGetMinX(detailFrame) : CGRectGetMaxX(detailFrame);
     if (CGRectIsEmpty(listFrame) || CGRectIsEmpty(detailFrame) ||
         !listIntersects || !detailIntersects || fabs(listBoundary - detailBoundary) > 32.0) {
-        _apollo_grabber.hidden = YES;
-        return;
+        hidden = YES;
+        goto apply;
     }
 
-    static const CGFloat kWidth = 5.0, kHeight = 44.0;
-    _apollo_grabber.hidden = NO;
-    _apollo_grabber.frame = CGRectMake(listBoundary - kWidth / 2.0,
-                                       CGRectGetMidY(listFrame) - kHeight / 2.0,
-                                       kWidth, kHeight);
-    [self.view bringSubviewToFront:_apollo_grabber];
+    // The visible pill remains 5x44pt, but its real control is 44x64pt so touch,
+    // pointer, and Switch Control users do not have to hit a decorative sliver.
+    static const CGFloat kWidth = 44.0, kHeight = 64.0;
+    resolvedFrame = CGRectMake(listBoundary - kWidth / 2.0,
+                               CGRectGetMidY(listFrame) - kHeight / 2.0,
+                               kWidth, kHeight);
+
+apply:
+    if (_apollo_grabber.hidden != hidden) {
+        _apollo_grabber.hidden = hidden;
+#if APOLLO_SIM_BUILD
+        _apollo_simGeometryWriteCount++;
+#endif
+    }
+    if (!hidden && (!_apollo_hasGrabberGeometry ||
+        fabs(_apollo_lastGrabberFrame.origin.x - resolvedFrame.origin.x) > 0.5 ||
+        fabs(_apollo_lastGrabberFrame.origin.y - resolvedFrame.origin.y) > 0.5 ||
+        fabs(_apollo_lastGrabberFrame.size.width - resolvedFrame.size.width) > 0.5 ||
+        fabs(_apollo_lastGrabberFrame.size.height - resolvedFrame.size.height) > 0.5)) {
+        if (!CGRectEqualToRect(_apollo_grabber.frame, resolvedFrame)) {
+            _apollo_grabber.frame = resolvedFrame;
+#if APOLLO_SIM_BUILD
+            _apollo_simGeometryWriteCount++;
+#endif
+        }
+    }
+    _apollo_hasGrabberGeometry = YES;
+    _apollo_lastGrabberHidden = hidden;
+    _apollo_lastGrabberFrame = resolvedFrame;
+    [_apollo_grabber refreshAccessibilityValue];
+}
+
+#pragma mark - Shared divider width
+
+- (void)apollo_applyScenePreferredPrimaryWidth:(CGFloat)width {
+    CGFloat clamped = ApolloPaneClampedPreferredPrimaryWidth(width);
+    if (fabs(_apollo_lastAppliedPreferredPrimaryWidth - clamped) <= 0.5 &&
+        fabs(self.preferredPrimaryColumnWidth - clamped) <= 0.5) return;
+    _apollo_lastAppliedPreferredPrimaryWidth = clamped;
+    // A non-automatic absolute value takes precedence over the configured
+    // fraction. minimum/maximum remain requests to UIKit, which may still
+    // resolve narrower when the window cannot fit both columns.
+    self.preferredPrimaryColumnWidth = clamped;
+    [_apollo_grabber refreshAccessibilityValue];
+    [self apollo_scheduleResolvedGeometryRefresh];
+}
+
+- (void)apollo_synchronizePreferredPrimaryWidth {
+    UIWindowScene *scene = self.viewIfLoaded.window.windowScene;
+    if (!scene) return;
+
+    NSNumber *sceneWidth = objc_getAssociatedObject(scene, &kApolloPaneScenePreferredWidthKey);
+    if (!sceneWidth) {
+        sceneWidth = ApolloPanePersistedPrimaryWidth(scene);
+        if (!sceneWidth) {
+            CGFloat availableWidth = CGRectGetWidth(self.viewIfLoaded.bounds);
+            CGFloat defaultWidth = availableWidth > 0.0
+                ? availableWidth * kApolloPaneDefaultPrimaryWidthFraction : 420.0;
+            sceneWidth = @(ApolloPaneClampedPreferredPrimaryWidth(defaultWidth));
+        }
+        objc_setAssociatedObject(scene, &kApolloPaneScenePreferredWidthKey, sceneWidth,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[PaneWidth] scene initialized preferred=%.0f persisted=%d",
+                  sceneWidth.doubleValue, ApolloPanePersistedPrimaryWidth(scene) != nil);
+    }
+
+    UITabBarController *tabs = self.tabBarController;
+    BOOL appliedSibling = NO;
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
+        [(ApolloPaneSplitViewController *)child
+            apollo_applyScenePreferredPrimaryWidth:sceneWidth.doubleValue];
+        appliedSibling = YES;
+    }
+    if (!appliedSibling) [self apollo_applyScenePreferredPrimaryWidth:sceneWidth.doubleValue];
+}
+
+- (void)apollo_publishPreferredPrimaryWidth:(CGFloat)width persist:(BOOL)persist {
+    CGFloat clamped = ApolloPaneClampedPreferredPrimaryWidth(width);
+    UIWindowScene *scene = self.viewIfLoaded.window.windowScene;
+    if (scene) {
+        objc_setAssociatedObject(scene, &kApolloPaneScenePreferredWidthKey, @(clamped),
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (persist) ApolloPanePersistPrimaryWidth(clamped, scene);
+    }
+
+    UITabBarController *tabs = self.tabBarController;
+    BOOL appliedSibling = NO;
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
+        [(ApolloPaneSplitViewController *)child apollo_applyScenePreferredPrimaryWidth:clamped];
+        appliedSibling = YES;
+    }
+    if (!appliedSibling) [self apollo_applyScenePreferredPrimaryWidth:clamped];
+    if (persist) {
+        ApolloLog(@"[PaneWidth] tab %ld committed scene preference %.0f (resolved %.0f)",
+                  (long)self.apollo_tabIndex, clamped, self.primaryColumnWidth);
+    }
+}
+
+- (void)apollo_dividerPanChanged:(UIPanGestureRecognizer *)gesture {
+    CGFloat direction = self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading ? 1.0 : -1.0;
+    if (gesture.state == UIGestureRecognizerStateBegan) {
+        _apollo_dividerPanStartWidth = ApolloPaneClampedPreferredPrimaryWidth(
+            self.primaryColumnWidth > 0.0 ? self.primaryColumnWidth
+                                          : self.preferredPrimaryColumnWidth);
+    }
+    CGFloat translation = [gesture translationInView:self.view].x * direction;
+    CGFloat target = ApolloPaneClampedPreferredPrimaryWidth(
+        _apollo_dividerPanStartWidth + translation);
+    switch (gesture.state) {
+        case UIGestureRecognizerStateBegan:
+        case UIGestureRecognizerStateChanged:
+            [self apollo_publishPreferredPrimaryWidth:target persist:NO];
+            break;
+        case UIGestureRecognizerStateEnded:
+            [self apollo_publishPreferredPrimaryWidth:target persist:YES];
+            break;
+        case UIGestureRecognizerStateCancelled:
+        case UIGestureRecognizerStateFailed:
+            [self apollo_publishPreferredPrimaryWidth:_apollo_dividerPanStartWidth persist:NO];
+            break;
+        default:
+            break;
+    }
+}
+
+- (void)apollo_nudgePreferredPrimaryWidth:(CGFloat)delta {
+    if (!ApolloPaneSplitShowsTiledPrimary(self)) return;
+    CGFloat current = _apollo_lastAppliedPreferredPrimaryWidth > 0.0
+        ? _apollo_lastAppliedPreferredPrimaryWidth : self.preferredPrimaryColumnWidth;
+    [self apollo_publishPreferredPrimaryWidth:current + delta persist:YES];
+    [_apollo_grabber refreshAccessibilityValue];
+}
+
+- (NSString *)apollo_primaryWidthAccessibilityValue {
+    CGFloat preferred = _apollo_lastAppliedPreferredPrimaryWidth > 0.0
+        ? _apollo_lastAppliedPreferredPrimaryWidth : self.preferredPrimaryColumnWidth;
+    CGFloat resolved = self.primaryColumnWidth;
+    if (preferred <= 0.0 || preferred == UISplitViewControllerAutomaticDimension) return @"Automatic";
+    if (resolved > 0.0 && fabs(preferred - resolved) > 1.0) {
+        return [NSString stringWithFormat:@"Preferred %.0f points, currently %.0f points",
+                                          preferred, resolved];
+    }
+    return [NSString stringWithFormat:@"%.0f points", preferred];
+}
+
+- (NSArray<UIKeyCommand *> *)keyCommands {
+    NSMutableArray<UIKeyCommand *> *commands = [[super keyCommands] mutableCopy] ?: [NSMutableArray array];
+    UIKeyCommand *narrow = [UIKeyCommand keyCommandWithInput:UIKeyInputLeftArrow
+                                              modifierFlags:UIKeyModifierAlternate
+                                                     action:@selector(apollo_narrowPrimaryColumn:)];
+    narrow.discoverabilityTitle = @"Narrow List Column";
+    UIKeyCommand *widen = [UIKeyCommand keyCommandWithInput:UIKeyInputRightArrow
+                                             modifierFlags:UIKeyModifierAlternate
+                                                    action:@selector(apollo_widenPrimaryColumn:)];
+    widen.discoverabilityTitle = @"Widen List Column";
+    [commands addObjectsFromArray:@[ narrow, widen ]];
+    return commands;
+}
+
+- (void)apollo_narrowPrimaryColumn:(UIKeyCommand *)command {
+    [self apollo_nudgePreferredPrimaryWidth:-20.0];
+}
+
+- (void)apollo_widenPrimaryColumn:(UIKeyCommand *)command {
+    [self apollo_nudgePreferredPrimaryWidth:20.0];
 }
 
 // The ground the floating columns sit on.
@@ -2022,7 +2712,26 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
 // as "not themeable" — Apollo's pages were #191926 under the active palette
 // while the ground behind them stayed #000000.
 - (void)apollo_applyGroundTheme {
-    self.view.backgroundColor = ApolloThemePageBackgroundColor() ?: self.view.backgroundColor;
+    UIView *view = self.viewIfLoaded;
+    if (!view) return;
+    view.backgroundColor = ApolloThemePageBackgroundColor() ?: view.backgroundColor;
+}
+
+- (void)apollo_activeThemeChanged:(NSNotification *)notification {
+    (void)notification;
+#if APOLLO_SIM_BUILD
+    _apollo_simThemeNotificationCount++;
+#endif
+    // Apollo's canonical theme notification arrives for both stock-theme
+    // selection and custom-theme invalidation. Repaint every surface owned by
+    // the pane itself; Apollo continues to repaint the hosted app controllers.
+    [self apollo_applyGroundTheme];
+    [self apollo_applyGrabberTheme];
+    for (UIViewController *controller in self.apollo_detailNav.viewControllers) {
+        if ([controller isKindOfClass:[ApolloPaneDetailPlaceholderViewController class]]) {
+            [(ApolloPaneDetailPlaceholderViewController *)controller apollo_applyTheme];
+        }
+    }
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previous {
@@ -2051,14 +2760,70 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
         ApolloLog(@"[PaneSplit] tab %ld armed compact primary restore at expansion trait boundary",
                   (long)self.apollo_tabIndex);
     }
-    [self apollo_applyGroundTheme];
-    [self apollo_applyGrabberTheme];
-    [self apollo_scheduleShowPrimaryItemRefresh];
+    if (self.isViewLoaded) {
+        [self apollo_applyGroundTheme];
+        [self apollo_applyGrabberTheme];
+        [self apollo_scheduleShowPrimaryItemRefresh];
+        [self apollo_scheduleResolvedGeometryRefresh];
+    }
 }
 
+- (void)viewSafeAreaInsetsDidChange {
+    [super viewSafeAreaInsetsDidChange];
+    [self apollo_scheduleResolvedGeometryRefresh];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak ApolloPaneSplitViewController *weakSelf = self;
+    [coordinator animateAlongsideTransition:nil
+        completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+            [weakSelf apollo_scheduleResolvedGeometryRefresh];
+        }];
+}
+
+#if APOLLO_SIM_BUILD
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
+    _apollo_simLayoutPassCount++;
+}
+#endif
+
+- (void)apollo_scheduleResolvedGeometryRefresh {
+    if (!self.isViewLoaded || _apollo_geometryRefreshScheduled) return;
+
+    id<UIViewControllerTransitionCoordinator> coordinator = self.transitionCoordinator;
+    if (coordinator) {
+        if (_apollo_geometryRefreshWaitingForTransition) return;
+        _apollo_geometryRefreshWaitingForTransition = YES;
+        __weak ApolloPaneSplitViewController *weakSelf = self;
+        [coordinator animateAlongsideTransition:nil
+            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+                ApolloPaneSplitViewController *strongSelf = weakSelf;
+                if (!strongSelf) return;
+                strongSelf->_apollo_geometryRefreshWaitingForTransition = NO;
+                [strongSelf apollo_scheduleResolvedGeometryRefresh];
+            }];
+        return;
+    }
+
+    _apollo_geometryRefreshScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_apollo_geometryRefreshScheduled = NO;
+        [self apollo_applyResolvedGeometry];
+    });
+}
+
+- (void)apollo_applyResolvedGeometry {
+#if APOLLO_SIM_BUILD
+    _apollo_simGeometryRefreshCount++;
+#endif
+    [self apollo_synchronizePreferredPrimaryWidth];
+    [(ApolloPaneColumnHostViewController *)self.apollo_detailHost
+        apollo_scheduleListColumnGeometryRefresh];
     [self apollo_layoutColumnGrabber];
+
     UIViewController *detailTop = self.apollo_detailNav.topViewController;
     BOOL resolvedStateChanged = !_apollo_hasSampledResolvedDisplayState ||
         _apollo_lastSampledDisplayMode != self.displayMode ||
@@ -2077,8 +2842,8 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
                   (long)self.splitBehavior, self.isCollapsed,
                   ApolloPaneSplitShowsPrimary(self), ApolloPaneSplitShowsTiledPrimary(self),
                   NSStringFromClass(detailTop.class));
-        // Bar-item writes from layoutSubviews can recursively invalidate
-        // navigation layout. Defer the identity-based reconciliation instead.
+        // Navigation-item reconciliation remains deferred so this geometry
+        // transaction cannot synchronously invalidate navigation layout.
         [self apollo_scheduleShowPrimaryItemRefresh];
     }
     if (_apollo_loggedResolvedLayout) return;
@@ -2444,6 +3209,82 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
 }
 
 #if APOLLO_SIM_BUILD
+static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection *traits) {
+    UIColor *resolved = [color resolvedColorWithTraitCollection:traits];
+    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
+    if (![resolved getRed:&red green:&green blue:&blue alpha:&alpha]) return @"unresolved";
+    return [NSString stringWithFormat:@"#%02X%02X%02X/%02X",
+        (unsigned)lrint(red * 255.0), (unsigned)lrint(green * 255.0),
+        (unsigned)lrint(blue * 255.0), (unsigned)lrint(alpha * 255.0)];
+}
+
+- (NSString *)apollo_simThemeState {
+    ApolloPaneDetailPlaceholderViewController *placeholder = nil;
+    for (UIViewController *controller in self.apollo_detailNav.viewControllers) {
+        if ([controller isKindOfClass:[ApolloPaneDetailPlaceholderViewController class]]) {
+            placeholder = (ApolloPaneDetailPlaceholderViewController *)controller;
+            break;
+        }
+    }
+    UITraitCollection *traits = self.traitCollection;
+    return [NSString stringWithFormat:
+        @"tab=%ld loaded=%d attached=%d style=%ld notifications=%lu ground=%@ marker=%@ "
+         "placeholderLoaded=%d placeholder=%@ icon=%@",
+        (long)self.apollo_tabIndex, self.isViewLoaded, self.viewIfLoaded.window != nil,
+        (long)traits.userInterfaceStyle, (unsigned long)_apollo_simThemeNotificationCount,
+        ApolloPaneSimColorDescription(self.viewIfLoaded.backgroundColor, traits),
+        ApolloPaneSimColorDescription([_apollo_grabber markerColor], traits),
+        placeholder.isViewLoaded,
+        ApolloPaneSimColorDescription(placeholder.viewIfLoaded.backgroundColor, traits),
+        ApolloPaneSimColorDescription([placeholder apollo_simIconTintColor], traits)];
+}
+
+- (void)apollo_simSetPreferredPrimaryColumnWidth:(CGFloat)width {
+    [self apollo_synchronizePreferredPrimaryWidth];
+    [self apollo_publishPreferredPrimaryWidth:width persist:YES];
+}
+
+- (NSString *)apollo_simPreferredPrimaryColumnWidthState {
+    UIWindowScene *scene = self.viewIfLoaded.window.windowScene;
+    NSNumber *sceneWidth = scene
+        ? objc_getAssociatedObject(scene, &kApolloPaneScenePreferredWidthKey) : nil;
+    return [NSString stringWithFormat:
+        @"tab=%ld loaded=%d attached=%d hSize=%ld collapsed=%d tiled=%d "
+         "scenePreferred=%.0f requested=%.0f resolved=%.0f grabberHidden=%d "
+         "grabberFrame=%@ pointerInteractions=%lu keyCommands=%lu "
+         "accessibilityLabel=%@ accessibilityValue=%@",
+        (long)self.apollo_tabIndex, self.isViewLoaded, self.viewIfLoaded.window != nil,
+        (long)self.traitCollection.horizontalSizeClass, self.isCollapsed,
+        ApolloPaneSplitShowsTiledPrimary(self), sceneWidth.doubleValue,
+        self.preferredPrimaryColumnWidth, self.primaryColumnWidth,
+        _apollo_grabber.hidden, NSStringFromCGRect(_apollo_grabber.frame),
+        (unsigned long)_apollo_grabber.interactions.count,
+        (unsigned long)self.keyCommands.count,
+        _apollo_grabber.accessibilityLabel ?: @"(nil)",
+        _apollo_grabber.accessibilityValue ?: @"(nil)"];
+}
+
+- (BOOL)apollo_simAdjustDivider:(NSString *)operation {
+    if (!_apollo_grabber || _apollo_grabber.hidden) return NO;
+    if ([operation isEqualToString:@"increment"]) {
+        [_apollo_grabber accessibilityIncrement];
+        return YES;
+    }
+    if ([operation isEqualToString:@"decrement"]) {
+        [_apollo_grabber accessibilityDecrement];
+        return YES;
+    }
+    if ([operation isEqualToString:@"keyboard-widen"]) {
+        [self apollo_widenPrimaryColumn:nil];
+        return YES;
+    }
+    if ([operation isEqualToString:@"keyboard-narrow"]) {
+        [self apollo_narrowPrimaryColumn:nil];
+        return YES;
+    }
+    return NO;
+}
+
 - (void)apollo_simSetCrossColumnNavigationBlocked:(BOOL)blocked {
     _apollo_simCrossColumnNavigationBlocked = blocked;
     ApolloLog(@"[PaneTransition] tab %ld simulator gate=%d",
@@ -2538,6 +3379,27 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     if (!_apollo_showPrimaryOwner || !_apollo_showPrimaryItem.enabled) return NO;
     [self apollo_showPrimaryItemActivated:_apollo_showPrimaryItem];
     return YES;
+}
+
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset {
+    ApolloPaneColumnHostViewController *host =
+        [self.apollo_detailHost isKindOfClass:[ApolloPaneColumnHostViewController class]]
+            ? (ApolloPaneColumnHostViewController *)self.apollo_detailHost : nil;
+    NSString *hostState = [host apollo_simLayoutPassStateReset:reset] ?: @"host unavailable";
+    NSString *state = [NSString stringWithFormat:
+        @"panePasses=%lu paneRefreshes=%lu paneWrites=%lu grabberHidden=%d "
+         "grabberFrame=%@ %@ pass=%d",
+        (unsigned long)_apollo_simLayoutPassCount,
+        (unsigned long)_apollo_simGeometryRefreshCount,
+        (unsigned long)_apollo_simGeometryWriteCount,
+        _apollo_grabber.hidden, NSStringFromCGRect(_apollo_grabber.frame), hostState,
+        !_apollo_geometryRefreshScheduled && !_apollo_geometryRefreshWaitingForTransition];
+    if (reset) {
+        _apollo_simLayoutPassCount = 0;
+        _apollo_simGeometryRefreshCount = 0;
+        _apollo_simGeometryWriteCount = 0;
+    }
+    return state;
 }
 
 - (NSString *)apollo_simMasterSelectionState {
@@ -3247,6 +4109,12 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer.view == _apollo_grabber &&
+        [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+        if (!ApolloPaneSplitShowsTiledPrimary(self)) return NO;
+        CGPoint velocity = [(UIPanGestureRecognizer *)gestureRecognizer velocityInView:self.view];
+        return fabs(velocity.x) > fabs(velocity.y);
+    }
     if (gestureRecognizer != _apollo_compactBackEdgeGesture) return YES;
     if (!_apollo_compactDetailChromeActive || !self.isCollapsed ||
         self.apollo_detailNav.viewControllers.count != 1) return NO;
@@ -3263,6 +4131,15 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     ApolloLog(@"[PaneSplit] tab %ld compact edge Back begin=%d initialX=%.0f velocity=(%.0f,%.0f)",
               (long)self.apollo_tabIndex, shouldBegin, initialX, velocity.x, velocity.y);
     return shouldBegin;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+        shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)other {
+    // UIKit may keep its private separator recognizer beneath our 44pt control.
+    // Let both observe the same drag; our absolute preferred-width write is the
+    // authoritative result and this avoids disabling UIKit's own transition
+    // bookkeeping on releases where the separator still participates.
+    return gestureRecognizer.view == _apollo_grabber || other.view == _apollo_grabber;
 }
 
 - (void)apollo_compactBackEdgeGestureChanged:(UIPanGestureRecognizer *)gesture {
@@ -3335,7 +4212,7 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
                 });
             }];
     } else {
-        [self apollo_scheduleShowPrimaryItemRefresh];
+        [self apollo_resolvedDisplayStateMayHaveChanged];
     }
 }
 
@@ -3474,6 +4351,7 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     } @finally {
         _apollo_topologyMutationInProgress = NO;
         [self apollo_scheduleShowPrimaryItemRefresh];
+        [self apollo_scheduleResolvedGeometryRefresh];
         [self apollo_navigationTransitionDidSettle];
     }
 }
@@ -3566,6 +4444,7 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
         _apollo_postCollapsePrimaryBridgeStack = nil;
         _apollo_topologyMutationInProgress = NO;
         [self apollo_scheduleShowPrimaryItemRefresh];
+        [self apollo_scheduleResolvedGeometryRefresh];
         if (settlesPendingCompactRestore) {
             [self apollo_scheduleCompactPrimaryRestoreReconciliation:
                 expansionRestoreGeneration observations:0];

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -12,6 +12,7 @@
 #import "ApolloSettingsSearch.h"
 #import "ApolloReportViewController.h"
 #import "ApolloThemeRuntime.h"
+#import "ipad/ApolloPaneLayout.h"
 #import "ApolloWallpapersViewController.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
@@ -66,6 +67,32 @@ static BOOL ApolloRootCellCopiesNativeSurface(NSIndexPath *indexPath) {
     // themed native donor rather than retaining a resolved surface from the
     // appearance in which they were first created.
     return indexPath.section == 0 || indexPath.section == 2;
+}
+
+// `cellForRowAtIndexPath:` runs inside UITableView's update transaction. UIKit
+// asserts if code asks for visibleCells from that callback, so propagate the
+// native donor surface only after the table has committed. Theme/appearance
+// transitions can span more than one run-loop turn; retry briefly instead of
+// racing the update or retaining a stale surface on the tweak-owned cards.
+static void ApolloApplyRootNativeSurfaceWhenStable(UITableView *tableView, UIColor *surface,
+                                                    NSUInteger retriesRemaining) {
+    __weak UITableView *weakTable = tableView;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UITableView *liveTable = weakTable;
+        if (!liveTable) return;
+        if (liveTable.hasUncommittedUpdates) {
+            if (retriesRemaining > 0) {
+                ApolloApplyRootNativeSurfaceWhenStable(liveTable, surface, retriesRemaining - 1);
+            }
+            return;
+        }
+        for (UITableViewCell *visibleCell in liveTable.visibleCells) {
+            NSIndexPath *visiblePath = [liveTable indexPathForCell:visibleCell];
+            if (ApolloRootCellCopiesNativeSurface(visiblePath)) {
+                ApolloApplyRootNativeSurface(visibleCell, surface);
+            }
+        }
+    });
 }
 
 // Apollo's root Settings screen adds an Export button for its legacy settings
@@ -312,25 +339,7 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
     if (nativeSurface) {
         objc_setAssociatedObject(self, &kApolloRootNativeSurfaceKey, nativeSurface,
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        for (UITableViewCell *visibleCell in tableView.visibleCells) {
-            NSIndexPath *visiblePath = [tableView indexPathForCell:visibleCell];
-            if (ApolloRootCellCopiesNativeSurface(visiblePath)) {
-                ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
-            }
-        }
-        // Apollo can finish its own cell theming later in this run-loop turn.
-        // Reassert once more after that pass so the custom cards match the
-        // final native surface during animated appearance transitions.
-        __weak UITableView *weakTable = tableView;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UITableView *liveTable = weakTable;
-            for (UITableViewCell *visibleCell in liveTable.visibleCells) {
-                NSIndexPath *visiblePath = [liveTable indexPathForCell:visibleCell];
-                if (ApolloRootCellCopiesNativeSurface(visiblePath)) {
-                    ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
-                }
-            }
-        });
+        ApolloApplyRootNativeSurfaceWhenStable(tableView, nativeSurface, 4);
     }
     UIImage *normalizedIcon = ApolloRootSettingsIconForTitle(cell.textLabel.text);
     if (normalizedIcon) cell.imageView.image = normalizedIcon;
@@ -350,6 +359,12 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
             %orig;
             return;
         }
+        // These two tweak-owned rows return before Apollo's native Settings
+        // selection handler. Hand their selection to the iPad pane router
+        // before the immediate deselect/push so the still-visible master list
+        // keeps the row corresponding to its new detail controller selected.
+        ApolloPaneStageMasterTableSelectionIfNeeded(
+            (UIViewController *)self, tableView, indexPath);
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         if (indexPath.row == 0) {
             CustomAPIViewController *vc = [[CustomAPIViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];

--- a/src/settings/ApolloSettingsRouter.h
+++ b/src/settings/ApolloSettingsRouter.h
@@ -39,6 +39,10 @@ UIViewController *ApolloSettingsRouteInstantiate(NSString *routeId);
 // Main thread only.
 BOOL ApolloSettingsRouteOpenNow(NSString *routeId);
 
+// Scene-scoped variant for URL/shortcut callbacks. This prevents a route from
+// landing in another active window when more than one scene exists.
+BOOL ApolloSettingsRouteOpenNowInScene(NSString *routeId, UIWindowScene *scene);
+
 // Convenience for in-app callers: dispatches to main and retries briefly while
 // the tab controller comes up. Unknown ids are logged and dropped.
 void ApolloSettingsRouteOpen(NSString *routeId);

--- a/src/settings/ApolloSettingsRouter.m
+++ b/src/settings/ApolloSettingsRouter.m
@@ -136,12 +136,12 @@ UIViewController *ApolloSettingsRouteInstantiate(NSString *routeId) {
     return builder ? builder() : nil;
 }
 
-BOOL ApolloSettingsRouteOpenNow(NSString *routeId) {
+BOOL ApolloSettingsRouteOpenNowInScene(NSString *routeId, UIWindowScene *scene) {
     ApolloSettingsRouterEnsureRegistry();
     ApolloSettingsRouteBuilder builder = [routeId isKindOfClass:[NSString class]] ? sRouteBuilders[routeId.lowercaseString] : nil;
     if (!builder) return NO;
 
-    UIViewController *tabBarController = ApolloMainTabBarController();
+    UIViewController *tabBarController = ApolloMainTabBarControllerForScene(scene);
     if (!tabBarController) return NO;
 
     if ([tabBarController respondsToSelector:@selector(goToSettingsTab)]) {
@@ -167,6 +167,10 @@ BOOL ApolloSettingsRouteOpenNow(NSString *routeId) {
     [nav pushViewController:builder() animated:YES];
     ApolloLog(@"[SettingsRouter] Opened route '%@'", routeId);
     return YES;
+}
+
+BOOL ApolloSettingsRouteOpenNow(NSString *routeId) {
+    return ApolloSettingsRouteOpenNowInScene(routeId, nil);
 }
 
 static void ApolloSettingsRouteOpenWithRetry(NSString *routeId, NSUInteger attempt) {


### PR DESCRIPTION
Preserve the row that owns the detail destination, load tab panes lazily, and coordinate pane chrome with tab visibility, settings routes, and theme surfaces.

Stacked on `je/ipad-03-navigation`; review this PR against that base.

Validation: Simulator target compiled and linked.

Part of the replacement stack for #886. The complete runtime stack remains experimental and opt-in. These draft slices are for review in order; do not ship an intermediate navigation implementation. Foldable/resizable-phone support is a separate follow-up. Existing device-only and performance validation gaps remain recorded in the validation PR.

Review order: #1053 → #1054 → #1055 → #1056 → #1057 → #1058; resizable iPhone support: #1059.
