### PR TITLE
iPad panes 4/4: chrome, search and resize scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,14 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloTabBarHideStyle.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
     $(SRC_DIR)/ipad/ApolloPaneLayout.m \
+    $(SRC_DIR)/ipad/ApolloPaneDiagnostics.m \
+    $(SRC_DIR)/ipad/ApolloPaneGeometry.m \
+    $(SRC_DIR)/ipad/ApolloPaneTransitionObserver.m \
+    $(SRC_DIR)/ipad/ApolloPaneChrome.m \
+    $(SRC_DIR)/ipad/ApolloPaneSidebar.m \
+    $(SRC_DIR)/ipad/ApolloPaneFocus.m \
+    $(SRC_DIR)/ipad/ApolloPaneContent.xm \
+    $(SRC_DIR)/ipad/ApolloPaneColumnHostViewController.m \
     $(SRC_DIR)/ipad/ApolloPaneRouting.m \
     $(SRC_DIR)/ipad/ApolloPaneForwardHistory.m \
     $(SRC_DIR)/ipad/ApolloPaneSplitViewController.m \

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -309,12 +309,10 @@ static BOOL ApolloTabChildWantsNativeMinimize(UIViewController *child) {
         sApolloAutoHidePaneTabScans++;
 #endif
         ApolloPaneSplitViewController *pane = (ApolloPaneSplitViewController *)child;
-        UINavigationController *primary =
-            [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
-        if (ApolloNavWantsNativeTabBarMinimize(primary)) return YES;
-        UINavigationController *detail =
-            [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
-        return detail != primary && ApolloNavWantsNativeTabBarMinimize(detail);
+        if (!pane.isCollapsed) return NO; // Neighboring pane context rows stay fixed.
+        UIViewController *visible = [pane apollo_preferredContentColumnController];
+        return [visible isKindOfClass:UINavigationController.class] &&
+            ApolloNavWantsNativeTabBarMinimize((id)visible);
     }
 
     if ([child isKindOfClass:[UISplitViewController class]]) {
@@ -338,10 +336,7 @@ static BOOL ApolloTabChildWantsNativeMinimize(UIViewController *child) {
 
 static BOOL ApolloTabBarControllerWantsNativeMinimize(UITabBarController *tbc) {
     if (!tbc) return NO;
-    for (UIViewController *child in tbc.viewControllers) {
-        if (ApolloTabChildWantsNativeMinimize(child)) return YES;
-    }
-    return NO;
+    return ApolloTabChildWantsNativeMinimize(tbc.selectedViewController);
 }
 
 #if APOLLO_SIM_BUILD

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -148,6 +148,7 @@ void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *u
 // subreddit/user views). Returns NO if the handler is unavailable — fall back to
 // ApolloPresentWebURLFromViewController.
 BOOL ApolloRouteURLThroughApp(NSURL *url);
+BOOL ApolloRouteURLThroughAppInScene(NSURL *url, UIWindowScene *scene);
 
 // Returns all UIWindows across every connected UIWindowScene.
 // Use instead of the deprecated UIApplication.windows property.

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -622,57 +622,44 @@ CGFloat ApolloNavItemTrailingContentInset(UINavigationItem *item) {
 // the AppDelegate's ivar is nil. The AppDelegate's application:openURL:options:
 // handler (sub_100161d08) reads AppDelegate.tabBarController for navigation,
 // so we ensure it has a reference before calling.
-static BOOL ApolloRouteURLThroughUIApplication(NSURL *url) {
-    if (![url isKindOfClass:[NSURL class]]) {
-        return NO;
-    }
-
-    UIApplication *application = [UIApplication sharedApplication];
-    id<UIApplicationDelegate> appDelegate = [application delegate];
-
-    if (![appDelegate respondsToSelector:@selector(application:openURL:options:)]) {
-        return NO;
-    }
-
-    // Ensure AppDelegate.tabBarController is populated
+extern void *ApolloSwiftExchangePaneTabs(void *storage, const void *object);
+BOOL ApolloRouteURLThroughAppInScene(NSURL *url, UIWindowScene *scene) {
+    if (![url isKindOfClass:NSURL.class] || !NSThread.isMainThread) return NO;
+    UIApplication *application = UIApplication.sharedApplication;
+    id appDelegate = application.delegate;
+    SEL selector = @selector(application:openURL:options:);
+    if (![appDelegate respondsToSelector:selector]) return NO;
+    // Apollo's AppDelegate router uses a legacy tab ivar. Scope that bridge to
+    // this synchronous callback and restore it even if native routing throws.
+    // Never persist one scene's tab controller into a process-global delegate.
+    UITabBarController *tabs = (id)ApolloMainTabBarControllerForScene(scene);
+    if (![tabs isKindOfClass:UITabBarController.class]) return NO;
+    if (scene && tabs.viewIfLoaded.window.windowScene != scene) return NO;
+    Ivar ivar = class_getInstanceVariable([appDelegate class], "tabBarController");
+    Ivar next = class_getInstanceVariable([appDelegate class], "apolloProProducts");
+    // Verified in AppDelegate's native destructor at 0x10016cb10: ldr +
+    // objc_release, followed by apolloProProducts eight bytes later. Swift's
+    // mangled Optional encoding is deliberately not interpreted as ObjC @.
+    if (![appDelegate isMemberOfClass:objc_getClass("_TtC6Apollo11AppDelegate")] || !ivar || !next ||
+        ivar_getOffset(next) - ivar_getOffset(ivar) != sizeof(void *)) return NO;
+    void *storage = (uint8_t *)(__bridge void *)appDelegate + ivar_getOffset(ivar);
+    id previous = (__bridge_transfer id)ApolloSwiftExchangePaneTabs(storage, (__bridge const void *)tabs);
     @try {
-        Ivar appTabBarIvar = class_getInstanceVariable([appDelegate class], "tabBarController");
-        if (appTabBarIvar && !object_getIvar(appDelegate, appTabBarIvar)) {
-            for (UIScene *scene in application.connectedScenes) {
-                if (![scene isKindOfClass:[UIWindowScene class]]) continue;
-                id sceneDelegate = [(UIWindowScene *)scene delegate];
-                if (!sceneDelegate) continue;
-                Ivar sceneTabBarIvar = class_getInstanceVariable([sceneDelegate class], "tabBarController");
-                if (!sceneTabBarIvar) continue;
-                id sceneTabBar = object_getIvar(sceneDelegate, sceneTabBarIvar);
-                if (sceneTabBar) {
-                    ApolloLog(@"[ApolloRouteURL] Copying SceneDelegate tabBarController to AppDelegate");
-                    object_setIvar(appDelegate, appTabBarIvar, sceneTabBar);
-                    break;
-                }
-            }
-        }
-    } @catch (NSException *e) {
-        ApolloLog(@"[ApolloRouteURL] Failed to copy tabBarController: %@", e);
-    }
-
-    // Call the app delegate's URL handler directly — stays in-process,
-    // never hits iOS's URL scheme dispatch.
-    @try {
-        BOOL (*msgSend)(id, SEL, id, id, id) = (BOOL (*)(id, SEL, id, id, id))objc_msgSend;
-        msgSend(appDelegate, @selector(application:openURL:options:), application, url, @{});
-        return YES;
-    } @catch (NSException *exception) {
-        ApolloLog(@"[ApolloRouteURL] application:openURL:options: threw: %@", exception);
+        return ((BOOL (*)(id, SEL, id, id, id))objc_msgSend)(appDelegate, selector, application, url, @{});
+    } @catch (__unused NSException *exception) {
+        ApolloLog(@"[ApolloRouteURL] native route failed");
         return NO;
+    } @finally {
+        __unused id replaced = (__bridge_transfer id)ApolloSwiftExchangePaneTabs(storage, (__bridge const void *)previous);
     }
 }
 
-// Public wrapper: route a reddit URL through Apollo's own handler so posts,
-// comments, subreddits and users open the native views. Returns NO when the
-// handler is unavailable, so callers can fall back to a web view.
+static BOOL ApolloRouteURLThroughUIApplication(NSURL *url) {
+    return ApolloRouteURLThroughAppInScene(url, nil);
+}
+
 BOOL ApolloRouteURLThroughApp(NSURL *url) {
-    return ApolloRouteURLThroughUIApplication(url);
+    return ApolloRouteURLThroughAppInScene(url, nil);
 }
 
 NSURL *ApolloURLByConvertingResolvedURLToApolloScheme(NSURL *url) {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -2622,13 +2622,15 @@ static const void *kApolloDeletedCommentsLinkTapGestureKey = &kApolloDeletedComm
 // "links to reddit posts take you out of Apollo, into the web view"); everything else
 // opens in Apollo's web view.
 static void ApolloDeletedCommentsOpenRecoveredBodyURL(UIViewController *presenter, NSURL *url) {
-    if (!url) return;
+    UIWindowScene *scene = presenter.viewIfLoaded.window.windowScene;
+    if (!url || !scene) return;
     NSString *host = [url.host lowercaseString] ?: @"";
     BOOL isReddit = [host isEqualToString:@"redd.it"] ||
                     [host hasSuffix:@".redd.it"] ||
                     [host isEqualToString:@"reddit.com"] ||
                     [host hasSuffix:@".reddit.com"];
-    if (isReddit && ApolloRouteURLThroughApp(url)) return;
+    if (isReddit && ApolloRouteURLThroughAppInScene(
+        ApolloURLByConvertingResolvedURLToApolloScheme(url) ?: url, scene)) return;
     ApolloPresentWebURLFromViewController(presenter, url);
 }
 

--- a/src/ApolloFindInComments.xm
+++ b/src/ApolloFindInComments.xm
@@ -56,6 +56,7 @@
 #import <objc/message.h>
 
 #import "ApolloCommon.h"
+#import "ipad/ApolloPaneLayout.h"
 
 // MARK: - minimal local Texture declarations
 //
@@ -94,17 +95,46 @@ static const CGFloat kFICMinCorrection = 2.0;         // skip corrections smalle
 
 // MARK: - state
 //
-// One in-thread search is active at a time (the bar is modal to its comments
-// screen), so module-level state + a generation counter is enough. The
-// generation bumps on every selection and on dismiss/disappear; scheduled
-// verification blocks carry the generation they were armed for and bail once
-// it moves on.
+// Each controller owns its asynchronous verification. A second window or a
+// disappearing thread must never cancel another controller's active search.
+@interface ApolloCommentsFindSession : NSObject
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, weak) ASTextNode *matchNode;
+@property (nonatomic) NSRange matchRange;
+@property (nonatomic) NSUInteger generation;
+@end
+@implementation ApolloCommentsFindSession
+- (void)sceneDeactivated:(NSNotification *)notification {
+    if (notification.object != self.controller.viewIfLoaded.window.windowScene) return;
+    self.generation++;
+    self.matchNode = nil;
+    self.matchRange = NSMakeRange(NSNotFound, 0);
+}
+@end
 
-static BOOL sFICCaptureWindow = NO;               // inside a native selection call (main thread)
-static __weak id sFICMatchNode = nil;             // current match's ASTextNode
-static NSRange sFICMatchRange = {NSNotFound, 0};  // current match's range within that node
-static __weak UIViewController *sFICSearchVC = nil;
-static long sFICGeneration = 0;
+static char kFICSessionKey;
+// Only the synchronous native matcher uses a process-local scope. Save/restore
+// it across reentrancy; asynchronous work never consults this pointer.
+static ApolloCommentsFindSession *sFICCaptureSession;
+
+static ApolloCommentsFindSession *FICSession(UIViewController *controller) {
+    ApolloCommentsFindSession *session = objc_getAssociatedObject(controller, &kFICSessionKey);
+    if (!session) {
+        session = [ApolloCommentsFindSession new];
+        session.controller = controller;
+        [NSNotificationCenter.defaultCenter addObserver:session selector:@selector(sceneDeactivated:) name:UISceneWillDeactivateNotification object:nil];
+        session.matchRange = NSMakeRange(NSNotFound, 0);
+        objc_setAssociatedObject(controller, &kFICSessionKey, session, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return session;
+}
+
+static void FICCancel(UIViewController *controller) {
+    ApolloCommentsFindSession *session = objc_getAssociatedObject(controller, &kFICSessionKey);
+    session.generation++;
+    session.matchNode = nil;
+    session.matchRange = NSMakeRange(NSNotFound, 0);
+}
 
 // Multi-term (comma) search: armed only for the synchronous native rebuild.
 static BOOL sFICMultiActive = NO;
@@ -161,23 +191,26 @@ static NSArray<NSString *> *FICParseMultiTerms(NSString *query) {
 
 // MARK: - verification / correction
 
-static void FICScheduleVerifyPass(long gen, int passesLeft, NSTimeInterval delay);
+static void FICScheduleVerifyPass(ApolloCommentsFindSession *session, NSUInteger gen, int passesLeft, NSTimeInterval delay);
 
 // One verification pass: recompute where the current match actually sits now
 // and nudge it into view if the native scroll left it outside. Returns YES if
 // a follow-up pass is worth scheduling (we corrected, or geometry wasn't ready).
-static BOOL FICVerifyOnce(long gen) {
-    if (gen != sFICGeneration) return NO;
+static BOOL FICVerifyOnce(ApolloCommentsFindSession *session, NSUInteger gen) {
+    if (!session || gen != session.generation) return NO;
 
-    UIViewController *vc = sFICSearchVC;
-    ASTextNode *node = sFICMatchNode;
+    UIViewController *vc = session.controller;
+    ASTextNode *node = session.matchNode;
     if (!vc || !node || !vc.viewLoaded) return NO;
-    if (sFICMatchRange.location == NSNotFound) return NO;
+    if (session.matchRange.location == NSNotFound) return NO;
     if (!FICSearchIsActive(vc)) return NO;   // bar dismissed / query cleared
 
     ASTableNode *tableNode = FICObjectIvar(vc, "tableNode");
     UITableView *tableView = [tableNode isNodeLoaded] ? [tableNode view] : nil;
     if (!tableView || !tableView.window) return NO;
+    if (@available(iOS 13.0, *)) {
+        if (tableView.window.windowScene.activationState != UISceneActivationStateForegroundActive) return NO;
+    }
 
     // Highlight repaint: when the selected match's node was far off-screen,
     // its first display (kicked off while the animated scroll approached) can
@@ -202,14 +235,15 @@ static BOOL FICVerifyOnce(long gen) {
     while (cellNode && ![cellNode isKindOfClass:cellClass]) cellNode = cellNode.supernode;
     if (!cellNode) return NO;
     NSIndexPath *indexPath = [tableNode indexPathForNode:(ASCellNode *)cellNode];
-    if (!indexPath) return NO;               // row got recycled/reloaded from under the search
+    if (!indexPath || indexPath.section >= tableView.numberOfSections ||
+        indexPath.row >= [tableView numberOfRowsInSection:indexPath.section]) return NO;               // row got recycled/reloaded from under the search
     CGRect rowRect = [tableView rectForRowAtIndexPath:indexPath];
 
     // Match rect inside the row; falls back to the whole row while the text
     // node still has no calculated layout (frameForTextRange comes back empty).
     CGRect matchRect = rowRect;
     BOOL usedRowFallback = YES;
-    CGRect textRect = [node frameForTextRange:sFICMatchRange];
+    CGRect textRect = [node frameForTextRange:session.matchRange];
     if (!CGRectIsEmpty(textRect)) {
         CGRect inCell = [node convertRect:textRect toNode:cellNode];
         if (!CGRectIsEmpty(inCell) && !isnan(inCell.origin.y)) {
@@ -272,16 +306,18 @@ static BOOL FICVerifyOnce(long gen) {
               CGRectGetMinY(visible), CGRectGetMaxY(visible),
               usedRowFallback ? @", row fallback" : @"",
               tableView.contentOffset.y, targetY);
-    [tableView setContentOffset:CGPointMake(tableView.contentOffset.x, targetY) animated:YES];
+    [tableView setContentOffset:CGPointMake(tableView.contentOffset.x, targetY) animated:!UIAccessibilityIsReduceMotionEnabled()];
     return YES;
 }
 
-static void FICScheduleVerifyPass(long gen, int passesLeft, NSTimeInterval delay) {
+static void FICScheduleVerifyPass(ApolloCommentsFindSession *session, NSUInteger gen, int passesLeft, NSTimeInterval delay) {
     if (passesLeft <= 0) return;
+    __weak ApolloCommentsFindSession *weakSession = session;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (gen != sFICGeneration) return;
-        if (FICVerifyOnce(gen)) {
-            FICScheduleVerifyPass(gen, passesLeft - 1, kFICVerifyDelay2);
+        ApolloCommentsFindSession *session = weakSession;
+        if (!session || gen != session.generation) return;
+        if (FICVerifyOnce(session, gen)) {
+            FICScheduleVerifyPass(session, gen, passesLeft - 1, kFICVerifyDelay2);
         }
     });
 }
@@ -289,15 +325,20 @@ static void FICScheduleVerifyPass(long gen, int passesLeft, NSTimeInterval delay
 // Arms capture + verification around one native selection call. The selector
 // runs synchronously: the match list is (re)built if needed and the current
 // match's frameForTextRange: fires inside, giving us the node + range.
-static void FICRunSelection(dispatch_block_t orig) {
-    long gen = ++sFICGeneration;
-    sFICMatchNode = nil;
-    sFICMatchRange = NSMakeRange(NSNotFound, 0);
-    sFICCaptureWindow = YES;
-    orig();
-    sFICCaptureWindow = NO;
-    if (sFICMatchNode && sFICMatchRange.location != NSNotFound) {
-        FICScheduleVerifyPass(gen, kFICMaxPasses, kFICVerifyDelay1);
+static void FICRunSelection(UIViewController *controller, dispatch_block_t orig) {
+    ApolloCommentsFindSession *session = FICSession(controller);
+    NSUInteger gen = ++session.generation;
+    session.matchNode = nil;
+    session.matchRange = NSMakeRange(NSNotFound, 0);
+    ApolloCommentsFindSession *previous = sFICCaptureSession;
+    sFICCaptureSession = session;
+    @try {
+        orig();
+    } @finally {
+        sFICCaptureSession = previous;
+    }
+    if (session.matchNode && session.matchRange.location != NSNotFound) {
+        FICScheduleVerifyPass(session, gen, kFICMaxPasses, kFICVerifyDelay1);
     }
 }
 
@@ -310,9 +351,9 @@ static void FICRunSelection(dispatch_block_t orig) {
 // earlier in the routine, so last-write-wins records the right node + range.
 %hook ASTextNode
 - (CGRect)frameForTextRange:(NSRange)range {
-    if (sFICCaptureWindow && [NSThread isMainThread]) {
-        sFICMatchNode = self;
-        sFICMatchRange = range;
+    if ([NSThread isMainThread] && sFICCaptureSession) {
+        sFICCaptureSession.matchNode = (ASTextNode *)self;
+        sFICCaptureSession.matchRange = range;
     }
     return %orig;
 }
@@ -320,9 +361,9 @@ static void FICRunSelection(dispatch_block_t orig) {
 
 %hook ASTextNode2
 - (CGRect)frameForTextRange:(NSRange)range {
-    if (sFICCaptureWindow && [NSThread isMainThread]) {
-        sFICMatchNode = self;
-        sFICMatchRange = range;
+    if ([NSThread isMainThread] && sFICCaptureSession) {
+        sFICCaptureSession.matchNode = (ASTextNode *)self;
+        sFICCaptureSession.matchRange = range;
     }
     return %orig;
 }
@@ -355,6 +396,146 @@ static void FICRunSelection(dispatch_block_t orig) {
 }
 %end
 
+// UIKit owns one find panel; Apollo still owns matching and decoration.
+// The hidden native field is only the input adapter, never a second responder.
+API_AVAILABLE(ios(16.0))
+@interface ApolloPaneFindAdapter : UIFindSession <UIFindInteractionDelegate>
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, strong) UIFindInteraction *interaction;
+@property (nonatomic) BOOL previousSearching;
+@property (nonatomic) BOOL previousToolbarHidden;
+@end
+
+static char kPaneFindAdapter;
+static char kPaneFindToolbarBand;
+
+API_AVAILABLE(ios(16.0))
+@implementation ApolloPaneFindAdapter
+- (UITextField *)nativeField { return FICObjectIvar(self.controller, "searchTextField"); }
+- (NSArray<NSNumber *> *)nativeCounts {
+    UILabel *label = FICObjectIvar(self.controller, "searchIndexInfoLabel");
+    NSArray *parts = [label.text componentsSeparatedByCharactersInSet:NSCharacterSet.decimalDigitCharacterSet.invertedSet];
+    NSMutableArray *counts = [NSMutableArray array];
+    for (NSString *part in parts) if (part.length) [counts addObject:@(part.integerValue)];
+    return counts;
+}
+- (NSInteger)resultCount {
+    NSArray *counts = self.nativeCounts;
+    return counts.count == 2 ? [counts[1] integerValue] : 0;
+}
+- (NSInteger)highlightedResultIndex {
+    NSArray *counts = self.nativeCounts;
+    return counts.count == 2 && [counts[0] integerValue] > 0 ? [counts[0] integerValue] - 1 : NSNotFound;
+}
+- (BOOL)supportsReplacement { return NO; }
+- (void)performSearchWithQuery:(NSString *)query options:(UITextSearchOptions *)options {
+    (void)options; // unsupported match modes are omitted from the options menu.
+    UITextField *field = self.nativeField;
+    if (!field || !self.controller) return;
+    field.text = query;
+    ((void (*)(id, SEL, id))objc_msgSend)(self.controller,
+        NSSelectorFromString(@"textFieldEditingChangedWithSender:"), field);
+    [self.interaction updateResultCount];
+}
+- (void)highlightNextResultInDirection:(UITextStorageDirection)direction {
+    SEL selector = NSSelectorFromString(direction == UITextStorageDirectionForward
+        ? @"nextResultButtonTappedWithSender:" : @"previousResultButtonTappedWithSender:");
+    if ([self.controller respondsToSelector:selector]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(self.controller, selector, self.nativeField);
+        [self.interaction updateResultCount];
+    }
+}
+- (UIFindSession *)findInteraction:(UIFindInteraction *)interaction sessionForView:(UIView *)view {
+    return self.nativeField ? self : nil;
+}
+- (void)findInteraction:(UIFindInteraction *)interaction didBeginFindSession:(UIFindSession *)session {
+    ptrdiff_t offset = FICIvarOffset(self.controller, "isSearching");
+    if (offset >= 0) {
+        uint8_t *flag = (uint8_t *)(__bridge void *)self.controller + offset;
+        self.previousSearching = *flag != 0;
+        *flag = 1;
+    }
+    UIView *toolbar = FICObjectIvar(self.controller, "upperToolbar");
+    self.previousToolbarHidden = toolbar.hidden;
+    toolbar.hidden = YES;
+}
+- (void)findInteraction:(UIFindInteraction *)interaction didEndFindSession:(UIFindSession *)session {
+    [self performSearchWithQuery:@"" options:nil];
+    FICCancel(self.controller);
+    ptrdiff_t offset = FICIvarOffset(self.controller, "isSearching");
+    if (offset >= 0) *((uint8_t *)(__bridge void *)self.controller + offset) = self.previousSearching;
+    UIView *toolbar = FICObjectIvar(self.controller, "upperToolbar");
+    toolbar.hidden = self.previousToolbarHidden;
+}
+@end
+
+extern "C" BOOL ApolloPanePrepareCommentsFind(UIViewController *controller) {
+    if (!ApolloPaneSplitControllerFor(controller) || !FICIsCommentsSearchVC(controller)) return NO;
+    if (@available(iOS 16.0, *)) {
+        if (!FICObjectIvar(controller, "searchTextField")) return NO;
+        ApolloPaneFindAdapter *adapter = objc_getAssociatedObject(controller, &kPaneFindAdapter);
+        if (!adapter) {
+            adapter = [ApolloPaneFindAdapter new];
+            adapter.controller = controller;
+            adapter.interaction = [[UIFindInteraction alloc] initWithSessionDelegate:adapter];
+            adapter.interaction.optionsMenuProvider = ^UIMenu *(NSArray<UIMenuElement *> *options) {
+                return [UIMenu menuWithTitle:@"" children:@[]];
+            };
+            [controller.view addInteraction:adapter.interaction];
+            objc_setAssociatedObject(controller, &kPaneFindAdapter, adapter, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        UIView *toolbar = FICObjectIvar(controller, "upperToolbar");
+        ASTableNode *node = FICObjectIvar(controller, "tableNode");
+        UITableView *table = node.isNodeLoaded ? node.view : nil;
+        if (!objc_getAssociatedObject(table, &kPaneFindToolbarBand)) {
+            CGFloat band = CGRectGetHeight(toolbar.bounds);
+            if (band > 0.0 && band < 120.0) {
+                objc_setAssociatedObject(table, &kPaneFindToolbarBand, @(band), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                UIEdgeInsets inset = table.contentInset;
+                if (fabs(inset.top - band) <= 1.0) { inset.top = 0; table.contentInset = inset; }
+            }
+        }
+        toolbar.hidden = YES;
+        return YES;
+    }
+    return NO;
+}
+
+extern "C" BOOL ApolloPanePresentCommentsFind(UIViewController *controller) {
+    if (!ApolloPanePrepareCommentsFind(controller)) return NO;
+    if (@available(iOS 16.0, *)) {
+        ApolloPaneFindAdapter *adapter = objc_getAssociatedObject(controller, &kPaneFindAdapter);
+        [adapter.interaction presentFindNavigatorShowingReplace:NO];
+        return YES;
+    }
+    return NO;
+}
+
+#if APOLLO_SIM_BUILD
+extern "C" NSDictionary *ApolloPaneSimFind(UIViewController *controller, NSString *operation) {
+    if (!ApolloPanePrepareCommentsFind(controller)) return @{@"supported": @NO};
+    if (@available(iOS 16.0, *)) {
+        ApolloPaneFindAdapter *adapter = objc_getAssociatedObject(controller, &kPaneFindAdapter);
+        if ([operation isEqualToString:@"open"]) ApolloPanePresentCommentsFind(controller);
+        if ([operation hasPrefix:@"query "]) [adapter performSearchWithQuery:[operation substringFromIndex:6] options:nil];
+        if ([operation isEqualToString:@"next"]) [adapter highlightNextResultInDirection:UITextStorageDirectionForward];
+        if ([operation isEqualToString:@"previous"]) [adapter highlightNextResultInDirection:UITextStorageDirectionBackward];
+        if ([operation isEqualToString:@"dismiss"]) [adapter.interaction dismissFindNavigator];
+        return @{@"supported": @YES, @"count": @(adapter.resultCount), @"highlightedIndex": @(adapter.highlightedResultIndex),
+            @"hasQuery": @(adapter.nativeField.text.length > 0)};
+    }
+    return @{@"supported": @NO};
+}
+#endif
+
+%hook ASTableView
+- (void)setContentInset:(UIEdgeInsets)inset {
+    NSNumber *band = objc_getAssociatedObject(self, &kPaneFindToolbarBand);
+    if (band && fabs(inset.top - band.doubleValue) <= 1.0) inset.top = 0;
+    %orig(inset);
+}
+%end
+
 // MARK: - hooks: selection entry points
 //
 // Every path that (re)selects a match is one of these three ObjC methods
@@ -365,49 +546,61 @@ static void FICRunSelection(dispatch_block_t orig) {
 %hook _TtC6Apollo22CommentsViewController
 
 - (void)nextResultButtonTappedWithSender:(id)sender {
-    FICRunSelection(^{ %orig; });
+    FICRunSelection((UIViewController *)self, ^{ %orig; });
 }
 
 - (void)previousResultButtonTappedWithSender:(id)sender {
-    FICRunSelection(^{ %orig; });
+    FICRunSelection((UIViewController *)self, ^{ %orig; });
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
     %orig;
-    sFICGeneration++;   // cancel any pending verification for this screen
+    FICCancel((UIViewController *)self);
+    if (@available(iOS 16.0, *)) {
+        ApolloPaneFindAdapter *adapter = objc_getAssociatedObject(self, &kPaneFindAdapter);
+        [adapter.interaction dismissFindNavigator];
+    }
 }
 
 %end
 
 %hook _TtC6Apollo21ASTableViewController
 
+- (void)textFieldDidBeginEditing:(UITextField *)field {
+    if (FICIsCommentsSearchVC(self) && ApolloPaneSplitControllerFor((UIViewController *)self)) {
+        [field resignFirstResponder];
+        if (ApolloPanePresentCommentsFind((UIViewController *)self)) return;
+    }
+    %orig;
+}
+
 - (void)textFieldEditingChangedWithSender:(id)sender {
     if (!FICIsCommentsSearchVC(self)) {   // feed search bar shares this class — leave it alone
         %orig;
         return;
     }
-    sFICSearchVC = (UIViewController *)self;
 
     NSString *query = nil;
     if ([sender respondsToSelector:@selector(text)]) query = [sender text];
     NSArray<NSString *> *terms = FICParseMultiTerms(query);
-    if (terms) {
-        sFICMultiTerms = terms;
-        sFICMultiQuery = query;
-        sFICMultiActive = YES;
-        ApolloLog(@"[FindInComments] multi-term search: %lu terms", (unsigned long)terms.count);
+    BOOL previousActive = sFICMultiActive;
+    NSArray<NSString *> *previousTerms = sFICMultiTerms;
+    NSString *previousQuery = sFICMultiQuery;
+    sFICMultiTerms = terms;
+    sFICMultiQuery = query;
+    sFICMultiActive = terms != nil;
+    @try {
+        FICRunSelection((UIViewController *)self, ^{ %orig; });
+    } @finally {
+        sFICMultiActive = previousActive;
+        sFICMultiTerms = previousTerms;
+        sFICMultiQuery = previousQuery;
     }
-    FICRunSelection(^{ %orig; });
-    sFICMultiActive = NO;
-    sFICMultiTerms = nil;
-    sFICMultiQuery = nil;
 }
 
 - (void)dismissSearchBarButtonTappedWithSender:(id)sender {
     if (FICIsCommentsSearchVC(self)) {
-        sFICGeneration++;
-        sFICMatchNode = nil;
-        sFICMatchRange = NSMakeRange(NSNotFound, 0);
+        FICCancel((UIViewController *)self);
     }
     %orig;
 }

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -2209,7 +2209,8 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 // behind it.
 - (void)apollo_openCurrentPost {
     NSURL *postURL = [self apollo_currentItem].postURL;
-    if (!postURL) return;
+    UIWindowScene *originatingScene = self.viewIfLoaded.window.windowScene;
+    if (!postURL || !originatingScene) return;
     if (!self.isDismissing) {
         self.isDismissing = YES;
         [self apollo_notifyWillDismiss];
@@ -2218,9 +2219,9 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         // Apollo's URL handler only acts on apollo:// URLs — handing it the raw
         // https reddit.com link is silently ignored. The scheme conversion is
         // what every other in-app route in the tweak goes through.
-        if (ApolloRouteResolvedURLViaApolloScheme(postURL)) return;
-        if (!ApolloRouteURLThroughApp(postURL)) {
-            ApolloLog(@"[Gallery] couldn't route %@ through the app", postURL.absoluteString);
+        NSURL *nativeURL = ApolloURLByConvertingResolvedURLToApolloScheme(postURL) ?: postURL;
+        if (!ApolloRouteURLThroughAppInScene(nativeURL, originatingScene)) {
+            ApolloLog(@"[Gallery] native post route unavailable");
         }
     }];
 }

--- a/src/ApolloImmersiveHeaderBackground.m
+++ b/src/ApolloImmersiveHeaderBackground.m
@@ -1,3 +1,4 @@
+#import "ipad/ApolloPaneChrome.h"
 #import "ApolloImmersiveHeaderBackground.h"
 
 #import <CoreImage/CoreImage.h>
@@ -324,6 +325,7 @@ static void ApolloImmersiveRequestBackdrop(UIImage *banner, void (^completion)(U
 @property(nonatomic, strong) UIView *contentContainer;
 @property(nonatomic, strong) UIImageView *backdropView;
 @property(nonatomic, strong) CAGradientLayer *veilLayer;
+@property(nonatomic, strong) UIView *paneChromeCover;
 @property(nonatomic, strong) UIView *sharpClip;
 @property(nonatomic, strong) UIImageView *sharpView;
 @property(nonatomic, strong) CAGradientLayer *sharpFeatherMask;
@@ -396,6 +398,10 @@ static void ApolloImmersiveRequestBackdrop(UIImage *banner, void (^completion)(U
     // theme's chrome text color in both light and dark.
     _chromeScrimLayer = [CAGradientLayer layer];
     [_contentContainer.layer addSublayer:_chromeScrimLayer];
+    _paneChromeCover = [UIView new];
+    _paneChromeCover.userInteractionEnabled = NO;
+    _paneChromeCover.hidden = YES;
+    [self addSubview:_paneChromeCover];
     return self;
 }
 
@@ -466,6 +472,12 @@ static void ApolloImmersiveRequestBackdrop(UIImage *banner, void (^completion)(U
     CGFloat extendedHeight = MIN(self.extendedHeight, totalHeight);
     UIColor *pageColor = [self.pageColor resolvedColorWithTraitCollection:self.traitCollection];
     self.backgroundColor = pageColor;
+    CGFloat boundary = ApolloPaneContextBottomInView(self);
+    BOOL hideCover = boundary <= 0.0;
+    if (self.paneChromeCover.hidden != hideCover) self.paneChromeCover.hidden = hideCover;
+    if (![self.paneChromeCover.backgroundColor isEqual:pageColor]) self.paneChromeCover.backgroundColor = pageColor;
+    CGRect coverFrame = CGRectMake(0, 0, width, MIN(totalHeight, boundary));
+    if (!CGRectEqualToRect(self.paneChromeCover.frame, coverFrame)) self.paneChromeCover.frame = coverFrame;
 
     CGAffineTransform transform = self.contentContainer.transform;
     self.contentContainer.transform = CGAffineTransformIdentity;

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -75,6 +75,7 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
+#import "ipad/ApolloPaneLayout.h"
 #import "ApolloSearchNativeBar.h"
 
 // Apollo's animator object -> the most recently built UIViewPropertyAnimator.
@@ -127,7 +128,7 @@ static UIView *ApolloNavMakeShadowView(CGRect frame, UITraitCollection *traits) 
     layer.shadowOpacity = 0.3f;
     layer.shadowPath = [UIBezierPath bezierPathWithRect:shadow.bounds].CGPath;
     layer.shouldRasterize = YES;
-    layer.rasterizationScale = UIScreen.mainScreen.scale;
+    layer.rasterizationScale = MAX(1.0, traits.displayScale);
     return shadow;
 }
 
@@ -146,7 +147,11 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     UISearchController *fromSearch = fromVC.navigationItem.searchController;
     BOOL restoreSearchOnCancel = ApolloNativeFeedSearchEnabled() && !fromSearch.active &&
                                  CGRectGetHeight(fromSearch.searchBar.bounds) > 1.0;
-    CGFloat width = CGRectGetWidth(container.bounds);
+    BOOL paneTransition = ApolloPaneSplitControllerFor(fromVC) || ApolloPaneSplitControllerFor(toVC);
+    BOOL reduceMotion = paneTransition && UIAccessibilityIsReduceMotionEnabled();
+    CGFloat fromAlpha = fromView.alpha, toAlpha = toView.alpha;
+    CGFloat direction = paneTransition && container.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft ? -1.0 : 1.0;
+    CGFloat width = CGRectGetWidth(container.bounds) * direction;
     CGFloat parallax = width / kApolloNavParallaxDivisor;
 
     CGRect fromRest = (CGRect){CGPointZero, fromView.bounds.size};
@@ -176,6 +181,14 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
         [container insertSubview:dim belowSubview:shadow];
     }
 
+    if (reduceMotion) {
+        fromView.frame = fromRest;
+        toView.frame = toRest;
+        toView.alpha = push ? 0.0 : toAlpha;
+        shadow.hidden = YES;
+        dim.hidden = YES;
+    }
+
     // UIKit does this itself for non-interruptible animators; without it the touch that
     // began the edge pan keeps feeding the cell under the finger (delayed highlight flash).
     BOOL fromWasInteractive = fromView.userInteractionEnabled;
@@ -192,9 +205,9 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     // can sit at partial alpha indefinitely and then reverse, which is where a capsule on the
     // incoming title reads as a stray bubble. A timed push/pop cross-fades capsule and title
     // together in half a second, exactly as it always did.
-    NSTimeInterval duration = interactive ? kApolloNavInteractiveDuration : kApolloNavNonInteractiveDuration;
+    NSTimeInterval duration = reduceMotion ? 0.16 : (interactive ? kApolloNavInteractiveDuration : kApolloNavNonInteractiveDuration);
     UIViewPropertyAnimator *animator;
-    if (interactive) {
+    if (interactive || reduceMotion) {
         animator = [[UIViewPropertyAnimator alloc] initWithDuration:duration
                                                               curve:UIViewAnimationCurveLinear
                                                          animations:nil];
@@ -205,7 +218,10 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
     }
 
     [animator addAnimations:^{
-        if (push) {
+        if (reduceMotion) {
+            if (push) toView.alpha = toAlpha;
+            else fromView.alpha = 0.0;
+        } else if (push) {
             toView.frame = toRest;
             shadow.frame = toRest;
             fromView.frame = CGRectOffset(fromRest, -parallax, 0.0);
@@ -226,6 +242,8 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
             // Reversal already put the views back; make the rest frames exact.
             fromView.frame = fromRest;
         }
+        fromView.alpha = fromAlpha;
+        toView.alpha = toAlpha;
         fromView.userInteractionEnabled = fromWasInteractive;
         toView.userInteractionEnabled = toWasInteractive;
         ApolloLog(@"[InterruptibleNav] %s animator for ctx %p finished (cancelled=%d)",
@@ -283,7 +301,7 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
 %end
 
 %ctor {
-    if (!IsLiquidGlass()) return;
+    if (!IsLiquidGlass() && !ApolloPaneLayoutEnabled()) return;
     Class animatorClass = objc_getClass("_TtC6Apollo24ApolloNavigationAnimator");
     if (!animatorClass || !class_getInstanceVariable(animatorClass, "isPresenting")) {
         ApolloLog(@"[InterruptibleNav] ApolloNavigationAnimator not found or changed shape; inactive");

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -1,3 +1,4 @@
+#import "ipad/ApolloPaneChrome.h"
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
@@ -1072,7 +1073,7 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         CGFloat targetAlpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
         self.glassView.alpha = targetAlpha;
         [hostView insertSubview:self.glassView atIndex:0];
-        if (self.fadeNextInstall) {
+        if (self.fadeNextInstall && !UIAccessibilityIsReduceMotionEnabled()) {
             self.fadeNextInstall = NO;
             UIVisualEffectView *installed = self.glassView;
             installed.alpha = 0.0;
@@ -1141,6 +1142,12 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
 
 - (void)refreshTargets {
     UIView *jumpBar = ApolloFindJumpBar(self.titleControl);
+    if (!jumpBar && ApolloPaneUsesUnifiedChrome(self.titleControl)) {
+        [self.glassView removeFromSuperview];
+        self.glassView = nil;
+        self.observationValid = NO;
+        return;
+    }
     UIView *hostView = jumpBar ?: self.titleControl;
     NSMutableArray<UIView *> *glassCandidates = [NSMutableArray array];
 
@@ -1203,8 +1210,12 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
 
 - (void)scheduleTargetRefreshIfNeeded {
     UIView *titleControl = self.titleControl;
-    if (!titleControl) return;
+    if (!titleControl || self.refreshScheduled) return;
     UIView *jumpBar = ApolloFindJumpBar(titleControl);
+    if (!jumpBar && ApolloPaneUsesUnifiedChrome(titleControl)) {
+        if (self.glassView) [self scheduleTargetRefresh];
+        return;
+    }
     BOOL unchanged = self.observationValid &&
         CGRectEqualToRect(self.observedTitleFrame, titleControl.frame) &&
         CGRectEqualToRect(self.observedTitleBounds, titleControl.bounds) &&

--- a/src/ApolloSearchNativeBar.xm
+++ b/src/ApolloSearchNativeBar.xm
@@ -41,6 +41,8 @@
 #import "ApolloState.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloSearchNativeBar.h"
+#import "ipad/ApolloPaneChrome.h"
+#import "ipad/ApolloPaneLayout.h"
 
 // Forward ref for the geometry hooks (same pattern as ApolloSearchInPlace.xm).
 @interface ASTableView : UITableView
@@ -91,41 +93,60 @@ static BOOL NSBRetargetApolloTopPark(UIScrollView *sv, CGFloat *y);
 
 // MARK: - Session state
 //
-// Only one feed search is ever active at a time; the session is keyed to the
-// controller whose native bar last began editing. Everything is __weak so a
-// popped controller degrades to "no session" with no teardown bookkeeping.
-static __weak UIViewController *sNSBSessionVC    = nil;
-static __weak UIScrollView     *sNSBSessionTable = nil;
-static __weak UINavigationBar  *sNSBSessionNav   = nil;
-static BOOL sNSBSessionTyped   = NO;
-static BOOL sNSBTransitioning  = NO;  // feed VC is disappearing (push/pop in flight)  // Apollo's isSearching was engaged (needs a real dismiss)
-static BOOL sNSBUserScrolled   = NO;  // user dragged the results — stop pinning so they can browse
-static NSUInteger sNSBDismissGen = 0; // stale-timer guard for the settle snap
-// Separate generation for the clear button's DEFERRED reload. Kept apart from
-// sNSBDismissGen so bumping it can never perturb the dismiss settle timers:
-// any new keystroke, another clear, or a cancel invalidates a pending reload.
-static NSUInteger sNSBClearGen = 0;
-// YES for the length of a dismiss: refuse Apollo's spurious refreshControl=nil.
-static BOOL sNSBGuardRefreshControl = NO;
-// Dismiss window: for ~1.4s after cancel, Apollo's model-reset re-parks the
-// inset/offset for ITS resting shape (and mid-morph values). The final
-// geometry is already known when the X is tapped — the nav bar (palette
-// included) does not move during the cancel — so correct every re-park write
-// INLINE to the captured target. Without this the reload renders at the wrong
-// rest and the settle timers hop it into place a visible beat later.
-static BOOL    sNSBDismissWindow    = NO;
-static BOOL    sNSBDismissScrolling = NO;  // YES while the retargeted scroll-back animates
-// YES between the cancel tap and Apollo's scroll-back actually running. The
-// per-frame pins must stay down for that gap: firing one early snaps the feed
-// to the rest in a single frame, and Apollo's animation then has nothing left
-// to travel — the teleport we are trying to remove.
-static BOOL    sNSBAwaitingScroll    = NO;
-static CGFloat sNSBDismissTargetTop = 0.0;
+// A controller owns its query and geometry corrections. Views carry an O(1)
+// association to that session; no window traversal or process-global “active
+// search” can make a second scene cancel the first scene's pending work.
+@class ApolloNSBScrollTween;
+@interface ApolloNativeFeedSession : NSObject
+@property (nonatomic, weak) UIViewController *controller;
+@property (nonatomic, weak) UIScrollView *table;
+@property (nonatomic, weak) UINavigationBar *navigationBar;
+@property (nonatomic) BOOL typed;
+@property (nonatomic) BOOL transitioning;
+@property (nonatomic) BOOL userScrolled;
+@property (nonatomic) NSUInteger dismissGeneration;
+@property (nonatomic) NSUInteger clearGeneration;
+@property (nonatomic) BOOL guardRefreshControl;
+@property (nonatomic) BOOL dismissWindow;
+@property (nonatomic) BOOL dismissScrolling;
+@property (nonatomic) BOOL awaitingScroll;
+@property (nonatomic) BOOL chromeUpdatePending;
+@property (nonatomic) CGFloat dismissTargetTop;
+@property (nonatomic) CGFloat toolbarBand;
+@property (nonatomic, strong) ApolloNSBScrollTween *tween;
+@end
+@implementation ApolloNativeFeedSession
+- (instancetype)init {
+    if ((self = [super init])) _toolbarBand = 45.0;
+    return self;
+}
+@end
+@interface ApolloNativeFeedSession (SceneLifetime)
+- (void)sceneDeactivated:(NSNotification *)notification;
+@end
+static const void *kNSBSessionKey = &kNSBSessionKey;
+static ApolloNativeFeedSession *NSBSessionForView(UIView *view) {
+    return view ? objc_getAssociatedObject(view, kNSBSessionKey) : nil;
+}
+static ApolloNativeFeedSession *NSBSessionForVC(UIViewController *vc) {
+    if (!vc) return nil;
+    ApolloNativeFeedSession *session = objc_getAssociatedObject(vc, kNSBSessionKey);
+    if (!session) {
+        session = [ApolloNativeFeedSession new];
+        session.controller = vc;
+        [NSNotificationCenter.defaultCenter addObserver:session selector:@selector(sceneDeactivated:) name:UISceneWillDeactivateNotification object:nil];
+        objc_setAssociatedObject(vc, kNSBSessionKey, session, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return session;
+}
+static void NSBMarkSessionView(UIView *view, ApolloNativeFeedSession *session) {
+    if (view && NSBSessionForView(view) != session)
+        objc_setAssociatedObject(view, kNSBSessionKey, session, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
 
 static const void *kNSBBridgeKey     = &kNSBBridgeKey;      // VC -> bridge delegate object
 static const void *kNSBFeedTableKey  = &kNSBFeedTableKey;   // ASTableView -> @YES (native-managed feed)
 static const void *kNSBAppearedKey   = &kNSBAppearedKey;    // VC -> @YES once it has appeared at least once
-static CGFloat sNSBToolbarBand = 45.0; // Apollo's resting toolbar height (the band its inset reserves)
 // How far above the safe area a resting write may sit and still count as one:
 // the toolbar band (45pt fresh, 37pt on a feed restored after a post) plus
 // room for the taller values Apollo computes mid nav-morph.
@@ -174,7 +195,13 @@ static BOOL NSBTraceEnabled(void) {
 // output back at us, and an earlier subtract-and-floor attempt compounded on
 // those echoes.
 static void NSBRelativizeInset(UIScrollView *sv, UIEdgeInsets *inset) {
+    ApolloNativeFeedSession *session = NSBSessionForView(sv);
     UIEdgeInsets safe = sv.safeAreaInsets;
+    // Pane hosts put the table below the real context row, so their safe top
+    // is legitimately zero. The hidden native toolbar still writes its band;
+    // the phone-only safe.top > 1 guard used to leave a blank 45pt pane row.
+    if (safe.top <= 1.0 && ApolloPaneUsesUnifiedChrome(sv) &&
+        inset->top >= 0.0 && inset->top <= kNSBBandSlack) inset->top = 0.0;
 
     // Top. A write within a band's reach of the safe area is a resting write —
     // that covers the settled shape, the smaller value Apollo runs while a
@@ -184,7 +211,7 @@ static void NSBRelativizeInset(UIScrollView *sv, UIEdgeInsets *inset) {
     // spinner) still gets its room. Idempotent: 0 maps back to 0.
     if (safe.top > 1.0 && inset->top >= safe.top - kNSBBandSlack) {
         CGFloat extra = inset->top - safe.top;
-        inset->top = (extra <= kNSBBandSlack) ? 0.0 : (extra - sNSBToolbarBand);
+        inset->top = (extra <= kNSBBandSlack) ? 0.0 : (extra - session.toolbarBand);
         if (inset->top < 0.0) inset->top = 0.0;
     }
 
@@ -201,7 +228,7 @@ static void NSBRelativizeInset(UIScrollView *sv, UIEdgeInsets *inset) {
 }
 
 BOOL ApolloNativeFeedSearchEnabled(void) {
-    return IsLiquidGlass();
+    return IsLiquidGlass() || ApolloPaneLayoutActive();
 }
 
 static BOOL NSBRetargetApolloTopPark(UIScrollView *sv, CGFloat *y) {
@@ -216,17 +243,18 @@ static BOOL NSBRetargetApolloTopPark(UIScrollView *sv, CGFloat *y) {
     return YES;
 }
 
-static NSString *NSBSessionQueryText(void) {
-    UIViewController *vc = sNSBSessionVC;
+static NSString *NSBSessionQueryText(ApolloNativeFeedSession *session) {
+    UIViewController *vc = session.controller;
     if (!vc) return nil;
     UITextField *field = (UITextField *)ApolloNSBObjectIvar(vc, "searchTextField");
     return [field isKindOfClass:[UITextField class]] ? field.text : nil;
 }
 
 BOOL ApolloNativeFeedSearchActiveQuery(UIScrollView *tableView) {
+    ApolloNativeFeedSession *session = NSBSessionForView(tableView);
     return ApolloNativeFeedSearchEnabled() && tableView != nil &&
-           tableView == sNSBSessionTable && sNSBSessionTyped &&
-           NSBSessionQueryText().length > 0;
+           tableView == session.table && session.typed &&
+           NSBSessionQueryText(session).length > 0;
 }
 
 // A feed controller we manage: an ASTableViewController with Apollo's search
@@ -242,7 +270,11 @@ static BOOL NSBIsNativeSearchFeedVC(UIViewController *vc) {
 static UIScrollView *NSBTableForVC(UIViewController *vc) {
     id tableNode = ApolloNSBObjectIvar(vc, "tableNode");
     UIView *tv = [tableNode respondsToSelector:@selector(view)] ? [tableNode view] : nil;
-    return [tv isKindOfClass:objc_getClass("ASTableView")] ? (UIScrollView *)tv : nil;
+    if (![tv isKindOfClass:objc_getClass("ASTableView")]) return nil;
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
+    session.table = (UIScrollView *)tv;
+    NSBMarkSessionView(tv, session);
+    return (UIScrollView *)tv;
 }
 
 static UIViewController *NSBFeedVCForView(UIView *view) {
@@ -258,33 +290,34 @@ static UIViewController *NSBFeedVCForView(UIView *view) {
 // MARK: - Driving Apollo's pipeline
 
 // Both defined with the tween, below.
-static void NSBFinishScrollBack(void);
+static void NSBFinishScrollBack(ApolloNativeFeedSession *session);
 static void NSBDissolveSwap(UIScrollView *table);
 static void NSBScrollBackAfterClear(UIViewController *vc, BOOL animated,
                                     void (^completion)(BOOL didScroll));
 
 static void NSBDriveApolloQuery(UIViewController *vc, NSString *text) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     UITextField *field = (UITextField *)ApolloNSBObjectIvar(vc, "searchTextField");
     if (![field isKindOfClass:[UITextField class]]) return;
     // A new query supersedes an in-flight dismiss: drop the geometry correction
     // AND bump the generation so a pending scroll-back completion can't tear
     // down the session the user just re-entered.
-    sNSBDismissWindow = NO;
-    ++sNSBDismissGen;
+    session.dismissWindow = NO;
+    ++session.dismissGeneration;
     // Bump the clear generation BEFORE ending the scroll-back. -finish runs the
     // tween's completion SYNCHRONOUSLY, and that completion is the one carrying
-    // the deferred reload — so with the bump after, its `clearGen != sNSBClearGen`
+    // the deferred reload — so with the bump after, its `clearGen != session.clearGeneration`
     // guard still compared equal and a superseded clear fired an empty-query
     // reload immediately before the real one, doubling the work on the very path
     // the deferral exists to keep clear.
-    NSUInteger clearGen = ++sNSBClearGen;
+    NSUInteger clearGen = ++session.clearGeneration;
     // End the scroll-back outright rather than letting it run out its clock:
     // it holds the offset against every other writer (NSBTweenHoldsOffset), so
     // left alive it would drag the feed to rest under the query the user is
     // typing and hand over to the surfacing pin only when it finished.
-    NSBFinishScrollBack();
+    NSBFinishScrollBack(session);
     ApolloNSBWriteBoolIvar(vc, "isSearching", YES);
-    sNSBSessionTyped = YES;
+    session.typed = YES;
     if (![field.text isEqualToString:(text ?: @"")]) field.text = text ?: @"";
 
     __weak UIViewController *weakVC = vc;
@@ -322,15 +355,15 @@ static void NSBDriveApolloQuery(UIViewController *vc, NSString *text) {
     // the surfaced offset in one frame with nothing opposing it, which is the
     // flash in its worst form: no scroll at all. A drag DURING the restore still
     // wins; the tween bails on it in -step:.
-    sNSBUserScrolled = NO;
+    session.userScrolled = NO;
     NSBScrollBackAfterClear(vc, YES, ^(BOOL didScroll) {
-        if (clearGen != sNSBClearGen) return;  // typed again, or dismissed
+        if (clearGen != session.clearGeneration) return;  // typed again, or dismissed
         if (!didScroll) NSBDissolveSwap(NSBTableForVC(weakVC));
         reload();
     });
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.85 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        if (clearGen != sNSBClearGen) return;
+        if (clearGen != session.clearGeneration) return;
         NSBScrollBackAfterClear(weakVC, NO, nil);
     });
 }
@@ -369,7 +402,11 @@ static void NSBDriveApolloQuery(UIViewController *vc, NSString *text) {
 
 - (void)step:(CADisplayLink *)link {
     UIScrollView *sv = self.scrollView;
-    if (!sv) { [self finish]; return; }
+    if (!sv.window || sv.window.windowScene.activationState != UISceneActivationStateForegroundActive) {
+        self.completion = nil;
+        [self finish];
+        return;
+    }
     if (self.startTime == 0.0) self.startTime = link.timestamp;
     CGFloat t = (CGFloat)((link.timestamp - self.startTime) / self.duration);
     if (t < 0.0) t = 0.0;
@@ -394,12 +431,26 @@ static void NSBDriveApolloQuery(UIViewController *vc, NSString *text) {
 
 @end
 
-static ApolloNSBScrollTween *sNSBTween = nil;
+
+@implementation ApolloNativeFeedSession (SceneLifetime)
+- (void)sceneDeactivated:(NSNotification *)notification {
+    if (notification.object != self.controller.viewIfLoaded.window.windowScene) return;
+    self.dismissGeneration++;
+    self.clearGeneration++;
+    self.dismissWindow = NO;
+    self.dismissScrolling = NO;
+    self.awaitingScroll = NO;
+    self.guardRefreshControl = NO;
+    self.tween.completion = nil;
+    [self.tween finish];
+    self.tween = nil;
+}
+@end
 
 // End a scroll-back early (a new query supersedes it). Safe on nil, and on a
 // tween that already finished — -finish clears its own link and completion.
-static void NSBFinishScrollBack(void) {
-    [sNSBTween finish];
+static void NSBFinishScrollBack(ApolloNativeFeedSession *session) {
+    [session.tween finish];
 }
 
 // A running scroll-back owns its table's offset outright.
@@ -410,7 +461,7 @@ static void NSBFinishScrollBack(void) {
 // — keeps the feed up there. While they are up, UIKit's periodic re-clamp is
 // invisible, because the very next frame forces the offset back.
 //
-// The teardown stands those pins down (session cleared, sNSBAwaitingScroll
+// The teardown stands those pins down (session cleared, session.awaitingScroll
 // set) so the scroll-back has room to travel, and that is exactly when the
 // clamp becomes visible. Any inset or row-count change during the dismissal
 // runs -[UIScrollView _adjustContentOffsetIfNecessary], which drags the offset
@@ -424,7 +475,8 @@ static void NSBFinishScrollBack(void) {
 // current value over everything else. A user grab still wins — the tween
 // bails on it in -step: and the pin stands down here.
 static BOOL NSBTweenHoldsOffset(UIScrollView *sv, CGFloat *y) {
-    ApolloNSBScrollTween *tween = sNSBTween;
+    ApolloNativeFeedSession *session = NSBSessionForView(sv);
+    ApolloNSBScrollTween *tween = session.tween;
     if (!tween || !tween.link || tween.scrollView != sv) return NO;
     if (sv.isDragging || sv.isTracking) return NO;
     *y = tween.currentY;
@@ -448,7 +500,7 @@ static void NSBRestoreHeaderForTable(UIScrollView *sv);
 // screen, let Apollo swap the rows underneath, and fade the snapshot out. The
 // nav bar is not covered, so the bar's own dismissal is untouched.
 static void NSBDissolveSwap(UIScrollView *table) {
-    if (!table) return;
+    if (!table.window || UIAccessibilityIsReduceMotionEnabled()) return;
     UIView *host = table.superview;
     if (!host || CGRectIsEmpty(table.bounds)) return;
     UIView *snap = [table snapshotViewAfterScreenUpdates:NO];
@@ -472,29 +524,30 @@ static void NSBDissolveSwap(UIScrollView *table) {
 // place, never while a scroll-back still owns the offset.
 static void NSBScrollBackAfterClear(UIViewController *vc, BOOL animated,
                                     void (^completion)(BOOL didScroll)) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     void (^done)(void) = ^{ if (completion) completion(NO); };
     if (!vc) { done(); return; }
     UIScrollView *sv = NSBTableForVC(vc);
     if (NSBTraceEnabled()) {
         ApolloLog(@"[NSBTrace] clear(anim=%d): sv=%d same=%d userScrolled=%d drag=%d/%d/%d "
                    "q=%lu tweenLive=%d off=%.1f rest=%.1f",
-                  (int)animated, (int)(sv != nil), (int)(sv == sNSBSessionTable),
-                  (int)sNSBUserScrolled, (int)sv.isDragging, (int)sv.isDecelerating,
-                  (int)sv.isTracking, (unsigned long)NSBSessionQueryText().length,
-                  (int)(sNSBTween && sNSBTween.link), sv.contentOffset.y,
+                  (int)animated, (int)(sv != nil), (int)(sv == session.table),
+                  (int)session.userScrolled, (int)sv.isDragging, (int)sv.isDecelerating,
+                  (int)sv.isTracking, (unsigned long)NSBSessionQueryText(session).length,
+                  (int)(session.tween && session.tween.link), sv.contentOffset.y,
                   -sv.adjustedContentInset.top);
     }
-    if (!sv || sv != sNSBSessionTable || sNSBUserScrolled) { done(); return; }
+    if (!sv || sv != session.table || session.userScrolled) { done(); return; }
     if (sv.isDragging || sv.isDecelerating || sv.isTracking) { done(); return; }
-    if (NSBSessionQueryText().length > 0) { done(); return; }  // user typed again
-    if (sNSBTween && sNSBTween.link) return;  // a scroll-back owns it; its own
+    if (NSBSessionQueryText(session).length > 0) { done(); return; }  // user typed again
+    if (session.tween && session.tween.link) return;  // a scroll-back owns it; its own
                                               // completion will run the reload
     CGFloat rest = -sv.adjustedContentInset.top;
     if (sv.contentOffset.y <= rest + 1.0) { done(); return; }
     // The banner has to be on screen to be seen sliding in; the surfacing pins
     // are already down (the query is empty), so nothing re-hides it.
     NSBRestoreHeaderForTable(sv);
-    if (!animated) {
+    if (!animated || UIAccessibilityIsReduceMotionEnabled()) {
         [sv setContentOffset:CGPointMake(0.0, rest) animated:NO];
         done();
         return;
@@ -504,8 +557,8 @@ static void NSBScrollBackAfterClear(UIViewController *vc, BOOL animated,
     tween.fromY = sv.contentOffset.y;
     tween.toY = rest;
     tween.duration = 0.32;
-    tween.completion = ^{ sNSBTween = nil; if (completion) completion(YES); };
-    sNSBTween = tween;
+    tween.completion = ^{ session.tween = nil; if (completion) completion(YES); };
+    session.tween = tween;
     [tween start];
 }
 
@@ -514,16 +567,17 @@ static void NSBApolloDismissNow(UIViewController *vc);
 
 
 static void NSBApolloDismiss(UIViewController *vc) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     if (!vc) return;
-    ++sNSBClearGen;  // a cancel supersedes a clear's deferred reload
+    ++session.clearGeneration;  // a cancel supersedes a clear's deferred reload
     UIScrollView *table = NSBTableForVC(vc);
     // Clear the session BEFORE Apollo's dismiss so our geometry pins are inert
     // and Apollo's own restore (offset/inset re-park) runs stock — verified clean.
-    sNSBSessionTyped = NO;
-    sNSBUserScrolled = NO;
+    session.typed = NO;
+    session.userScrolled = NO;
     if (table) NSBRestoreHeaderForTable(table);
-    sNSBDismissTargetTop = table ? NSBNavBottomForTable(table, vc) : 0.0;
-    sNSBDismissWindow = (sNSBDismissTargetTop > 1.0);
+    session.dismissTargetTop = table ? NSBNavBottomForTable(table, vc) : 0.0;
+    session.dismissWindow = (session.dismissTargetTop > 1.0);
 
     // Surfaced subreddit search: the chrome (banner + highlights) is parked
     // hundreds of points off the top. Teleporting it back is what read as a
@@ -533,8 +587,8 @@ static void NSBApolloDismiss(UIViewController *vc) {
     // the banner slides into place under the nav, and only then does Apollo's
     // reload swap the rows — by which point everything behind the glass is
     // already the banner, so the swap is invisible up there.
-    if (sNSBDismissWindow && table &&
-        table.contentOffset.y > -sNSBDismissTargetTop + 8.0 &&
+    if (!UIAccessibilityIsReduceMotionEnabled() && session.dismissWindow && table &&
+        table.contentOffset.y > -session.dismissTargetTop + 8.0 &&
         !table.isDragging && !table.isTracking) {
         // Give the feed its FINAL top inset before animating. While the search
         // is active Apollo runs a smaller inset (the palette is in its active
@@ -555,27 +609,27 @@ static void NSBApolloDismiss(UIViewController *vc) {
 
         // Hold the pins down for the animation: firing one snaps the feed to
         // the rest in a single frame and leaves the scroll nothing to travel.
-        sNSBAwaitingScroll = YES;
+        session.awaitingScroll = YES;
 
         // Scroll the chrome back first, then let Apollo swap the rows. Apollo's
         // own teardown scroll (aimed at ITS resting inset) is retargeted by the
         // setContentOffset:animated: hook below, so it agrees with this one
         // instead of cancelling it mid-flight.
-        NSUInteger scrollGen = ++sNSBDismissGen;
+        NSUInteger scrollGen = ++session.dismissGeneration;
         __weak UIViewController *weakVC = vc;
-        [sNSBTween finish];
+        [session.tween finish];
         ApolloNSBScrollTween *tween = [[ApolloNSBScrollTween alloc] init];
         tween.scrollView = table;
         tween.fromY = table.contentOffset.y;
-        tween.toY = -sNSBDismissTargetTop;
+        tween.toY = -session.dismissTargetTop;
         tween.duration = 0.32;
         tween.completion = ^{
-            sNSBAwaitingScroll = NO;
-            sNSBTween = nil;
-            if (scrollGen != sNSBDismissGen) return; // re-focused meanwhile
+            session.awaitingScroll = NO;
+            session.tween = nil;
+            if (scrollGen != session.dismissGeneration) return; // re-focused meanwhile
             NSBApolloDismissNow(weakVC);
         };
-        sNSBTween = tween;
+        session.tween = tween;
         [tween start];
         return;
     }
@@ -587,6 +641,7 @@ static void NSBApolloDismiss(UIViewController *vc) {
 
 // The teardown proper: hand the session back to Apollo and settle the geometry.
 static void NSBApolloDismissNow(UIViewController *vc) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     if (!vc) return;
     UIScrollView *table = NSBTableForVC(vc);
     id field = ApolloNSBObjectIvar(vc, "searchTextField");
@@ -602,7 +657,7 @@ static void NSBApolloDismissNow(UIViewController *vc) {
     // the control returns, and a pull still never reaches isRefreshing, because
     // the nil write has already torn down UIKit's refresh host. Refusing the
     // write leaves that host intact.
-    sNSBGuardRefreshControl = YES;
+    session.guardRefreshControl = YES;
     if ([vc respondsToSelector:@selector(dismissSearchBarButtonTappedWithSender:)]) {
         ((void (*)(id, SEL, id))objc_msgSend)(vc, @selector(dismissSearchBarButtonTappedWithSender:), field);
     }
@@ -610,18 +665,19 @@ static void NSBApolloDismissNow(UIViewController *vc) {
     // Apollo's restore lands in an animation completion, so the guard has to
     // outlive this call; the dismiss window is the same shape.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{ sNSBGuardRefreshControl = NO; });
+                   dispatch_get_main_queue(), ^{ session.guardRefreshControl = NO; });
 
     // Apollo's dismiss re-parks the offset for ITS resting inset (toolbar band
     // included), which leaves the feed a few rows' worth low against the native
     // rest. Once the dismiss animation settles, snap a near-top rest back flush.
     // Two checks because the re-park lands at slightly different times.
-    NSUInteger gen = ++sNSBDismissGen;
+    NSUInteger gen = ++session.dismissGeneration;
     __weak UIScrollView *weakTable = table;
     void (^settle)(void) = ^{
         UIScrollView *sv = weakTable;
-        if (!sv || gen != sNSBDismissGen || sNSBSessionTyped ||
-            sNSBDismissScrolling || sNSBAwaitingScroll) return;
+        if (!sv.window || sv.window.windowScene.activationState != UISceneActivationStateForegroundActive ||
+            gen != session.dismissGeneration || session.typed ||
+            session.dismissScrolling || session.awaitingScroll) return;
         if (sv.isDragging || sv.isDecelerating || sv.isTracking) return;
         // The inset needs no correction here any more: writes landing mid
         // nav-morph are computed against a transient height, but relativizing
@@ -638,8 +694,8 @@ static void NSBApolloDismissNow(UIViewController *vc) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.65 * NSEC_PER_SEC)), dispatch_get_main_queue(), settle);
     __weak UIViewController *weakPolicyVC = vc;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.40 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (gen == sNSBDismissGen) {
-            sNSBDismissWindow = NO;
+        if (gen == session.dismissGeneration) {
+            session.dismissWindow = NO;
             UIViewController *pvc = weakPolicyVC;
             if (pvc && !pvc.navigationItem.hidesSearchBarWhenScrolling) {
                 pvc.navigationItem.hidesSearchBarWhenScrolling = YES;
@@ -663,13 +719,14 @@ static BOOL NSBManagedHeader(UIScrollView *sv) {
 }
 
 static CGFloat NSBDesiredOffsetY(UIScrollView *sv) {
+    ApolloNativeFeedSession *session = NSBSessionForView(sv);
     // adjustedContentInset, not contentInset: it is the full chrome above the
     // first row in either inset-ownership mode (they are equal while the feed
     // runs behavior Never, and only the adjusted value is right once UIKit
     // owns the top through the safe area).
     CGFloat rest = -sv.adjustedContentInset.top;
     if (!NSBManagedHeader(sv)) return rest;
-    if (NSBSessionQueryText().length == 0) return rest;
+    if (NSBSessionQueryText(session).length == 0) return rest;
     UIView *hdr = [(UITableView *)sv tableHeaderView];
     CGFloat height = CGRectGetHeight(hdr.frame);
     if (height <= 1.0) return rest;
@@ -710,14 +767,16 @@ static CGFloat NSBDesiredOffsetY(UIScrollView *sv) {
 }
 
 static BOOL NSBIsSurfaced(UIScrollView *sv) {
-    if (!sv || sv != sNSBSessionTable || !sNSBSessionTyped || sNSBUserScrolled) return NO;
-    if (NSBSessionQueryText().length == 0) return NO;
+    ApolloNativeFeedSession *session = NSBSessionForView(sv);
+    if (!sv || sv != session.table || !session.typed || session.userScrolled) return NO;
+    if (NSBSessionQueryText(session).length == 0) return NO;
     return NSBDesiredOffsetY(sv) > (-sv.adjustedContentInset.top + 1.0);
 }
 
 static void NSBSetHeaderHidden(UIScrollView *sv, BOOL hidden) {
     if (!NSBManagedHeader(sv)) return;
     UIView *hdr = [(UITableView *)sv tableHeaderView];
+    NSBMarkSessionView(hdr, NSBSessionForView(sv));
     CGFloat a = hidden ? 0.0 : 1.0;
     if (hdr.alpha != a) {
         // Never animate this: the restore runs inside Apollo's dismiss
@@ -741,17 +800,20 @@ static void NSBRestoreHeaderForTable(UIScrollView *sv) {
 @implementation ApolloNativeSearchBridge
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
+    ApolloNativeFeedSession *session = NSBSessionForVC(self.feedVC);
     UIViewController *vc = self.feedVC;
     if (!vc) return;
-    sNSBSessionVC = vc;
-    sNSBSessionTable = NSBTableForVC(vc);
-    sNSBSessionNav = vc.navigationController.navigationBar;
-    sNSBUserScrolled = NO;
-    sNSBDismissWindow = NO;
-    ++sNSBDismissGen; // re-focusing cancels any pending dismiss work
+    session.controller = vc;
+    session.table = NSBTableForVC(vc);
+    session.navigationBar = vc.navigationController.navigationBar;
+    NSBMarkSessionView(session.navigationBar, session);
+    session.userScrolled = NO;
+    session.dismissWindow = NO;
+    ++session.dismissGeneration; // re-focusing cancels any pending dismiss work
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
+    ApolloNativeFeedSession *session = NSBSessionForVC(self.feedVC);
     UIViewController *vc = self.feedVC;
     if (!vc) return;
     // An empty change with the field unfocused is one of two very different
@@ -760,11 +822,11 @@ static void NSBRestoreHeaderForTable(UIScrollView *sv) {
     // the results the user is navigating into. At rest it is the user tapping
     // the bar's clear button on a restored query — that means "end the search".
     if (searchText.length == 0 && !searchBar.isFirstResponder) {
-        if (!sNSBTransitioning && sNSBSessionTyped) NSBApolloDismiss(vc);
+        if (!session.transitioning && session.typed) NSBApolloDismiss(vc);
         return;
     }
-    sNSBSessionVC = vc;
-    if (!sNSBSessionTable) sNSBSessionTable = NSBTableForVC(vc);
+    session.controller = vc;
+    if (!session.table) session.table = NSBTableForVC(vc);
     NSBDriveApolloQuery(vc, searchText);
 }
 
@@ -779,12 +841,13 @@ static void NSBRestoreHeaderForTable(UIScrollView *sv) {
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
+    ApolloNativeFeedSession *session = NSBSessionForVC(self.feedVC);
     // The explicit cancel is the ONLY place we end Apollo's session. A nav push
     // may deactivate the UIKit search UI without cancel — the results must
     // survive that so returning from a result keeps the search, like today.
     UIViewController *vc = self.feedVC;
     if (searchBar.text.length > 0) searchBar.text = @"";
-    if (sNSBSessionTyped) NSBApolloDismiss(vc);
+    if (session.typed) NSBApolloDismiss(vc);
 }
 
 @end
@@ -826,6 +889,7 @@ static void NSBAttachNativeSearch(UIViewController *vc) {
     // Attach laid-out-visible; the scroll-away policy flips it after the first
     // appearance (plain YES here parks the bar off-screen — no large title).
     navItem.searchController = sc;
+    ApolloPaneApplySearchPlacement(vc);
     navItem.hidesSearchBarWhenScrolling = NO;
 
     // Point UIKit's bar collapse tracking at the actual feed table — automatic
@@ -853,13 +917,14 @@ static void NSBAttachNativeSearch(UIViewController *vc) {
 // Hide Apollo's own toolbar (the resting pill inside the feed). Re-asserted
 // every layout pass — Apollo can recreate or re-show it across reloads.
 static void NSBHideApolloToolbar(UIViewController *vc) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     UIView *toolbar = (UIView *)ApolloNSBObjectIvar(vc, "upperToolbar");
     if (![toolbar isKindOfClass:[UIView class]]) return;
     if (!toolbar.hidden) {
         // Measure the band ONLY from the live (pre-hide) toolbar — once hidden
         // its layout drifts to junk heights that must not update the band.
         CGFloat h = CGRectGetHeight(toolbar.bounds);
-        if (h > 1.0 && h < 100.0) sNSBToolbarBand = h;
+        if (h > 1.0 && h < 100.0) session.toolbarBand = h;
         toolbar.hidden = YES;
     }
 }
@@ -906,10 +971,11 @@ static BOOL NSBHasSettledFeedGeometry(UIViewController *vc, UIScrollView *table)
     ApolloNativeSearchRestingState *state = NSBRestingStateForVC(vc);
     UINavigationController *nav = vc.navigationController;
     return state.visible && nav.topViewController == vc && nav.visibleViewController == vc &&
-           !ApolloNavTransitionInFlight() && !nav.transitionCoordinator && !vc.transitionCoordinator;
+           !nav.transitionCoordinator && !vc.transitionCoordinator;
 }
 
 static void NSBInvalidateRestingSearch(UIViewController *vc) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     ApolloNativeSearchRestingState *state = objc_getAssociatedObject(vc, kNSBRestingStateKey);
     if (!state) return;
     state.visible = NO;
@@ -921,17 +987,18 @@ static void NSBInvalidateRestingSearch(UIViewController *vc) {
     state.revealInFlight = NO;
     // End only our own temporary reveal, before the appearance callback lets
     // UIKit capture the navigation item's policy for the transition.
-    if (wasRevealing && !(sNSBDismissWindow && vc == sNSBSessionVC)) {
+    if (wasRevealing && !(session.dismissWindow && vc == session.controller)) {
         vc.navigationItem.hidesSearchBarWhenScrolling = YES;
     }
 }
 
 static void NSBApplyScrollAwayPolicy(UIViewController *vc, UIScrollView *table) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
     if (!NSBHasSettledFeedGeometry(vc, table)) return;
     UINavigationItem *item = vc.navigationItem;
     if (item.searchController && !item.hidesSearchBarWhenScrolling &&
         objc_getAssociatedObject(vc, kNSBAppearedKey) != nil &&
-        !NSBRestingStateForVC(vc).revealInFlight && !sNSBDismissWindow) {
+        !NSBRestingStateForVC(vc).revealInFlight && !session.dismissWindow) {
         item.hidesSearchBarWhenScrolling = YES;
     }
 }
@@ -972,9 +1039,11 @@ static void NSBRecheckRevealAfterRefresh(UIViewController *vc, UIScrollView *tab
 }
 
 static void NSBEnsureBarRevealedAtTop(UIViewController *vc, UIScrollView *table) {
+    ApolloNativeFeedSession *session = NSBSessionForVC(vc);
+    if (ApolloPaneUsesUnifiedChrome(vc.viewIfLoaded)) return;
     if (!NSBHasSettledFeedGeometry(vc, table)) return;
     ApolloNativeSearchRestingState *state = NSBRestingStateForVC(vc);
-    if (state.revealInFlight || state.revealAttemptedAtTop || sNSBDismissWindow) return;
+    if (state.revealInFlight || state.revealAttemptedAtTop || session.dismissWindow) return;
     if (table.isDragging || table.isDecelerating || table.isTracking) return;
     UINavigationItem *navItem = vc.navigationItem;
     UISearchController *sc = navItem.searchController;
@@ -1032,6 +1101,7 @@ void ApolloNativeFeedSearchRestoreCancelledNavigation(UIViewController *vc) {
 // pulled it down by hand. The feed's own geometry setters DO run on those
 // paths, so ask from there as well, coalesced to one check per runloop turn.
 static void NSBScheduleRevealCheck(UIScrollView *table) {
+    if (ApolloPaneUsesUnifiedChrome(table)) return;
     if (!table) return;
     if (objc_getAssociatedObject(table, kNSBFeedTableKey) == nil) return;
     UIViewController *vc = NSBFeedVCForView(table);
@@ -1075,9 +1145,13 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 %hook _TtC6Apollo21ASTableViewController
 
 - (void)viewWillAppear:(BOOL)animated {
+    ApolloNativeFeedSession *session = (ApolloNativeFeedSearchEnabled() && NSBIsNativeSearchFeedVC((id)self))
+        ? NSBSessionForVC((UIViewController *)self) : nil;
     if (ApolloNativeFeedSearchEnabled()) NSBInvalidateRestingSearch((UIViewController *)self);
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
+    session.navigationBar = [(UIViewController *)self navigationController].navigationBar;
+    NSBMarkSessionView(session.navigationBar, session);
     NSBAttachNativeSearch((UIViewController *)self);
     NSBHideApolloToolbar((UIViewController *)self);
     // Returning to a live search (e.g. back from an opened result): keep the
@@ -1090,20 +1164,23 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
         // Returning to a live query: Apollo's restore re-applies its
         // search-active layout (nav-bar transform/alpha hide) straight from
         // isSearching — no focus involved — so arm the whole session (including
-        // typed, which a cancel in a DIFFERENT feed may have cleared globally)
+        // its controller-owned typed state)
         // before it runs.
-        sNSBSessionVC = (UIViewController *)self;
-        sNSBSessionTable = NSBTableForVC((UIViewController *)self);
-        sNSBSessionNav = [(UIViewController *)self navigationController].navigationBar;
-        sNSBSessionTyped = YES;
+        session.controller = (UIViewController *)self;
+        session.table = NSBTableForVC((UIViewController *)self);
+        session.navigationBar = [(UIViewController *)self navigationController].navigationBar;
+        NSBMarkSessionView(session.navigationBar, session);
+        session.typed = YES;
     }
 }
 
 
 - (void)viewDidAppear:(BOOL)animated {
+    ApolloNativeFeedSession *session = (ApolloNativeFeedSearchEnabled() && NSBIsNativeSearchFeedVC((id)self))
+        ? NSBSessionForVC((UIViewController *)self) : nil;
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
-    sNSBTransitioning = NO;
+    session.transitioning = NO;
     // Record the appearance before anything can bail: the scroll-away policy is
     // applied from the layout pass too (see below), and on the paths where the
     // search controller is attached late this is the only thing that tells that
@@ -1118,17 +1195,29 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
     // Safety net for the return-to-live-query path: if Apollo's search-active
     // layout hid the nav bar before the guard armed, put it back.
     UINavigationBar *nav = [(UIViewController *)self navigationController].navigationBar;
-    if (sNSBSessionTyped && nav && nav == sNSBSessionNav) {
+    if (session.typed && nav && nav == session.navigationBar) {
         if (nav.transform.ty < -1.0) nav.transform = CGAffineTransformIdentity;
         if (nav.alpha < 1.0) nav.alpha = 1.0;
     }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    ApolloNativeFeedSession *session = (ApolloNativeFeedSearchEnabled() && NSBIsNativeSearchFeedVC((id)self))
+        ? NSBSessionForVC((UIViewController *)self) : nil;
     if (ApolloNativeFeedSearchEnabled()) NSBInvalidateRestingSearch((UIViewController *)self);
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
-    sNSBTransitioning = YES;
+    session.transitioning = YES;
+    if (NSBSessionForView(session.navigationBar) == session) NSBMarkSessionView(session.navigationBar, nil);
+    ++session.dismissGeneration;
+    ++session.clearGeneration;
+    session.dismissWindow = NO;
+    session.awaitingScroll = NO;
+    session.dismissScrolling = NO;
+    session.guardRefreshControl = NO;
+    session.tween.completion = nil;
+    NSBFinishScrollBack(session);
+    session.tween = nil;
     // Leaving the feed (e.g. opening a result) with the search UI presented:
     // deactivate it cleanly. Keeping it active across a push leaves UIKit's
     // presentation half-restored after the pop (missing nav bar, collapsed
@@ -1139,20 +1228,25 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 }
 
 - (void)viewDidLayoutSubviews {
+    ApolloNativeFeedSession *session = (ApolloNativeFeedSearchEnabled() && NSBIsNativeSearchFeedVC((id)self))
+        ? NSBSessionForVC((UIViewController *)self) : nil;
     %orig;
     if (!ApolloNativeFeedSearchEnabled() || !NSBIsNativeSearchFeedVC(self)) return;
-    // The toolbar/field ivars can be nil on the very first willAppear; attach
-    // lazily here too (idempotent — bails once a searchController exists).
-    NSBAttachNativeSearch((UIViewController *)self);
-    NSBHideApolloToolbar((UIViewController *)self);
-    // Late attachment can happen after didAppear; schedule the policy update
-    // here too, without driving another layout from this callback.
-    UIScrollView *table = NSBTableForVC((UIViewController *)self);
-    if (table && table == sNSBSessionTable) {
-        NSBSetHeaderHidden(table, NSBIsSurfaced(table));
-    }
-    // Recovery drives layout itself; never re-enter it from a layout callback.
-    NSBScheduleRevealCheck(table);
+    // Native toolbar ivars can arrive after willAppear. Coalesce late setup
+    // outside UIKit's layout callback; never change layout inputs recursively.
+    if (session.chromeUpdatePending) return;
+    session.chromeUpdatePending = YES;
+    __weak UIViewController *weakVC = (UIViewController *)self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        session.chromeUpdatePending = NO;
+        UIViewController *vc = weakVC;
+        if (!vc.viewIfLoaded.window) return;
+        NSBAttachNativeSearch(vc);
+        NSBHideApolloToolbar(vc);
+        UIScrollView *table = NSBTableForVC(vc);
+        if (table) NSBSetHeaderHidden(table, NSBIsSurfaced(table));
+        NSBScheduleRevealCheck(table);
+    });
 }
 
 %end
@@ -1225,6 +1319,7 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 }
 
 - (void)setContentOffset:(CGPoint)offset {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
     UIScrollView *sv = (UIScrollView *)self;
     if (ApolloNativeFeedSearchEnabled()) NSBScheduleRevealCheck(sv);
     if (ApolloNativeFeedSearchEnabled() && NSBRetargetApolloTopPark(sv, &offset.y) &&
@@ -1232,20 +1327,20 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
         ApolloLog(@"[NSBTrace] retarget offset -> %.1f (inTop=%.1f adjTop=%.1f)",
                   offset.y, sv.contentInset.top, sv.adjustedContentInset.top);
     }
-    if (ApolloNativeFeedSearchEnabled() && sNSBDismissWindow &&
-        !sNSBDismissScrolling && !sNSBAwaitingScroll &&
-        sv == sNSBSessionTable && !sv.isDragging && !sv.isTracking && !sv.isDecelerating &&
-        fabs(offset.y + sNSBDismissTargetTop) > 0.5) {
+    if (ApolloNativeFeedSearchEnabled() && session.dismissWindow &&
+        !session.dismissScrolling && !session.awaitingScroll &&
+        sv == session.table && !sv.isDragging && !sv.isTracking && !sv.isDecelerating &&
+        fabs(offset.y + session.dismissTargetTop) > 0.5) {
         // Pin in BOTH directions: Apollo's teardown re-park overshoots ABOVE
         // the top (into the rubber-band region) as well as landing below it.
-        offset.y = -sNSBDismissTargetTop;
+        offset.y = -session.dismissTargetTop;
     }
-    if (ApolloNativeFeedSearchEnabled() && sv == sNSBSessionTable &&
-        sNSBSessionTyped && NSBSessionQueryText().length > 0) {
+    if (ApolloNativeFeedSearchEnabled() && sv == session.table &&
+        session.typed && NSBSessionQueryText(session).length > 0) {
         CGFloat target = NSBDesiredOffsetY(sv);
-        if (sv.isDragging) sNSBUserScrolled = YES;
-        else if (offset.y <= target + 1.0) sNSBUserScrolled = NO;
-        if (!sv.isDragging && !sv.isDecelerating && !sNSBUserScrolled) {
+        if (sv.isDragging) session.userScrolled = YES;
+        else if (offset.y <= target + 1.0) session.userScrolled = NO;
+        if (!sv.isDragging && !sv.isDecelerating && !session.userScrolled) {
             if (NSBManagedHeader(sv) && target > -sv.adjustedContentInset.top + 1.0) {
                 offset.y = target;          // surfaced: chrome held off the top
             } else if (offset.y > target) {
@@ -1268,6 +1363,7 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 }
 
 - (void)setBounds:(CGRect)bounds {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
     UIScrollView *sv = (UIScrollView *)self;
     if (NSBTraceEnabled() && objc_getAssociatedObject(self, kNSBFeedTableKey) != nil &&
         bounds.origin.y < -sv.adjustedContentInset.top - 4.0) {
@@ -1297,13 +1393,13 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
         ApolloLog(@"[NSBTrace] retarget bounds -> %.1f (inTop=%.1f adjTop=%.1f)",
                   bounds.origin.y, sv.contentInset.top, sv.adjustedContentInset.top);
     }
-    if (ApolloNativeFeedSearchEnabled() && sNSBDismissWindow &&
-        !sNSBDismissScrolling && !sNSBAwaitingScroll &&
-        sv == sNSBSessionTable && !sv.isDragging && !sv.isTracking && !sv.isDecelerating &&
-        fabs(bounds.origin.y + sNSBDismissTargetTop) > 0.5) {
-        bounds.origin.y = -sNSBDismissTargetTop;
+    if (ApolloNativeFeedSearchEnabled() && session.dismissWindow &&
+        !session.dismissScrolling && !session.awaitingScroll &&
+        sv == session.table && !sv.isDragging && !sv.isTracking && !sv.isDecelerating &&
+        fabs(bounds.origin.y + session.dismissTargetTop) > 0.5) {
+        bounds.origin.y = -session.dismissTargetTop;
     }
-    if (ApolloNativeFeedSearchEnabled() && sv == sNSBSessionTable &&
+    if (ApolloNativeFeedSearchEnabled() && sv == session.table &&
         !sv.isDragging && !sv.isDecelerating && NSBIsSurfaced(sv)) {
         CGFloat want = NSBDesiredOffsetY(sv);
         if (fabs(bounds.origin.y - want) > 0.5) bounds.origin.y = want;
@@ -1323,8 +1419,9 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 // priorRefreshControl it never captured under the native bar, which nils the
 // feed's control and kills pull-to-refresh for the rest of the screen's life.
 - (void)setRefreshControl:(UIRefreshControl *)refreshControl {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
     if (ApolloNativeFeedSearchEnabled() && refreshControl == nil &&
-        sNSBGuardRefreshControl &&
+        session.guardRefreshControl &&
         objc_getAssociatedObject(self, kNSBFeedTableKey) != nil &&
         [(UITableView *)self refreshControl] != nil) {
         if (NSBTraceEnabled()) ApolloLog(@"[NSBTrace] blocked refreshControl=nil during dismiss");
@@ -1353,9 +1450,10 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 %hook ApolloSubredditHeaderWrapperView
 
 - (void)setAlpha:(CGFloat)alpha {
-    if (alpha > 0.0 && sNSBSessionTable &&
-        (UIView *)self == [(UITableView *)sNSBSessionTable tableHeaderView] &&
-        NSBIsSurfaced(sNSBSessionTable)) {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
+    if (alpha > 0.0 && session.table &&
+        (UIView *)self == [(UITableView *)session.table tableHeaderView] &&
+        NSBIsSurfaced(session.table)) {
         %orig(0.0);
         return;
     }
@@ -1378,8 +1476,9 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 %hook UINavigationBar
 
 - (void)setTransform:(CGAffineTransform)transform {
-    if (ApolloNativeFeedSearchEnabled() && self == sNSBSessionNav &&
-        sNSBSessionTyped && transform.ty < -1.0) {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
+    if (ApolloNativeFeedSearchEnabled() && self == session.navigationBar &&
+        session.typed && transform.ty < -1.0) {
         %orig(CGAffineTransformIdentity);
         return;
     }
@@ -1387,8 +1486,9 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 }
 
 - (void)setAlpha:(CGFloat)alpha {
-    if (ApolloNativeFeedSearchEnabled() && self == sNSBSessionNav &&
-        sNSBSessionTyped && alpha < 1.0) {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
+    if (ApolloNativeFeedSearchEnabled() && self == session.navigationBar &&
+        session.typed && alpha < 1.0) {
         %orig(1.0);
         return;
     }
@@ -1408,6 +1508,7 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
 %hook UIScrollView
 
 - (void)setContentOffset:(CGPoint)offset animated:(BOOL)animated {
+    ApolloNativeFeedSession *session = NSBSessionForView((UIView *)self);
     // The animated entry point is how Apollo's tab-bar scroll-to-top travels;
     // retarget it here so the whole animation aims at the real rest rather
     // than landing short and being corrected afterwards.
@@ -1416,19 +1517,19 @@ static void NSBScheduleRevealCheck(UIScrollView *table) {
         ApolloLog(@"[NSBTrace] retarget animated -> %.1f (inTop=%.1f adjTop=%.1f)",
                   offset.y, self.contentInset.top, self.adjustedContentInset.top);
     }
-    if (ApolloNativeFeedSearchEnabled() && sNSBDismissWindow &&
-        (UIScrollView *)self == sNSBSessionTable &&
+    if (ApolloNativeFeedSearchEnabled() && session.dismissWindow &&
+        (UIScrollView *)self == session.table &&
         !self.isDragging && !self.isTracking) {
-        CGFloat want = -sNSBDismissTargetTop;
+        CGFloat want = -session.dismissTargetTop;
         if (fabs(offset.y - want) > 0.5) offset.y = want;
-        animated = YES;
+        animated = !UIAccessibilityIsReduceMotionEnabled();
         // Stand the per-frame pins down for the length of the animation, or
         // they would clamp it back to a standstill on its first frame.
-        sNSBDismissScrolling = YES;
+        session.dismissScrolling = YES;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            sNSBDismissScrolling = NO;
-            sNSBAwaitingScroll = NO; // pins take over holding the final rest
+            session.dismissScrolling = NO;
+            session.awaitingScroll = NO; // pins take over holding the final rest
         });
     }
     %orig(offset, animated);

--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -82,6 +82,13 @@ typedef NS_ENUM(NSInteger, ApolloSubredditHeaderAssetKind) {
 
 @class ApolloSubredditHeaderView;
 
+static CGFloat ApolloSubredditLocalWidth(UIView *view) {
+    for (UIView *candidate = view; candidate; candidate = candidate.superview) {
+        if (CGRectGetWidth(candidate.bounds) > 0.0) return CGRectGetWidth(candidate.bounds);
+    }
+    return 320.0; // detached measurement only; never a screen/window assumption
+}
+
 @interface ApolloSubredditWeakControllerBox : NSObject
 @property(nonatomic, weak) UIViewController *viewController;
 @end
@@ -526,7 +533,7 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
 }
 
 - (void)applyInfo:(ApolloSubredditInfo *)info fallbackSubredditName:(NSString *)subredditName {
-    CGFloat width = self.bounds.size.width > 0 ? self.bounds.size.width : UIScreen.mainScreen.bounds.size.width;
+    CGFloat width = ApolloSubredditLocalWidth(self);
     CGFloat heightBefore = [self preferredHeightForWidth:width];
 
     // Whether the big display name (e.g. "Reddit Science") shows above the
@@ -935,7 +942,7 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
         [self addSubview:originalHeader];
     }
 
-    CGFloat width = self.bounds.size.width > 0 ? self.bounds.size.width : UIScreen.mainScreen.bounds.size.width;
+    CGFloat width = ApolloSubredditLocalWidth(self);
     ApolloSubredditLayoutWrappedHeader(self, header, originalHeader, width);
     self.hidden = NO;
     self.alpha = 1.0;
@@ -1369,7 +1376,7 @@ static UIImage *ApolloSubredditPlaceholderIconForUserInterfaceStyle(UIUserInterf
 
     UIUserInterfaceStyle resolved = style;
     if (resolved == UIUserInterfaceStyleUnspecified) {
-        resolved = UIScreen.mainScreen.traitCollection.userInterfaceStyle;
+        resolved = UITraitCollection.currentTraitCollection.userInterfaceStyle;
     }
     if (@available(iOS 13.0, *)) {
         return resolved == UIUserInterfaceStyleDark ? darkIcon : lightIcon;
@@ -1377,10 +1384,10 @@ static UIImage *ApolloSubredditPlaceholderIconForUserInterfaceStyle(UIUserInterf
     return darkIcon ?: lightIcon;
 }
 
-static UIImage *ApolloSubredditPlaceholderIcon(void) {
+static UIImage *ApolloSubredditPlaceholderIcon(UIView *view) {
     UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
     if (@available(iOS 13.0, *)) {
-        style = UIScreen.mainScreen.traitCollection.userInterfaceStyle;
+        style = view.traitCollection.userInterfaceStyle;
     }
     return ApolloSubredditPlaceholderIconForUserInterfaceStyle(style);
 }
@@ -1400,7 +1407,7 @@ static UIImage *ApolloSubredditDefaultBanner(void) {
 static UIColor *ApolloSubredditBannerBackgroundColorForUserInterfaceStyle(UIUserInterfaceStyle style) {
     UIUserInterfaceStyle resolved = style;
     if (resolved == UIUserInterfaceStyleUnspecified) {
-        resolved = UIScreen.mainScreen.traitCollection.userInterfaceStyle;
+        resolved = UITraitCollection.currentTraitCollection.userInterfaceStyle;
     }
     if (@available(iOS 13.0, *)) {
         if (resolved == UIUserInterfaceStyleDark) {
@@ -1411,10 +1418,10 @@ static UIColor *ApolloSubredditBannerBackgroundColorForUserInterfaceStyle(UIUser
     return [UIColor colorWithRed:39.0 / 255.0 green:39.0 / 255.0 blue:41.0 / 255.0 alpha:1.0];
 }
 
-static UIColor *ApolloSubredditBannerBackgroundColor(void) {
+static UIColor *ApolloSubredditBannerBackgroundColor(UIView *view) {
     UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
     if (@available(iOS 13.0, *)) {
-        style = UIScreen.mainScreen.traitCollection.userInterfaceStyle;
+        style = view.traitCollection.userInterfaceStyle;
     }
     return ApolloSubredditBannerBackgroundColorForUserInterfaceStyle(style);
 }
@@ -1424,7 +1431,7 @@ static void ApolloSubredditApplyLoadingBanner(ApolloSubredditHeaderView *header)
     header.bannerImageView.image = nil;
     header.bannerProvenanceKey = nil;
     header.pendingBannerURL = nil;
-    header.bannerImageView.backgroundColor = ApolloSubredditBannerBackgroundColor();
+    header.bannerImageView.backgroundColor = ApolloSubredditBannerBackgroundColor(header);
     ApolloSubredditSyncAmbient(header);
 }
 
@@ -1443,7 +1450,7 @@ static void ApolloSubredditApplyDefaultBanner(ApolloSubredditHeaderView *header)
 
 static void ApolloSubredditApplyPlaceholderIcon(ApolloSubredditHeaderView *header) {
     if (!header) return;
-    header.iconImageView.image = ApolloSubredditPlaceholderIcon();
+    header.iconImageView.image = ApolloSubredditPlaceholderIcon(header);
     header.iconImageView.backgroundColor = [UIColor clearColor];
 }
 
@@ -1597,7 +1604,7 @@ static void ApolloSubredditApplyIconForHeader(ApolloSubredditHeaderView *header,
 
 static ApolloSubredditHeaderView *ApolloSubredditCreateHeader(CGFloat width) {
     ApolloSubredditHeaderView *header = [[ApolloSubredditHeaderView alloc] initWithFrame:CGRectMake(0.0, 0.0, width, 210.0)];
-    header.iconImageView.image = ApolloSubredditPlaceholderIcon();
+    header.iconImageView.image = ApolloSubredditPlaceholderIcon(header);
     ApolloSubredditApplyLoadingBanner(header);
     return header;
 }
@@ -1729,8 +1736,7 @@ static void ApolloSubredditSyncAmbient(ApolloSubredditHeaderView *header) {
     // Apollo's chrome height changes, and unifies the profile/subreddit math.
     CGFloat chromeHeight = tableView.adjustedContentInset.top;
     if (chromeHeight <= 0.0) chromeHeight = viewController.view.safeAreaInsets.top;
-    CGFloat width = tableView.bounds.size.width > 0 ? tableView.bounds.size.width
-        : UIScreen.mainScreen.bounds.size.width;
+    CGFloat width = ApolloSubredditLocalWidth(tableView);
     // Must match apollo_identityForWidth:'s actual banner height (subreddit's
     // own compact constant, respecting the Show Banner toggle) — the shared
     // ApolloIdentityHeaderBannerHeight() default (150pt) is the profile
@@ -2200,7 +2206,7 @@ static void ApolloSubredditInstallOrUpdateHeader(UIViewController *viewControlle
 
     ApolloLog(@"[SubredditHeaders] install vc=%p subreddit=%@", viewController, subredditName);
 
-    CGFloat width = tableView.bounds.size.width > 0 ? tableView.bounds.size.width : UIScreen.mainScreen.bounds.size.width;
+    CGFloat width = ApolloSubredditLocalWidth(tableView);
     if (!header) {
         header = ApolloSubredditCreateHeader(width);
         objc_setAssociatedObject(viewController, kApolloSubredditHeaderViewKey, header, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -2288,7 +2294,7 @@ static void ApolloSubredditInstallOrUpdateHeader(UIViewController *viewControlle
         // feed back into an active navigation-bar layout pass.
         ApolloSubredditRequestTitleRelayout(viewController.navigationItem);
         objc_setAssociatedObject(viewController, kApolloSubredditNameKey, subredditName, OBJC_ASSOCIATION_COPY_NONATOMIC);
-        header.iconImageView.image = ApolloSubredditPlaceholderIcon();
+        header.iconImageView.image = ApolloSubredditPlaceholderIcon(header);
         header.usesCustomIcon = NO;
         header.usesCustomBanner = NO;
         header.subscriptionStateKnown = NO;
@@ -2470,7 +2476,7 @@ static void ApolloSubredditRefreshVisibleControllers(void) {
         return;
     }
 
-    CGFloat width = self.bounds.size.width > 0 ? self.bounds.size.width : UIScreen.mainScreen.bounds.size.width;
+    CGFloat width = ApolloSubredditLocalWidth(self);
     UIView *wrapper = ApolloSubredditBuildWrapper(ourHeader, tableHeaderView, width);
     UIViewController *viewController = ourHeader.hostViewController;
     ApolloSubredditSyncAssociations(self, viewController, ourHeader, wrapper, tableHeaderView);

--- a/src/ApolloSwiftIvarBridge.swift
+++ b/src/ApolloSwiftIvarBridge.swift
@@ -109,3 +109,69 @@ public func ApolloSwiftListAdapterIndexPathForModelIdentifier(
     guard let path = mapping[token.key] else { return nil }
     return Unmanaged.passRetained(path as NSIndexPath).toOpaque()
 }
+
+/// The native ListAdapter inserts a SectionController before returning its
+/// asynchronous node factory. Both dictionary values are class references;
+/// retain the returned object without exposing Swift Dictionary storage to ObjC.
+@_cdecl("ApolloSwiftListAdapterSectionController")
+public func ApolloSwiftListAdapterSectionController(
+    _ storage: UnsafeRawPointer?, _ indexPathObject: UnsafeRawPointer?
+) -> UnsafeMutableRawPointer? {
+    guard let storage, let indexPathObject else { return nil }
+    let indexPath = Unmanaged<NSIndexPath>.fromOpaque(indexPathObject).takeUnretainedValue() as IndexPath
+    let mapping = storage.assumingMemoryBound(to: [IndexPath: NSObject].self).pointee
+    guard let section = mapping[indexPath] else { return nil }
+    return Unmanaged.passRetained(section).toOpaque()
+}
+
+@_cdecl("ApolloSwiftAssignInteractiveTransition")
+public func ApolloSwiftAssignInteractiveTransition(
+    _ storage: UnsafeMutableRawPointer?, _ object: UnsafeRawPointer?
+) {
+    guard let storage else { return }
+    let transition = object.map {
+        Unmanaged<UIPercentDrivenInteractiveTransition>.fromOpaque($0).takeUnretainedValue()
+    }
+    storage.assumingMemoryBound(to: Optional<UIPercentDrivenInteractiveTransition>.self).pointee = transition
+}
+
+// Apollo 1.15.11 PostsType's metadata records this exact case/payload order.
+// Its frozen in-module representation is two Strings plus a discriminator
+// (33 bytes, 40-byte stride). ObjC validates the surrounding ivars first.
+private enum ApolloPaneNativePostsType {
+    case subreddit(String), multireddit(String, String), upvoted(String)
+    case downvoted(String), submissions(String), random(Bool), home, hidden
+}
+
+@_cdecl("ApolloSwiftPanePostsScope")
+public func ApolloSwiftPanePostsScope(_ storage: UnsafeRawPointer?) -> UnsafeMutableRawPointer? {
+    guard Thread.isMainThread, let storage,
+          MemoryLayout<ApolloPaneNativePostsType>.size == 33 else { return nil }
+    let tag = storage.load(fromByteOffset: 32, as: UInt8.self)
+    guard tag <= 6 else { return nil }
+    if tag >= 5 && storage.load(as: UInt8.self) > 1 { return nil }
+    let value = storage.assumingMemoryBound(to: ApolloPaneNativePostsType.self).pointee
+    let scope: String
+    switch value {
+    case .subreddit(let name): scope = "subreddit:" + name.lowercased()
+    case .multireddit(let name, let user): scope = "multi:" + user.lowercased() + "/" + name.lowercased()
+    case .upvoted(let user): scope = "upvoted:" + user.lowercased()
+    case .downvoted(let user): scope = "downvoted:" + user.lowercased()
+    case .submissions(let user): scope = "submissions:" + user.lowercased()
+    case .random(let nsfw): scope = nsfw ? "random:nsfw" : "random:safe"
+    case .home: scope = "home"
+    case .hidden: scope = "hidden"
+    }
+    return Unmanaged.passRetained(scope as NSString).toOpaque()
+}
+
+// AppDelegate.tabBarController is a strong Swift Optional, not an ObjC ivar
+// with an @ type encoding. Its native destructor releases one pointer slot.
+@_cdecl("ApolloSwiftExchangePaneTabs")
+public func ApolloSwiftExchangePaneTabs(_ storage: UnsafeMutableRawPointer?, _ object: UnsafeRawPointer?) -> UnsafeMutableRawPointer? {
+    guard let storage else { return nil }
+    let slot = storage.assumingMemoryBound(to: Optional<UITabBarController>.self)
+    let previous = slot.pointee
+    slot.pointee = object.map { Unmanaged<UITabBarController>.fromOpaque($0).takeUnretainedValue() }
+    return previous.map { Unmanaged.passRetained($0).toOpaque() }
+}

--- a/src/ipad/ApolloPaneChrome.h
+++ b/src/ipad/ApolloPaneChrome.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+__BEGIN_DECLS
+BOOL ApolloPaneUsesUnifiedChrome(UIView *view);
+CGFloat ApolloPaneContextBottomInView(UIView *view);
+BOOL ApolloPanePrefersCompactFeed(UIViewController *controller);
+void ApolloPaneSetComfortableFeed(UIViewController *controller, BOOL comfortable);
+void ApolloPaneInstallChromeForController(UIViewController *controller);
+void ApolloPaneApplySearchPlacement(UIViewController *controller);
+BOOL ApolloPanePrepareCommentsFind(UIViewController *controller);
+BOOL ApolloPanePresentCommentsFind(UIViewController *controller);
+__END_DECLS

--- a/src/ipad/ApolloPaneChrome.m
+++ b/src/ipad/ApolloPaneChrome.m
@@ -1,0 +1,178 @@
+#import "ApolloPaneChrome.h"
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSidebar.h"
+#import "ApolloPaneSplitViewController.h"
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "../ApolloThemeRuntime.h"
+
+static char kComfortableFeed;
+static NSString *const kPaneDensityPreference = @"ApolloPaneComfortableFeed";
+static UIViewController *ApolloPaneControllerForView(UIView *view) {
+    for (UIResponder *responder = view; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:UIViewController.class]) return (id)responder;
+    }
+    return nil;
+}
+
+BOOL ApolloPaneUsesUnifiedChrome(UIView *view) {
+    UISplitViewController *pane = ApolloPaneSplitControllerFor(ApolloPaneControllerForView(view));
+    return pane && !pane.isCollapsed;
+}
+
+CGFloat ApolloPaneContextBottomInView(UIView *view) {
+    UIViewController *controller = ApolloPaneControllerForView(view);
+    if (!ApolloPaneUsesUnifiedChrome(view)) return 0.0;
+    UINavigationController *nav = [controller isKindOfClass:UINavigationController.class]
+        ? (id)controller : controller.navigationController;
+    UINavigationBar *bar = nav.navigationBar;
+    if (!bar.window || bar.hidden) return 0.0;
+    return MAX(0.0, CGRectGetMaxY([bar convertRect:bar.bounds toView:view]));
+}
+
+BOOL ApolloPanePrefersCompactFeed(UIViewController *controller) {
+    ApolloPaneSplitViewController *pane = (id)ApolloPaneSplitControllerFor(controller);
+    if (!pane) return NO;
+    UINavigationController *primary = [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    NSNumber *preference = objc_getAssociatedObject(pane, &kComfortableFeed);
+    if (!preference) {
+        preference = @([NSUserDefaults.standardUserDefaults boolForKey:kPaneDensityPreference]);
+        objc_setAssociatedObject(pane, &kComfortableFeed, preference, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return controller.navigationController == primary && !preference.boolValue;
+}
+
+void ApolloPaneSetComfortableFeed(UIViewController *controller, BOOL comfortable) {
+    UISplitViewController *pane = ApolloPaneSplitControllerFor(controller);
+    if (pane) {
+        objc_setAssociatedObject(pane, &kComfortableFeed, @(comfortable), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [NSUserDefaults.standardUserDefaults setBool:comfortable forKey:kPaneDensityPreference];
+    }
+}
+
+static char kPaneLayoutButton;
+static char kPaneMenuConfiguration;
+static char kPaneDensityPrepared;
+static char kPaneFindButton;
+static char kPaneOriginalExtendedEdges;
+
+void ApolloPaneApplySearchPlacement(UIViewController *controller) {
+    if (!controller.navigationItem.searchController) return;
+    UISplitViewController *pane = ApolloPaneSplitControllerFor(controller);
+    if (!pane) return;
+    if (@available(iOS 26.0, *)) {
+        controller.navigationItem.preferredSearchBarPlacement = pane.isCollapsed
+            ? UINavigationItemSearchBarPlacementStacked : UINavigationItemSearchBarPlacementIntegratedButton;
+        controller.navigationItem.searchBarPlacementAllowsExternalIntegration = NO;
+        controller.navigationItem.searchBarPlacementAllowsToolbarIntegration = NO;
+    } else if (@available(iOS 16.0, *)) {
+        controller.navigationItem.preferredSearchBarPlacement = pane.isCollapsed
+            ? UINavigationItemSearchBarPlacementStacked : UINavigationItemSearchBarPlacementInline;
+    }
+}
+
+static void ApolloPaneReloadNativeFeed(UIViewController *controller) {
+    SEL reload = NSSelectorFromString(@"postCellAppearanceUpdatedWithNotification:");
+    if ([controller respondsToSelector:reload]) {
+        // This native entry invalidates section-controller mappings and reloads
+        // the table. A real Notification is required by Swift's nonoptional ABI.
+        NSNotification *notification = [NSNotification notificationWithName:@"ApolloPaneDensityChanged" object:nil];
+        ((void (*)(id, SEL, id))objc_msgSend)(controller, reload, notification);
+    }
+}
+
+void ApolloPaneInstallChromeForController(UIViewController *controller) {
+    ApolloPaneSplitViewController *pane = (id)ApolloPaneSplitControllerFor(controller);
+    if (!pane || !controller.isViewLoaded) return;
+    ApolloPaneApplySearchPlacement(controller);
+    UINavigationController *primary = [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    if (controller.navigationController != primary) {
+        Class comments = objc_getClass("_TtC6Apollo22CommentsViewController");
+        if (comments && [controller isKindOfClass:comments]) {
+            NSNumber *original = objc_getAssociatedObject(controller, &kPaneOriginalExtendedEdges);
+            if (!pane.isCollapsed) {
+                if (!original) {
+                    original = @(controller.edgesForExtendedLayout);
+                    objc_setAssociatedObject(controller, &kPaneOriginalExtendedEdges, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                }
+                UIRectEdge edges = original.unsignedIntegerValue & ~UIRectEdgeTop;
+                if (controller.edgesForExtendedLayout != edges) controller.edgesForExtendedLayout = edges;
+            } else if (original) {
+                controller.edgesForExtendedLayout = original.unsignedIntegerValue;
+                objc_setAssociatedObject(controller, &kPaneOriginalExtendedEdges, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
+        }
+        if (comments && [controller isKindOfClass:comments] &&
+            ApolloPanePrepareCommentsFind(controller) && !objc_getAssociatedObject(controller, &kPaneFindButton)) {
+            __weak UIViewController *weakController = controller;
+            UIAction *find = [UIAction actionWithTitle:@"Find in comments" image:[UIImage systemImageNamed:@"magnifyingglass"]
+                identifier:nil handler:^(__unused UIAction *action) { ApolloPanePresentCommentsFind(weakController); }];
+            UIBarButtonItem *button = [[UIBarButtonItem alloc] initWithPrimaryAction:find];
+            button.accessibilityIdentifier = @"ApolloPaneFindComments";
+            objc_setAssociatedObject(controller, &kPaneFindButton, button, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            controller.navigationItem.rightBarButtonItems = [(controller.navigationItem.rightBarButtonItems ?: @[]) arrayByAddingObject:button];
+        }
+        return;
+    }
+    Class posts = objc_getClass("_TtC6Apollo19PostsViewController");
+    BOOL feed = posts && [controller isKindOfClass:posts];
+    if (feed && !objc_getAssociatedObject(controller, &kPaneDensityPrepared)) {
+        objc_setAssociatedObject(controller, &kPaneDensityPrepared, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloPaneReloadNativeFeed(controller);
+    }
+    UIBarButtonItem *item = objc_getAssociatedObject(controller, &kPaneLayoutButton);
+    if (!item) {
+        item = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"rectangle.split.2x1"]
+            style:UIBarButtonItemStylePlain target:nil action:nil];
+        item.accessibilityLabel = @"Pane layout";
+        item.accessibilityIdentifier = @"ApolloPaneLayoutMenu";
+        objc_setAssociatedObject(controller, &kPaneLayoutButton, item, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    // Menus contain stable actions, not per-frame state. Rebuild only when
+    // their role/density/window action changes; still restore our item if a
+    // native navigation update replaced the bar's array.
+    BOOL canOpenWindow = ApolloPaneCanOpenDetailInNewWindow(pane);
+    NSUInteger flags = (feed ? 1 : 0) | (ApolloPanePrefersCompactFeed(controller) ? 2 : 0) | (canOpenWindow ? 4 : 0);
+    NSNumber *previous = objc_getAssociatedObject(controller, &kPaneMenuConfiguration);
+    if (previous && previous.unsignedIntegerValue == flags) {
+        NSArray *items = controller.navigationItem.rightBarButtonItems ?: @[];
+        if (![items containsObject:item]) controller.navigationItem.rightBarButtonItems = [items arrayByAddingObject:item];
+        return;
+    }
+    objc_setAssociatedObject(controller, &kPaneMenuConfiguration, @(flags), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak UIViewController *weakController = controller;
+    __weak ApolloPaneSplitViewController *weakPane = pane;
+    NSMutableArray<UIMenuElement *> *actions = [NSMutableArray array];
+    if (feed) {
+        BOOL compact = ApolloPanePrefersCompactFeed(controller);
+        UIAction *compactAction = [UIAction actionWithTitle:@"Compact list" image:[UIImage systemImageNamed:@"list.bullet"]
+            identifier:nil handler:^(__unused UIAction *action) {
+                UIViewController *owner = weakController;
+                if (!owner) return;
+                ApolloPaneSetComfortableFeed(owner, NO);
+                ApolloPaneReloadNativeFeed(owner);
+                ApolloPaneInstallChromeForController(owner);
+            }];
+        compactAction.state = compact ? UIMenuElementStateOn : UIMenuElementStateOff;
+        UIAction *comfortableAction = [UIAction actionWithTitle:@"Comfortable list" image:[UIImage systemImageNamed:@"rectangle.grid.1x2"]
+            identifier:nil handler:^(__unused UIAction *action) {
+                UIViewController *owner = weakController;
+                if (!owner) return;
+                ApolloPaneSetComfortableFeed(owner, YES);
+                ApolloPaneReloadNativeFeed(owner);
+                ApolloPaneInstallChromeForController(owner);
+            }];
+        comfortableAction.state = compact ? UIMenuElementStateOff : UIMenuElementStateOn;
+        [actions addObjectsFromArray:@[compactAction, comfortableAction]];
+    }
+    [actions addObject:[UIAction actionWithTitle:@"Reset column width" image:[UIImage systemImageNamed:@"arrow.counterclockwise"]
+        identifier:nil handler:^(__unused UIAction *action) { [weakPane apollo_resetPreferredPrimaryWidth]; }]];
+    if (canOpenWindow) {
+        [actions addObject:[UIAction actionWithTitle:@"Open detail in new window"
+            image:[UIImage systemImageNamed:@"plus.rectangle.on.rectangle"] identifier:nil
+            handler:^(__unused UIAction *action) { ApolloPaneOpenDetailInNewWindow(weakPane); }]];
+    }
+    item.menu = [UIMenu menuWithTitle:@"Pane layout" children:actions];
+    NSArray *existing = controller.navigationItem.rightBarButtonItems ?: @[];
+    if (![existing containsObject:item]) controller.navigationItem.rightBarButtonItems = [existing arrayByAddingObject:item];
+}

--- a/src/ipad/ApolloPaneColumnHostViewController.h
+++ b/src/ipad/ApolloPaneColumnHostViewController.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+@interface ApolloPaneColumnHostViewController : UIViewController
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
+@property (nonatomic, strong, readonly) UINavigationController *hostedNavigationController;
+- (void)apollo_scheduleListColumnGeometryRefresh;
+- (void)apollo_prepareReadableWidthForTopController;
+#if APOLLO_SIM_BUILD
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset;
+#endif
+@end
+

--- a/src/ipad/ApolloPaneColumnHostViewController.m
+++ b/src/ipad/ApolloPaneColumnHostViewController.m
@@ -1,0 +1,443 @@
+// Owns physical column containment and readable-content insets.
+#import "ApolloPaneColumnHostViewController.h"
+#import "ApolloPaneSplitViewController.h"
+#import "ApolloPaneGeometry.h"
+#import "../ApolloCommon.h"
+#import "../ApolloThemeRuntime.h"
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+@implementation ApolloPaneColumnHostViewController {
+    NSLayoutConstraint *_topConstraint;
+    NSLayoutConstraint *_bottomConstraint;
+    ApolloPaneGeometryScheduler *_geometryScheduler;
+    BOOL _hasResolvedGeometry;
+    CGFloat _lastResolvedTop;
+    CGFloat _lastResolvedBottom;
+    __weak UIViewController *_readableWidthViewController;
+    CGFloat _readableWidthBaseLeft;
+    CGFloat _readableWidthBaseRight;
+    CGFloat _readableWidthAppliedInset;
+#if APOLLO_SIM_BUILD
+    NSUInteger _simLayoutPassCount;
+    NSUInteger _simGeometryRefreshCount;
+    NSUInteger _simGeometryWriteCount;
+#endif
+}
+
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _hostedNavigationController = navigationController;
+
+        // The same tab-bar reservation the pane itself has to opt out of (see
+        // the pane's configure method), one level further down.
+        //
+        // UISplitViewController wraps this host in a navigation controller of
+        // its own, and THAT controller applies the identical
+        // -[UITabBarController _frameForViewController:] rule to its child: it
+        // subtracts the opaque tab bar's height unless the child extends under
+        // it. The pane opting in did not help, because this host is a separate
+        // controller that never inherited the flag.
+        //
+        // Measured: the host's view came out (0,0,1376,968) inside a 1032pt
+        // wrapper, so the detail column ended at 968 while the list column ended
+        // at 1022 — the comment list stopping 54pt above the bottom of the
+        // screen with a band of background under it.
+        self.edgesForExtendedLayout = UIRectEdgeAll;
+        self.extendedLayoutIncludesOpaqueBars = YES;
+
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(apollo_contentSizeCategoryDidChange:)
+                   name:UIContentSizeCategoryDidChangeNotification
+                 object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self apollo_restoreReadableWidthInsets];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // CLEAR, deliberately — this view must never paint.
+    //
+    // It is laid out at the FULL window width (iPadOS 26 gives the secondary
+    // column the whole window and floats the other columns over it), while the
+    // navigation controller inside it is inset to the visible column. Giving it
+    // a background therefore does not tint "the detail column", it tints the
+    // entire window: behind the floating sidebar, in the gap between columns,
+    // and above the list column.
+    //
+    // That is exactly what went wrong. It painted ApolloThemePageBackgroundColor(),
+    // which is black under a pure-black theme and so looked correct — until a
+    // themed palette made it #0B1F28 and the whole app turned teal behind
+    // Apollo's own black screens. Only the controllers actually occupying a
+    // column may paint; this one is scaffolding.
+    self.view.backgroundColor = UIColor.clearColor;
+
+    UINavigationController *nav = self.hostedNavigationController;
+    if (!nav) return;
+
+    [self addChildViewController:nav];
+    nav.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:nav.view];
+    // ALL FOUR edges pin to the safe area, vertically as well as horizontally.
+    //
+    // Leading/trailing is the Texture fix (see the class comment). Top/bottom
+    // used to pin to the view so the nav bar could extend under the status bar
+    // "as Apollo expects" — that was wrong, and it is what made the app read as
+    // three separate windows rather than one.
+    //
+    // Measured on an iPad Pro 13" landscape, the three navigation bars were:
+    //
+    //   sidebar   (10, 32, 270, 54)
+    //   list      (280, 32, 480, 54)
+    //   detail    (760, 86, 616, 54)   ← 54pt lower than both its neighbours
+    //
+    // UIKit positions the sidebar and the list column inside already-inset
+    // column views, so their bars start at the column's own top. The secondary
+    // column view spans the full window (0,0,1376,1032), so pinning the nav
+    // controller to its top told that controller it began at the very top of the
+    // screen and it applied the whole status-bar inset a second time. Pinning to
+    // the safe area gives it the same origin UIKit gave the other two, and the
+    // three bars line up.
+    // Leading/trailing follow the safe area — that is the Texture fix, and it is
+    // the only thing the safe area gets to decide here.
+    //
+    // Top/bottom are driven manually against the LIST column's real frame (see
+    // apollo_matchListColumnGeometry). The safe area is the wrong input for
+    // them: it produced a detail column running 32→1012 against the list
+    // column's 32→1022, and it cannot express the 10pt the navigation bar
+    // inserts above itself.
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    _topConstraint = [nav.view.topAnchor constraintEqualToAnchor:self.view.topAnchor
+                                                        constant:self.view.safeAreaInsets.top];
+    _bottomConstraint = [self.view.bottomAnchor constraintEqualToAnchor:nav.view.bottomAnchor
+                                                              constant:self.view.safeAreaInsets.bottom];
+    [NSLayoutConstraint activateConstraints:@[
+        [nav.view.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor],
+        [nav.view.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor],
+        _topConstraint,
+        _bottomConstraint,
+    ]];
+    [nav didMoveToParentViewController:self];
+}
+
+// UISplitViewController wraps any column view controller that is not already a
+// navigation controller in one of its own. This host is a plain UIViewController,
+// so the detail column ends up with TWO navigation bars stacked:
+//
+//   UIKit's wrapper bar   (0, 32, 1376, 54)   full width, empty, invisible
+//   Apollo's real bar     (760, 96, 616, 54)  pushed below it
+//
+// The wrapper bar is never seen, but it still reports itself through the safe
+// area — 86pt of top inset — which is what pushed Apollo's bar 54pt below the
+// sidebar's and the list column's bars and made the three columns read as three
+// separate windows. Its full-width background band was painting across the whole
+// app too.
+//
+// Hiding it costs nothing: the wrapper has no items, no title and no back
+// button, because everything the user interacts with lives on the real
+// navigation controller inside this host.
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    if (self.navigationController && !self.navigationController.navigationBarHidden) {
+        [self.navigationController setNavigationBarHidden:YES animated:NO];
+    }
+    [self apollo_scheduleListColumnGeometryRefresh];
+}
+
+// Lines the detail column up with the list column exactly, top and bottom.
+//
+// WHY NOT THE SAFE AREA. Both navigation controllers report a top safe-area
+// inset of ZERO, and yet:
+//
+//   list    view {0,0,480,990}     bar at y=0    (column starts at 32 → bar at 32)
+//   detail  view {760,32,616,980}  bar at y=10   (→ bar at 42)
+//
+// The 10pt is not an inset we can cancel — it is where Apollo's navigation
+// controller puts its own bar. UIKit's split view positions the list column's
+// navigation controller itself and gets y=0; the same class, parented into this
+// host, lays its bar at y=10. So the fix is not to argue with the bar but to
+// offset the view by exactly the gap the bar leaves, measured each layout.
+//
+// The bottom is the same idea from the other side: the safe area put the detail
+// column's bottom at 1012 against the list column's 1022, which is the band of
+// empty background under the comment list. Matching the list column's maxY
+// removes it, and matching is more robust than any constant since it tracks
+// whatever inset the platform applies to that column.
+//
+// Constraint writes must not originate from viewDidLayoutSubviews: even a
+// value-checked write there can invalidate the same layout transaction during
+// rotation or continuous window resize. Safe-area and transition callbacks
+// coalesce into one post-layout sample instead.
+- (void)viewSafeAreaInsetsDidChange {
+    [super viewSafeAreaInsetsDidChange];
+    [self apollo_scheduleListColumnGeometryRefresh];
+
+    ApolloPaneSplitViewController *pane =
+        [self.splitViewController isKindOfClass:[ApolloPaneSplitViewController class]]
+            ? (ApolloPaneSplitViewController *)self.splitViewController : nil;
+    [pane apollo_resolvedDisplayStateMayHaveChanged];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak ApolloPaneColumnHostViewController *weakSelf = self;
+    [coordinator animateAlongsideTransition:nil
+        completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
+            [weakSelf apollo_scheduleListColumnGeometryRefresh];
+        }];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self apollo_scheduleListColumnGeometryRefresh];
+}
+
+- (void)apollo_contentSizeCategoryDidChange:(NSNotification *)notification {
+    (void)notification;
+    [self apollo_scheduleListColumnGeometryRefresh];
+}
+
+- (UITableView *)apollo_tableInView:(UIView *)view depth:(NSUInteger)depth {
+    if (!view || depth > 10) return nil;
+    if ([view isKindOfClass:[UITableView class]]) return (UITableView *)view;
+    for (UIView *subview in view.subviews) {
+        UITableView *table = [self apollo_tableInView:subview depth:depth + 1];
+        if (table) return table;
+    }
+    return nil;
+}
+
+// Settings tables still use an additive safe-area contribution. Comments use
+// per-node readable specs, so media headers keep the full detail width and
+// asynchronously arriving prose is classified at its factory, not by row zero.
+- (BOOL)apollo_topControllerWantsReadableWidth:(UIViewController *)controller {
+    ApolloPaneSplitViewController *pane = (id)self.splitViewController;
+    if (![pane isKindOfClass:ApolloPaneSplitViewController.class]) return NO;
+    UIViewController *root = [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary].viewControllers.firstObject;
+    return [NSStringFromClass(root.class) hasSuffix:@"SettingsViewController"] &&
+        controller.isViewLoaded && [self apollo_tableInView:controller.view depth:0] != nil;
+}
+
+- (void)apollo_restoreReadableWidthInsets {
+    UIViewController *controller = _readableWidthViewController;
+    if (controller) {
+        UIEdgeInsets additional = controller.additionalSafeAreaInsets;
+        additional.left -= _readableWidthAppliedInset;
+        additional.right -= _readableWidthAppliedInset;
+        controller.additionalSafeAreaInsets = additional;
+    }
+    _readableWidthViewController = nil;
+    _readableWidthBaseLeft = 0.0;
+    _readableWidthBaseRight = 0.0;
+    _readableWidthAppliedInset = 0.0;
+}
+
+- (void)apollo_applyReadableWidthIfNeeded {
+    UIViewController *top = self.hostedNavigationController.topViewController;
+    BOOL wantsReadableWidth = [self apollo_topControllerWantsReadableWidth:top];
+    if (_readableWidthViewController != top || !wantsReadableWidth) {
+        [self apollo_restoreReadableWidthInsets];
+    }
+    if (!wantsReadableWidth || !top.isViewLoaded) return;
+
+    if (_readableWidthViewController != top) {
+        _readableWidthViewController = top;
+        _readableWidthBaseLeft = top.additionalSafeAreaInsets.left;
+        _readableWidthBaseRight = top.additionalSafeAreaInsets.right;
+    }
+
+    CGFloat width = CGRectGetWidth(top.view.bounds);
+    // A controller installed into a visible navigation stack has not always
+    // received its first bounds assignment yet. The navigation controller is
+    // already constrained to the real detail column, so its width is the exact
+    // pre-display fallback we need. Waiting for top.view.bounds to become
+    // nonzero would allow one unconstrained frame to reach the screen.
+    if (width <= 0.0 && self.hostedNavigationController.isViewLoaded) {
+        width = CGRectGetWidth(self.hostedNavigationController.view.bounds);
+    }
+    if (width <= 0.0) return;
+
+    // 680pt is close to UIKit's familiar readable measure while still leaving
+    // room for nested comment indentation. At accessibility text sizes the cap
+    // relaxes to 760pt so larger glyphs do not turn every sentence into a tall,
+    // narrow column. The nav bar and table/background remain full width; only
+    // safe-area-following cell content is inset.
+    UIContentSizeCategory category = top.traitCollection.preferredContentSizeCategory;
+    CGFloat maximumWidth = UIContentSizeCategoryIsAccessibilityCategory(category) ? 760.0 : 680.0;
+    UIEdgeInsets current = top.additionalSafeAreaInsets;
+    CGFloat systemLeft = MAX(0.0, top.view.safeAreaInsets.left - current.left);
+    CGFloat systemRight = MAX(0.0, top.view.safeAreaInsets.right - current.right);
+    // Preserve inset contributions added by Apollo or another feature.
+    _readableWidthBaseLeft = current.left - _readableWidthAppliedInset;
+    _readableWidthBaseRight = current.right - _readableWidthAppliedInset;
+    CGFloat naturalWidth = MAX(0.0, width - systemLeft - systemRight -
+                               _readableWidthBaseLeft - _readableWidthBaseRight);
+    CGFloat inset = MAX(0.0, floor((naturalWidth - maximumWidth) / 2.0));
+    if (fabs(_readableWidthAppliedInset - inset) <= 0.5 &&
+        fabs(current.left - (_readableWidthBaseLeft + inset)) <= 0.5 &&
+        fabs(current.right - (_readableWidthBaseRight + inset)) <= 0.5) return;
+
+    _readableWidthAppliedInset = inset;
+    current.left = _readableWidthBaseLeft + inset;
+    current.right = _readableWidthBaseRight + inset;
+    top.additionalSafeAreaInsets = current;
+    ApolloLog(@"[PaneReadable] %@ width=%.0f max=%.0f inset=%.0f accessibility=%d",
+              NSStringFromClass(top.class), naturalWidth, maximumWidth, inset,
+              UIContentSizeCategoryIsAccessibilityCategory(category));
+}
+
+- (void)apollo_prepareReadableWidthForTopController {
+    UIViewController *top = self.hostedNavigationController.topViewController;
+    if (!top) {
+        [self apollo_restoreReadableWidthInsets];
+        return;
+    }
+
+    // This destination is about to become visible, so loading it here does not
+    // defeat the pane's lazy offscreen-tab policy. It does let us classify its
+    // table surface and install additionalSafeAreaInsets before Core Animation
+    // commits the navigation transaction's first frame.
+    [top loadViewIfNeeded];
+#if APOLLO_SIM_BUILD
+    ApolloLog(@"[PaneReadablePrepare] %@ topWidth=%.0f navWidth=%.0f table=%d window=%d",
+              NSStringFromClass(top.class), CGRectGetWidth(top.view.bounds),
+              CGRectGetWidth(self.hostedNavigationController.viewIfLoaded.bounds),
+              [self apollo_tableInView:top.view depth:0] != nil,
+              top.view.window != nil);
+#endif
+    [self apollo_applyReadableWidthIfNeeded];
+}
+
+#if APOLLO_SIM_BUILD
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    _simLayoutPassCount++;
+}
+#endif
+
+- (void)apollo_scheduleListColumnGeometryRefresh {
+    if (!_geometryScheduler) {
+        _geometryScheduler = [[ApolloPaneGeometryScheduler alloc] initWithOwner:self update:^(id owner) {
+            [owner apollo_matchListColumnGeometry];
+        }];
+    }
+    [_geometryScheduler requestAfterCoordinator:self.splitViewController.transitionCoordinator];
+}
+
+- (void)apollo_matchListColumnGeometry {
+    UINavigationController *nav = self.hostedNavigationController;
+    if (!nav.isViewLoaded || !_topConstraint || !_bottomConstraint) return;
+#if APOLLO_SIM_BUILD
+    _simGeometryRefreshCount++;
+#endif
+
+    CGFloat height = self.view.bounds.size.height;
+    if (height <= 0.0) return;
+
+    [self apollo_applyReadableWidthIfNeeded];
+
+    // Fall back to the safe area whenever the list column cannot be measured —
+    // collapsed, mid-transition, or not yet loaded.
+    CGFloat top = self.view.safeAreaInsets.top;
+    CGFloat bottom = self.view.safeAreaInsets.bottom;
+    // UIKit's public content guide includes floating top tabs even when the
+    // legacy tabBar view is hidden. Use its actual area, never a guessed row
+    // height or private tab-bar subview frame.
+    UITabBarController *tabs = self.tabBarController;
+    if (@available(iOS 26.0, *)) {
+        UILayoutGuide *guide = tabs.contentLayoutGuide;
+        if (self.splitViewController.isCollapsed && guide.owningView.window) {
+            CGRect content = [guide.owningView convertRect:guide.layoutFrame toView:self.view];
+            top = MAX(top, CGRectGetMinY(content) - nav.navigationBar.frame.origin.y);
+            bottom = MAX(bottom, height - CGRectGetMaxY(content));
+        }
+    }
+
+    UISplitViewController *split = self.splitViewController;
+    UIViewController *list = [split isKindOfClass:[UISplitViewController class]]
+        ? [split viewControllerForColumn:UISplitViewControllerColumnPrimary]
+        : nil;
+    if (list.isViewLoaded && list.view.superview && ApolloPaneSplitShowsTiledPrimary(split)) {
+        CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
+        CGRect splitBoundsInHost = [split.view convertRect:split.view.bounds toView:self.view];
+        if (!CGRectIsEmpty(listFrame) && CGRectIntersectsRect(listFrame, splitBoundsInHost)) {
+            bottom = height - CGRectGetMaxY(listFrame);
+
+            // Align the two NAVIGATION BARS, not the two view origins.
+            //
+            // The list column's bar is not always flush with the top of its
+            // column, and how far in it sits depends on the mode: with the
+            // sidebar showing, column and bar both start at y=32; with the
+            // sidebar collapsed to the floating tab bar, the column starts at
+            // y=86 and its bar at y=140, 54pt inside. Matching view origins got
+            // the sidebar case right and then put our bar 54pt ABOVE the list's
+            // in the tab bar case. So take the list bar's real position as the
+            // target and back out our own bar's offset within its view.
+            UINavigationBar *listBar = [list isKindOfClass:[UINavigationController class]]
+                ? ((UINavigationController *)list).navigationBar : nil;
+            CGFloat targetBarY = CGRectGetMinY(listFrame);
+            if (listBar && !listBar.isHidden && listBar.superview) {
+                targetBarY = CGRectGetMinY([listBar.superview convertRect:listBar.frame toView:self.view]);
+            }
+            top = targetBarY - nav.navigationBar.frame.origin.y;
+        }
+    }
+
+    BOOL changed = !_hasResolvedGeometry ||
+        fabs(_lastResolvedTop - top) > 0.5 ||
+        fabs(_lastResolvedBottom - bottom) > 0.5;
+    if (!changed) return;
+
+    _hasResolvedGeometry = YES;
+    _lastResolvedTop = top;
+    _lastResolvedBottom = bottom;
+    BOOL wroteConstraint = NO;
+    if (fabs(_topConstraint.constant - top) > 0.5) {
+        _topConstraint.constant = top;
+        wroteConstraint = YES;
+    }
+    if (fabs(_bottomConstraint.constant - bottom) > 0.5) {
+        _bottomConstraint.constant = bottom;
+        wroteConstraint = YES;
+    }
+#if APOLLO_SIM_BUILD
+    if (wroteConstraint) _simGeometryWriteCount++;
+#else
+    (void)wroteConstraint;
+#endif
+}
+
+#if APOLLO_SIM_BUILD
+- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset {
+    NSString *state = [NSString stringWithFormat:
+        @"hostPasses=%lu hostRefreshes=%lu hostWrites=%lu top=%.1f bottom=%.1f",
+        (unsigned long)_simLayoutPassCount,
+        (unsigned long)_simGeometryRefreshCount,
+        (unsigned long)_simGeometryWriteCount,
+        _topConstraint.constant, _bottomConstraint.constant];
+    if (reset) {
+        _simLayoutPassCount = 0;
+        _simGeometryRefreshCount = 0;
+        _simGeometryWriteCount = 0;
+    }
+    return state;
+}
+#endif
+
+// The hosted navigation controller owns the chrome; forwarding these keeps the
+// host transparent to UIKit rather than having it answer for an empty view.
+- (UIViewController *)childViewControllerForStatusBarStyle { return self.hostedNavigationController; }
+- (UIViewController *)childViewControllerForStatusBarHidden { return self.hostedNavigationController; }
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden { return self.hostedNavigationController; }
+
+@end
+

--- a/src/ipad/ApolloPaneContent.h
+++ b/src/ipad/ApolloPaneContent.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+__BEGIN_DECLS
+id ApolloPanePrepareNodeFactory(id factory, UIViewController *controller);
+__END_DECLS

--- a/src/ipad/ApolloPaneContent.xm
+++ b/src/ipad/ApolloPaneContent.xm
@@ -1,0 +1,93 @@
+// Capture UI policy before handing Apollo's original node factory to Texture.
+// Background layout consumes immutable values and never walks UIKit objects.
+#import "ApolloPaneContent.h"
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import "../ApolloTextureDecls.h"
+#import "../ApolloThemeRuntime.h"
+#import <objc/runtime.h>
+
+static char kReadableWidth;
+static char kSelectionColor;
+
+id ApolloPanePrepareNodeFactory(id factory, UIViewController *controller) {
+    if (!factory || !NSThread.isMainThread) return factory;
+    ApolloPaneSplitViewController *pane = (id)ApolloPaneSplitControllerFor(controller);
+    if (!pane) return factory;
+    Class comments = objc_getClass("_TtC6Apollo22CommentsViewController");
+    BOOL prose = comments && [controller isKindOfClass:comments];
+    UINavigationController *primary = [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    BOOL master = controller.navigationController == primary;
+    if (!prose && !master) return factory;
+    NSNumber *measure = @(UIContentSizeCategoryIsAccessibilityCategory(
+        controller.traitCollection.preferredContentSizeCategory) ? 760.0 : 680.0);
+    UIColor *accent = ApolloThemeAccentColor() ?: UIColor.systemBlueColor;
+    UIColor *selection = [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traits) {
+        CGFloat opacity = traits.accessibilityContrast == UIAccessibilityContrastHigh ? 0.18 : 0.09;
+        return [[accent resolvedColorWithTraitCollection:traits] colorWithAlphaComponent:opacity];
+    }];
+    id (^nativeFactory)(void) = factory;
+    return [^id {
+        id node = nativeFactory();
+        if (prose) objc_setAssociatedObject(node, &kReadableWidth, measure, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (master) objc_setAssociatedObject(node, &kSelectionColor, selection, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return node;
+    } copy];
+}
+
+static CGFloat ApolloPaneProseInset(id node, struct ApolloTextureSizeRange range) {
+    NSNumber *measure = objc_getAssociatedObject(node, &kReadableWidth);
+    if (!measure || !isfinite(range.max.width)) return 0.0;
+    return MAX(0.0, floor((range.max.width - measure.doubleValue) / 2.0));
+}
+
+%group ApolloPaneContentGroup
+%hook ApolloPaneCommentCell
+- (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)range {
+    CGFloat inset = ApolloPaneProseInset(self, range);
+    if (inset <= 0.0) return %orig;
+    range.min.width = MAX(0, range.min.width - 2 * inset);
+    range.max.width -= 2 * inset;
+    id content = %orig(range);
+    return [objc_getClass("ASInsetLayoutSpec") insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, inset, 0, inset) child:content];
+}
+%end
+
+%hook ApolloPaneCommentsHeader
+- (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)range {
+    CGFloat inset = ApolloPaneProseInset(self, range);
+    if (inset <= 0.0) return %orig;
+    range.min.width = MAX(0, range.min.width - 2 * inset);
+    range.max.width -= 2 * inset;
+    id content = %orig(range);
+    return [objc_getClass("ASInsetLayoutSpec") insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, inset, 0, inset) child:content];
+}
+%end
+
+%hook ApolloPaneCompactPost
+- (UIView *)selectedBackgroundView {
+    UIView *view = %orig;
+    UIColor *color = objc_getAssociatedObject(self, &kSelectionColor);
+    if (color) view.backgroundColor = color;
+    return view;
+}
+%end
+
+%hook ApolloPaneLargePost
+- (UIView *)selectedBackgroundView {
+    UIView *view = %orig;
+    UIColor *color = objc_getAssociatedObject(self, &kSelectionColor);
+    if (color) view.backgroundColor = color;
+    return view;
+}
+%end
+%end
+
+%ctor {
+    if (!ApolloPaneLayoutEnabled()) return;
+    %init(ApolloPaneContentGroup,
+        ApolloPaneCommentCell=objc_getClass("_TtC6Apollo15CommentCellNode"),
+        ApolloPaneCommentsHeader=objc_getClass("_TtC6Apollo22CommentsHeaderCellNode"),
+        ApolloPaneCompactPost=objc_getClass("_TtC6Apollo19CompactPostCellNode"),
+        ApolloPaneLargePost=objc_getClass("_TtC6Apollo17LargePostCellNode"));
+}

--- a/src/ipad/ApolloPaneDiagnostics.h
+++ b/src/ipad/ApolloPaneDiagnostics.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+__BEGIN_DECLS
+// Opt-in on device and simulator: APOLLO_PANE_TRACE=1. Metadata is enumerated
+// operation names only; no route, query, model, title or account data.
+BOOL ApolloPaneTraceEnabled(void);
+void ApolloPaneTraceBegin(id owner, NSString *operation);
+void ApolloPaneTraceEnd(id owner, NSString *operation);
+void ApolloPaneTraceCancel(id owner);
+__END_DECLS

--- a/src/ipad/ApolloPaneDiagnostics.m
+++ b/src/ipad/ApolloPaneDiagnostics.m
@@ -1,0 +1,43 @@
+#import "ApolloPaneDiagnostics.h"
+#import <objc/runtime.h>
+#import <os/signpost.h>
+
+static char kIntervals;
+BOOL ApolloPaneTraceEnabled(void) {
+    static BOOL enabled;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ enabled = [NSProcessInfo.processInfo.environment[@"APOLLO_PANE_TRACE"] boolValue]; });
+    return enabled;
+}
+static os_log_t ApolloPaneLog(void) {
+    static os_log_t log;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ log = os_log_create("apollofix", "PaneOperations"); });
+    return log;
+}
+void ApolloPaneTraceBegin(id owner, NSString *operation) {
+    if (!ApolloPaneTraceEnabled() || !owner) return;
+    ApolloPaneTraceEnd(owner, operation);
+    NSMutableDictionary *intervals = objc_getAssociatedObject(owner, &kIntervals);
+    if (!intervals) {
+        intervals = [NSMutableDictionary dictionary];
+        objc_setAssociatedObject(owner, &kIntervals, intervals, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    os_signpost_id_t token = os_signpost_id_generate(ApolloPaneLog());
+    intervals[operation] = @(token);
+    os_signpost_interval_begin(ApolloPaneLog(), token, "PaneOperation", "%{public}@", operation);
+}
+void ApolloPaneTraceEnd(id owner, NSString *operation) {
+    if (!ApolloPaneTraceEnabled() || !owner) return;
+    NSMutableDictionary *intervals = objc_getAssociatedObject(owner, &kIntervals);
+    NSNumber *token = intervals[operation];
+    if (!token) return;
+    os_signpost_interval_end(ApolloPaneLog(), token.unsignedLongLongValue, "PaneOperation", "%{public}@", operation);
+    [intervals removeObjectForKey:operation];
+}
+void ApolloPaneTraceCancel(id owner) {
+    if (!ApolloPaneTraceEnabled() || !owner) return;
+    NSDictionary *intervals = objc_getAssociatedObject(owner, &kIntervals);
+    for (NSString *operation in intervals.allKeys) ApolloPaneTraceEnd(owner, operation);
+    objc_setAssociatedObject(owner, &kIntervals, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}

--- a/src/ipad/ApolloPaneEntryPoints.xm
+++ b/src/ipad/ApolloPaneEntryPoints.xm
@@ -16,24 +16,36 @@
 
 #import <UIKit/UIKit.h>
 #import <UserNotifications/UserNotifications.h>
+#import <objc/runtime.h>
 #import "ApolloPaneLayout.h"
 #import "ApolloPaneSplitViewController.h"
+#import "ApolloPaneSidebar.h"
 #import "../ApolloCommon.h"
 
 // UIKit entry callbacks are main-thread APIs. A counter, rather than a BOOL,
 // preserves the scope if another hooked entry point is invoked synchronously.
 static NSUInteger sApolloPaneNativeEntryDepth = 0;
-
-static BOOL ApolloPaneNativeEntryCompatibilityActive(void) {
-    return sApolloPaneNativeEntryDepth > 0 && ApolloPaneLayoutActive();
+static NSMutableArray *sApolloPaneEntryTabs;
+static UITabBarController *ApolloPaneEntryTabsForDelegate(id delegate) {
+    Ivar ivar = class_getInstanceVariable([delegate class], "tabBarController");
+    id value = ivar ? object_getIvar(delegate, ivar) : nil;
+    return [value isKindOfClass:UITabBarController.class] ? value : nil;
 }
 
-static void ApolloPaneBeginNativeEntry(void) {
-    if (ApolloPaneLayoutActive()) sApolloPaneNativeEntryDepth++;
+static BOOL ApolloPaneNativeEntryCompatibilityActive(UITabBarController *tabs) {
+    return sApolloPaneNativeEntryDepth > 0 && ApolloPaneLayoutActive() &&
+        sApolloPaneEntryTabs.lastObject == tabs;
+}
+
+static void ApolloPaneBeginNativeEntry(UITabBarController *tabs) {
+    if (!sApolloPaneEntryTabs) sApolloPaneEntryTabs = [NSMutableArray array];
+    [sApolloPaneEntryTabs addObject:tabs ?: NSNull.null];
+    sApolloPaneNativeEntryDepth++;
 }
 
 static void ApolloPaneEndNativeEntry(void) {
     if (sApolloPaneNativeEntryDepth > 0) sApolloPaneNativeEntryDepth--;
+    [sApolloPaneEntryTabs removeLastObject];
 }
 
 static NSArray<UIViewController *> *ApolloPaneActualTabChildren(UITabBarController *tabBarController) {
@@ -69,7 +81,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 
 - (UIViewController *)selectedViewController {
     UIViewController *actual = %orig;
-    if (!ApolloPaneNativeEntryCompatibilityActive() ||
+    if (!ApolloPaneNativeEntryCompatibilityActive(self) ||
         ![actual isKindOfClass:[ApolloPaneSplitViewController class]]) return actual;
     UIViewController *compatible = [(ApolloPaneSplitViewController *)actual
         apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ?: actual;
@@ -79,7 +91,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 
 - (NSArray<UIViewController *> *)viewControllers {
     NSArray<UIViewController *> *actual = %orig;
-    if (!ApolloPaneNativeEntryCompatibilityActive()) return actual;
+    if (!ApolloPaneNativeEntryCompatibilityActive(self)) return actual;
 
     NSMutableArray<UIViewController *> *compatible =
         [NSMutableArray arrayWithCapacity:actual.count];
@@ -97,7 +109,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 }
 
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {
-    if (!ApolloPaneNativeEntryCompatibilityActive()) { %orig; return; }
+    if (!ApolloPaneNativeEntryCompatibilityActive(self)) { %orig; return; }
     NSUInteger savedDepth = sApolloPaneNativeEntryDepth;
     sApolloPaneNativeEntryDepth = 0;
     @try {
@@ -108,7 +120,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 }
 
 - (void)setSelectedViewController:(UIViewController *)selectedViewController {
-    if (!ApolloPaneNativeEntryCompatibilityActive()) { %orig; return; }
+    if (!ApolloPaneNativeEntryCompatibilityActive(self)) { %orig; return; }
     UIViewController *actual = ApolloPaneActualChildForSyntheticChild(self, selectedViewController);
     NSUInteger savedDepth = sApolloPaneNativeEntryDepth;
     sApolloPaneNativeEntryDepth = 0;
@@ -124,7 +136,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 %hook _TtC6Apollo11AppDelegate
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options {
-    ApolloPaneBeginNativeEntry();
+    ApolloPaneBeginNativeEntry(ApolloPaneEntryTabsForDelegate(self));
     ApolloLog(@"[PaneEntry] AppDelegate URL callback active=%d", ApolloPaneLayoutActive());
     @try {
         return %orig(application, url, options);
@@ -136,7 +148,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
  didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)(void))completionHandler {
-    ApolloPaneBeginNativeEntry();
+    ApolloPaneBeginNativeEntry(ApolloPaneEntryTabsForDelegate(self));
     ApolloLog(@"[PaneEntry] AppDelegate notification callback active=%d", ApolloPaneLayoutActive());
     @try {
         %orig(center, response, completionHandler);
@@ -162,7 +174,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
         compatible = [(ApolloPaneSplitViewController *)viewController
             apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ?: viewController;
     }
-    ApolloPaneBeginNativeEntry();
+    ApolloPaneBeginNativeEntry(tabBarController);
     @try {
         return %orig(tabBarController, compatible);
     } @finally {
@@ -171,7 +183,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 }
 
 - (void)scene:(UIScene *)scene openURLContexts:(NSSet *)URLContexts {
-    ApolloPaneBeginNativeEntry();
+    ApolloPaneBeginNativeEntry(ApolloPaneEntryTabsForDelegate(self));
     ApolloLog(@"[PaneEntry] SceneDelegate URL callback active=%d", ApolloPaneLayoutActive());
     @try {
         %orig(scene, URLContexts);
@@ -183,7 +195,7 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 - (void)windowScene:(UIWindowScene *)windowScene
  performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
    completionHandler:(void (^)(BOOL succeeded))completionHandler {
-    ApolloPaneBeginNativeEntry();
+    ApolloPaneBeginNativeEntry(ApolloPaneEntryTabsForDelegate(self));
     ApolloLog(@"[PaneEntry] SceneDelegate shortcut callback active=%d", ApolloPaneLayoutActive());
     @try {
         %orig(windowScene, shortcutItem, completionHandler);
@@ -193,7 +205,12 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 }
 
 - (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
-    ApolloPaneBeginNativeEntry();
+    if ([scene isKindOfClass:UIWindowScene.class] &&
+        ApolloPaneReceiveSceneActivity((UIWindowScene *)scene, userActivity)) {
+        ApolloPaneOpenPendingSceneLink((UIWindowScene *)scene);
+        return;
+    }
+    ApolloPaneBeginNativeEntry(ApolloPaneEntryTabsForDelegate(self));
     ApolloLog(@"[PaneEntry] SceneDelegate activity callback active=%d", ApolloPaneLayoutActive());
     @try {
         %orig(scene, userActivity);
@@ -209,5 +226,6 @@ static UIViewController *ApolloPaneActualChildForSyntheticChild(UITabBarControll
 %ctor {
     if (!ApolloPaneLayoutEnabled()) return;
     %init(ApolloPaneEntryPointsGroup);
+    ApolloPaneEntryPointsSetReady();
     ApolloLog(@"[PaneEntry] installed scoped native-entry compatibility adapter");
 }

--- a/src/ipad/ApolloPaneFocus.h
+++ b/src/ipad/ApolloPaneFocus.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+@class ApolloPaneSplitViewController;
+__BEGIN_DECLS
+void ApolloPaneInstallFocus(ApolloPaneSplitViewController *pane);
+UIViewController *ApolloPaneFocusedController(ApolloPaneSplitViewController *pane);
+void ApolloPaneFocusColumn(ApolloPaneSplitViewController *pane, BOOL detail, BOOL announce);
+void ApolloPaneRefreshFocus(ApolloPaneSplitViewController *pane);
+void ApolloPaneRestoreFocusPolicy(ApolloPaneSplitViewController *pane);
+__END_DECLS

--- a/src/ipad/ApolloPaneFocus.m
+++ b/src/ipad/ApolloPaneFocus.m
@@ -1,0 +1,84 @@
+#import "ApolloPaneFocus.h"
+#import "ApolloPaneSplitViewController.h"
+#import <objc/runtime.h>
+
+@interface ApolloPaneFocusOwner : NSObject <UIGestureRecognizerDelegate>
+@property (nonatomic, weak) ApolloPaneSplitViewController *pane;
+@property (nonatomic) BOOL detail;
+@property (nonatomic, strong) NSMapTable<UIScrollView *, NSNumber *> *originalScrollPolicy;
+@end
+
+static char kFocusOwner;
+static UIScrollView *ApolloPaneScrollView(UIView *view, NSUInteger depth) {
+    if (!view || depth > 8) return nil;
+    if ([view isKindOfClass:UITableView.class]) return (id)view;
+    for (UIView *child in view.subviews) {
+        UIScrollView *scroll = ApolloPaneScrollView(child, depth + 1);
+        if (scroll) return scroll;
+    }
+    return nil;
+}
+
+@implementation ApolloPaneFocusOwner
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gesture
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)other { return YES; }
+- (void)tapped:(UITapGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateEnded) return;
+    UINavigationController *detail = [self.pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    UIView *view = detail.viewIfLoaded;
+    BOOL inside = view.window && CGRectContainsPoint(view.bounds, [gesture locationInView:view]);
+    ApolloPaneFocusColumn(self.pane, inside, NO);
+}
+@end
+
+void ApolloPaneInstallFocus(ApolloPaneSplitViewController *pane) {
+    if (objc_getAssociatedObject(pane, &kFocusOwner)) return;
+    ApolloPaneFocusOwner *owner = [ApolloPaneFocusOwner new];
+    owner.pane = pane;
+    owner.originalScrollPolicy = [NSMapTable weakToStrongObjectsMapTable];
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:owner action:@selector(tapped:)];
+    tap.cancelsTouchesInView = NO;
+    tap.delaysTouchesBegan = NO;
+    tap.delaysTouchesEnded = NO;
+    tap.delegate = owner;
+    [pane.view addGestureRecognizer:tap];
+    objc_setAssociatedObject(pane, &kFocusOwner, owner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+UIViewController *ApolloPaneFocusedController(ApolloPaneSplitViewController *pane) {
+    ApolloPaneFocusOwner *owner = objc_getAssociatedObject(pane, &kFocusOwner);
+    UINavigationController *nav = [pane apollo_navigationControllerForColumn:
+        owner.detail ? ApolloPaneColumnSecondary : ApolloPaneColumnPrimary];
+    if (!nav.viewIfLoaded.window) nav = (id)[pane apollo_preferredContentColumnController];
+    return nav.topViewController;
+}
+
+void ApolloPaneRefreshFocus(ApolloPaneSplitViewController *pane) {
+    ApolloPaneFocusOwner *owner = objc_getAssociatedObject(pane, &kFocusOwner);
+    UIViewController *focused = ApolloPaneFocusedController(pane);
+    for (NSNumber *column in @[@(ApolloPaneColumnPrimary), @(ApolloPaneColumnSecondary)]) {
+        UINavigationController *nav = [pane apollo_navigationControllerForColumn:column.integerValue];
+        UIScrollView *table = ApolloPaneScrollView(nav.topViewController.viewIfLoaded, 0);
+        if (table && ![owner.originalScrollPolicy objectForKey:table])
+            [owner.originalScrollPolicy setObject:@(table.scrollsToTop) forKey:table];
+        table.scrollsToTop = nav.topViewController == focused && table.window != nil;
+    }
+}
+
+void ApolloPaneFocusColumn(ApolloPaneSplitViewController *pane, BOOL detail, BOOL announce) {
+    ApolloPaneFocusOwner *owner = objc_getAssociatedObject(pane, &kFocusOwner);
+    owner.detail = detail;
+    ApolloPaneRefreshFocus(pane);
+    if (announce) {
+        [pane becomeFirstResponder];
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                        ApolloPaneFocusedController(pane).viewIfLoaded);
+    }
+}
+
+void ApolloPaneRestoreFocusPolicy(ApolloPaneSplitViewController *pane) {
+    ApolloPaneFocusOwner *owner = objc_getAssociatedObject(pane, &kFocusOwner);
+    for (UIScrollView *table in owner.originalScrollPolicy.keyEnumerator)
+        table.scrollsToTop = [[owner.originalScrollPolicy objectForKey:table] boolValue];
+    [owner.originalScrollPolicy removeAllObjects];
+}

--- a/src/ipad/ApolloPaneGeometry.h
+++ b/src/ipad/ApolloPaneGeometry.h
@@ -1,0 +1,23 @@
+#import <UIKit/UIKit.h>
+
+__BEGIN_DECLS
+BOOL ApolloPaneSplitShowsPrimary(UISplitViewController *split);
+BOOL ApolloPaneSplitShowsTiledPrimary(UISplitViewController *split);
+__END_DECLS
+
+// One pending update per owner, weak lifetime, bounded coordinator wait.
+// The update receives the owner instead of capturing it in a retained block.
+@interface ApolloPaneGeometryScheduler : NSObject
+@property (nonatomic, readonly, getter=isPending) BOOL pending;
+- (instancetype)initWithOwner:(UIViewController *)owner update:(void (^)(id owner))update;
+- (void)requestAfterCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator;
+- (void)cancel;
+@end
+
+// One write on the next display frame. The link exists only while a write is
+// pending; the owner stays weak even when UIKit retains the display link.
+@interface ApolloPaneFrameScheduler : NSObject
+- (instancetype)initWithOwner:(UIViewController *)owner update:(void (^)(id owner))update;
+- (void)request;
+- (void)cancel;
+@end

--- a/src/ipad/ApolloPaneGeometry.m
+++ b/src/ipad/ApolloPaneGeometry.m
@@ -1,0 +1,101 @@
+#import "ApolloPaneGeometry.h"
+#import "ApolloPaneDiagnostics.h"
+
+BOOL ApolloPaneSplitShowsPrimary(UISplitViewController *split) {
+    if (!split) return NO;
+    if (@available(iOS 26.0, *)) {
+        return [split isShowingColumn:UISplitViewControllerColumnPrimary];
+    }
+    if (split.isCollapsed) {
+        UIView *view = [split viewControllerForColumn:UISplitViewControllerColumnPrimary].viewIfLoaded;
+        return view.window != nil && !view.hidden;
+    }
+    return split.displayMode == UISplitViewControllerDisplayModeOneBesideSecondary ||
+        split.displayMode == UISplitViewControllerDisplayModeOneOverSecondary;
+}
+
+BOOL ApolloPaneSplitShowsTiledPrimary(UISplitViewController *split) {
+    return split && !split.isCollapsed && ApolloPaneSplitShowsPrimary(split) &&
+        split.displayMode == UISplitViewControllerDisplayModeOneBesideSecondary &&
+        split.splitBehavior == UISplitViewControllerSplitBehaviorTile &&
+        split.transitionCoordinator == nil;
+}
+
+@implementation ApolloPaneGeometryScheduler {
+    __weak UIViewController *_owner;
+    void (^_update)(id);
+    NSUInteger _generation;
+    BOOL _pending;
+}
+- (instancetype)initWithOwner:(UIViewController *)owner update:(void (^)(id))update {
+    if ((self = [super init])) { _owner = owner; _update = [update copy]; }
+    return self;
+}
+- (void)cancel { _generation++; _pending = NO; }
+- (BOOL)isPending { return _pending; }
+- (void)deliverGeneration:(NSUInteger)generation {
+    if (!_pending || generation != _generation) return;
+    _pending = NO;
+    UIViewController *owner = _owner;
+    if (owner.viewIfLoaded.window) {
+        ApolloPaneTraceBegin(owner, @"geometry");
+        _update(owner);
+        ApolloPaneTraceEnd(owner, @"geometry");
+    }
+}
+- (void)requestAfterCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    NSAssert(NSThread.isMainThread, @"Pane geometry is main-thread owned");
+    if (_pending || !_owner.isViewLoaded) return;
+    _pending = YES;
+    NSUInteger generation = ++_generation;
+    __weak ApolloPaneGeometryScheduler *weakSelf = self;
+    void (^deliver)(void) = ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf deliverGeneration:generation];
+        });
+    };
+    if (!coordinator) { deliver(); return; }
+    BOOL accepted = [coordinator animateAlongsideTransition:nil completion:^(__unused id context) {
+        deliver();
+    }];
+    // UIKit can call completion even when registration returns NO. Generation
+    // gating makes those two delivery paths idempotent.
+    if (!accepted) { deliver(); return; }
+    __weak id<UIViewControllerTransitionCoordinator> weakCoordinator = coordinator;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        ApolloPaneGeometryScheduler *scheduler = weakSelf;
+        if (!scheduler || generation != scheduler->_generation || !scheduler->_pending) return;
+        // A disappearing scene must not leave an owner latched forever. If a
+        // transition is still active, the next lifecycle event requests anew.
+        if (weakCoordinator && scheduler->_owner.transitionCoordinator == weakCoordinator) {
+            [scheduler cancel];
+        } else {
+            [scheduler deliverGeneration:generation];
+        }
+    });
+}
+@end
+
+@implementation ApolloPaneFrameScheduler {
+    __weak UIViewController *_owner;
+    void (^_update)(id);
+    CADisplayLink *_link;
+}
+- (instancetype)initWithOwner:(UIViewController *)owner update:(void (^)(id))update {
+    if ((self = [super init])) { _owner = owner; _update = [update copy]; }
+    return self;
+}
+- (void)request {
+    if (_link) return;
+    _link = [CADisplayLink displayLinkWithTarget:self selector:@selector(deliver:)];
+    [_link addToRunLoop:NSRunLoop.mainRunLoop forMode:NSRunLoopCommonModes];
+}
+- (void)deliver:(CADisplayLink *)link {
+    [self cancel];
+    UIViewController *owner = _owner;
+    if (owner.viewIfLoaded.window.windowScene.activationState == UISceneActivationStateForegroundActive)
+        _update(owner);
+}
+- (void)cancel { [_link invalidate]; _link = nil; }
+- (void)dealloc { [self cancel]; }
+@end

--- a/src/ipad/ApolloPaneGeometryPolicy.h
+++ b/src/ipad/ApolloPaneGeometryPolicy.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <math.h>
+#include <stdbool.h>
+
+// Pure policy: preferences survive constrained windows; resolved requests do
+// not consume the reader's minimum useful width. UIKit owns final geometry.
+static inline double ApolloPanePreferredWidth(double width) {
+    return fmin(480.0, fmax(340.0, isfinite(width) ? width : 420.0));
+}
+
+static inline double ApolloPaneResolvedWidth(double preferred, double available) {
+    double width = ApolloPanePreferredWidth(preferred);
+    if (!isfinite(available) || available <= 0.0) return width;
+    return fmin(width, fmax(340.0, available - 420.0));
+}
+
+static inline bool ApolloPanePrimaryIsPhysicallyLeft(bool leading, bool rightToLeft) {
+    return leading != rightToLeft;
+}

--- a/src/ipad/ApolloPaneInstall.xm
+++ b/src/ipad/ApolloPaneInstall.xm
@@ -26,6 +26,7 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloPaneLayout.h"
+#import "ApolloPaneSidebar.h"
 #import "ApolloPaneSplitViewController.h"
 #import "../ApolloCommon.h"   // ApolloLog, ApolloMainTabBarController
 #import "../ApolloState.h"    // sIPadPaneLayout
@@ -445,6 +446,12 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
 
 - (void)scene:(UIScene *)scene willConnectToSession:(id)session options:(id)options {
     %orig;
+    // Apollo's original cold-connection handler doesn't consume our explicit
+    // new-window route. Preserve only that URL until this exact scene activates.
+    if ([scene isKindOfClass:UIWindowScene.class]) {
+        for (NSUserActivity *activity in ((UISceneConnectionOptions *)options).userActivities)
+            ApolloPaneReceiveSceneActivity((UIWindowScene *)scene, activity);
+    }
 
 #if APOLLO_SIM_BUILD
     // Deterministic cold-entry harness for Xcode 27, whose URL dispatcher does
@@ -455,7 +462,7 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     NSString *coldURLString = NSProcessInfo.processInfo.environment[@"APOLLO_SIM_COLD_URL"];
     NSURL *coldURL = coldURLString.length > 0 ? [NSURL URLWithString:coldURLString] : nil;
     if (coldURL) {
-        BOOL routed = ApolloRouteURLThroughApp(coldURL);
+        BOOL routed = ApolloRouteURLThroughAppInScene(coldURL, (UIWindowScene *)scene);
         ApolloLog(@"[PaneInstall] simulator cold URL injection routed=%d scheme=%@",
                   routed, coldURL.scheme.lowercaseString);
     }
@@ -464,7 +471,7 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     // Re-check the gate here rather than trusting the %ctor decision alone: a
     // second scene (Stage Manager, an external display) connects later, and the
     // install must be idempotent per tab bar controller rather than per process.
-    if (!ApolloPaneLayoutEnabled()) return;
+    if (!ApolloPaneLayoutEnabled() || !ApolloPaneBootstrapReady()) return;
 
     UITabBarController *tabBarController = nil;
     @try {
@@ -492,7 +499,7 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     }
 
     if (ApolloPaneInstallIntoTabBarController(tabBarController)) {
-        ApolloPaneLayoutSetActive(YES);
+        ApolloPaneRegisterScene((UIWindowScene *)scene, tabBarController);
 #if APOLLO_SIM_BUILD
         ApolloPaneInstallSimWriteStatus(tabBarController, @"installed", YES, nil);
 #endif
@@ -520,5 +527,27 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     }
 
     %init(ApolloPaneInstallGroup, SceneDelegate = sceneDelegateClass);
+    // Observe UIKit's public scene events instead of assuming Apollo implements
+    // every optional delegate method. Enumerate the scene registry so hidden,
+    // detached tabs receive cancellation too, without loading their views.
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center addObserverForName:UISceneWillDeactivateNotification object:nil queue:NSOperationQueue.mainQueue
+        usingBlock:^(NSNotification *note) {
+            if (![note.object isKindOfClass:UIWindowScene.class]) return;
+            for (ApolloPaneSplitViewController *pane in ApolloPaneSplitsForScene(note.object))
+                [pane apollo_sceneBecameInactive];
+        }];
+    [center addObserverForName:UISceneDidActivateNotification object:nil queue:NSOperationQueue.mainQueue
+        usingBlock:^(NSNotification *note) {
+            if (![note.object isKindOfClass:UIWindowScene.class]) return;
+            for (ApolloPaneSplitViewController *pane in ApolloPaneSplitsForScene(note.object))
+                [pane apollo_sceneBecameActive];
+            __weak UIWindowScene *weakScene = note.object;
+            dispatch_async(dispatch_get_main_queue(), ^{ ApolloPaneOpenPendingSceneLink(weakScene); });
+        }];
+    [center addObserverForName:UISceneDidDisconnectNotification object:nil queue:NSOperationQueue.mainQueue
+        usingBlock:^(NSNotification *note) {
+            if ([note.object isKindOfClass:UIWindowScene.class]) ApolloPaneDisconnectScene(note.object);
+        }];
     ApolloLog(@"[PaneInstall] scene delegate hook installed; awaiting scene connect");
 }

--- a/src/ipad/ApolloPaneLayout.h
+++ b/src/ipad/ApolloPaneLayout.h
@@ -63,6 +63,15 @@ BOOL ApolloPaneLayoutActive(void);
 // or partial install is what makes the whole feature fail safe: every consumer
 // falls back to stock behavior rather than half-applying.
 void ApolloPaneLayoutSetActive(BOOL active);
+void ApolloPaneRouterSetReady(void);
+void ApolloPaneEntryPointsSetReady(void);
+BOOL ApolloPaneBootstrapReady(void);
+void ApolloPaneRegisterScene(UIWindowScene *scene, UITabBarController *tabs);
+void ApolloPaneDisconnectScene(UIWindowScene *scene);
+NSArray<UISplitViewController *> *ApolloPaneRegisteredSplits(void);
+NSArray<UISplitViewController *> *ApolloPaneSplitsForScene(UIWindowScene *scene);
+void ApolloPaneRegisterNavigationItems(UINavigationController *navigationController);
+UISplitViewController *_Nullable ApolloPanePrimarySplitForNavigationItem(UINavigationItem *item);
 
 // MARK: - Hierarchy
 

--- a/src/ipad/ApolloPaneLayout.m
+++ b/src/ipad/ApolloPaneLayout.m
@@ -2,15 +2,44 @@
 
 #import "ApolloPaneLayout.h"
 #import "ApolloPaneSplitViewController.h"
+#import "ApolloPaneSidebar.h"
 #import "../ApolloCommon.h"   // ApolloLog
 #import "../ApolloState.h"    // sIPadPaneLayout
+#import <objc/runtime.h>
 
 // Set once, from the main thread, during scene connect. Read from the main
 // thread by every consumer. No synchronization needed and none implied — if a
 // background reader ever appears, make this atomic rather than adding a lock
 // around a single BOOL.
 static BOOL sPaneLayoutActive = NO;
+static BOOL sPaneRouterReady;
+static BOOL sPaneEntryPointsReady;
+static NSMapTable<UIWindowScene *, UITabBarController *> *sPaneSceneTabs;
+
+void ApolloPaneRouterSetReady(void) { sPaneRouterReady = YES; }
+void ApolloPaneEntryPointsSetReady(void) { sPaneEntryPointsReady = YES; }
+BOOL ApolloPaneBootstrapReady(void) {
+    if (!sPaneRouterReady || !sPaneEntryPointsReady) return NO;
+    static BOOL compatible;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        Class nav = objc_getClass("_TtC6Apollo26ApolloNavigationController");
+        Ivar interaction = class_getInstanceVariable(nav, "interactionController");
+        Ivar history = class_getInstanceVariable(nav, "poppedViewControllers");
+        compatible = nav && interaction && history &&
+            ivar_getOffset(interaction) - ivar_getOffset(history) == sizeof(void *) &&
+            class_getInstanceMethod(nav, @selector(pushViewController:animated:)) &&
+            class_getInstanceMethod(nav, @selector(popToViewController:animated:)) &&
+            class_getInstanceMethod(nav, @selector(setViewControllers:animated:));
+#if APOLLO_SIM_BUILD
+        if ([NSProcessInfo.processInfo.environment[@"APOLLO_PANE_SIM_REQUIRED_CAPABILITY_FAILURE"] boolValue]) compatible = NO;
+#endif
+        ApolloLog(@"[PaneBootstrap] router=%d entry=%d navigationContract=%d", sPaneRouterReady, sPaneEntryPointsReady, compatible);
+    });
+    return compatible;
+}
 static NSMapTable<UINavigationController *, UISplitViewController *> *sPaneNavigationOwners = nil;
+static NSMapTable<UINavigationItem *, UINavigationController *> *sPaneItemOwners;
 
 BOOL ApolloPaneLayoutSupported(void) {
     static BOOL supported = NO;
@@ -25,12 +54,20 @@ BOOL ApolloPaneLayoutSupported(void) {
         // untouched everywhere else.
         if (@available(iOS 18.0, *)) {
             supported = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad);
+#if APOLLO_SIM_BUILD
+            // Development only: exercise an actual phone idiom at cold narrow
+            // launch and through resizing. Never spoof UIDevice or global traits.
+            supported |= [NSProcessInfo.processInfo.environment[@"APOLLO_SIM_ADAPTIVE_PHONE"] boolValue];
+#endif
         }
     });
     return supported;
 }
 
 BOOL ApolloPaneLayoutEnabled(void) {
+#if APOLLO_SIM_BUILD
+    if ([NSProcessInfo.processInfo.environment[@"APOLLO_SIM_ADAPTIVE_PHONE"] boolValue]) return ApolloPaneLayoutSupported();
+#endif
     return ApolloPaneLayoutSupported() && sIPadPaneLayout;
 }
 
@@ -78,6 +115,7 @@ void ApolloPaneRegisterNavigationController(UINavigationController *navigationCo
         sPaneNavigationOwners = [NSMapTable weakToWeakObjectsMapTable];
     }
     [sPaneNavigationOwners setObject:splitViewController forKey:navigationController];
+    ApolloPaneRegisterNavigationItems(navigationController);
 }
 
 void ApolloPaneUnregisterNavigationController(UINavigationController *navigationController) {
@@ -109,4 +147,61 @@ void ApolloPaneStageMasterTableSelectionIfNeeded(
                                               itemIdentifier:nil
                                                identityOwner:nil];
     [pane apollo_stageMasterSelectionIntent:intent];
+}
+
+void ApolloPaneRegisterScene(UIWindowScene *scene, UITabBarController *tabs) {
+    if (!scene || !tabs) return;
+    if (!sPaneSceneTabs) sPaneSceneTabs = [NSMapTable weakToWeakObjectsMapTable];
+    [sPaneSceneTabs setObject:tabs forKey:scene];
+    ApolloPaneLayoutSetActive(YES);
+    // UIKit may reconnect an existing tab hierarchy after scene disconnection.
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:ApolloPaneSplitViewController.class]) continue;
+        ApolloPaneSplitViewController *pane = (id)child;
+        ApolloPaneRegisterNavigationController([pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary], pane);
+        ApolloPaneRegisterNavigationController([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary], pane);
+    }
+    ApolloPaneInstallSidebar(tabs);
+}
+
+NSArray<UISplitViewController *> *ApolloPaneSplitsForScene(UIWindowScene *scene) {
+    NSMutableArray *panes = [NSMutableArray array];
+    for (UIViewController *child in [sPaneSceneTabs objectForKey:scene].viewControllers)
+        if ([child isKindOfClass:ApolloPaneSplitViewController.class]) [panes addObject:child];
+    return panes;
+}
+
+void ApolloPaneDisconnectScene(UIWindowScene *scene) {
+    UITabBarController *tabs = [sPaneSceneTabs objectForKey:scene];
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:ApolloPaneSplitViewController.class]) continue;
+        ApolloPaneSplitViewController *pane = (id)child;
+        [pane apollo_sceneDidDisconnect];
+        ApolloPaneUnregisterNavigationController([pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]);
+        ApolloPaneUnregisterNavigationController([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]);
+    }
+    [sPaneSceneTabs removeObjectForKey:scene];
+    ApolloPaneLayoutSetActive(sPaneSceneTabs.objectEnumerator.allObjects.count > 0);
+}
+
+NSArray<UISplitViewController *> *ApolloPaneRegisteredSplits(void) {
+    // Event-time snapshot, never a window/view-tree walk. Weak registrations
+    // also cover detached, previously visited tabs during synchronous routing.
+    NSHashTable *unique = [NSHashTable hashTableWithOptions:NSPointerFunctionsObjectPointerPersonality];
+    for (UISplitViewController *pane in sPaneNavigationOwners.objectEnumerator) [unique addObject:pane];
+    return unique.allObjects;
+}
+
+void ApolloPaneRegisterNavigationItems(UINavigationController *nav) {
+    if (!nav) return;
+    if (!sPaneItemOwners) sPaneItemOwners = [NSMapTable weakToWeakObjectsMapTable];
+    for (UIViewController *controller in nav.viewControllers) {
+        [sPaneItemOwners setObject:nav forKey:controller.navigationItem];
+    }
+}
+
+UISplitViewController *ApolloPanePrimarySplitForNavigationItem(UINavigationItem *item) {
+    UINavigationController *nav = [sPaneItemOwners objectForKey:item];
+    ApolloPaneSplitViewController *pane = (id)[sPaneNavigationOwners objectForKey:nav];
+    return nav && nav == [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary] ? pane : nil;
 }

--- a/src/ipad/ApolloPaneRouter.xm
+++ b/src/ipad/ApolloPaneRouter.xm
@@ -18,12 +18,17 @@
 //
 // Full design + RE notes: docs/ipad-pane-layout-plan.md
 
+#import "ApolloPaneChrome.h"
+#import "ApolloPaneContent.h"
+#import "ApolloPaneTransitionObserver.h"
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <dlfcn.h>
 #import "ApolloPaneForwardHistory.h"
 #import "ApolloPaneLayout.h"
+#import "ApolloPaneDiagnostics.h"
+#import "ApolloPaneGeometry.h"
 #import "ApolloPaneRouting.h"
 #import "ApolloPaneSplitViewController.h"
 #import "../ApolloCommon.h"
@@ -170,24 +175,16 @@ static void ApolloPaneObservePrimaryPopSettlement(
         NSUInteger token);
 
 static void ApolloPanePollPrimaryPopSettlement(
-        ApolloPaneSplitViewController *pane,
-        UINavigationController *navigationController,
-        NSArray<UIViewController *> *beforeStack,
-        NSUInteger token,
-        NSUInteger observations) {
-    if (!pane || !navigationController || token == 0) return;
-    if (navigationController.transitionCoordinator) {
-        NSTimeInterval delay = observations < 120 ? 0.05 : 0.25;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{
-            ApolloPanePollPrimaryPopSettlement(pane, navigationController, beforeStack,
-                                                token, observations + 1);
-        });
-        return;
-    }
-    [pane apollo_primaryNavigationPopDidSettle:token
-                                   beforeStack:beforeStack
-                                      cancelled:NO];
+        ApolloPaneSplitViewController *pane, UINavigationController *navigationController,
+        NSArray<UIViewController *> *beforeStack, NSUInteger token, NSUInteger observations) {
+    (void)observations;
+    if (!pane || !navigationController || !token) return;
+    __weak UINavigationController *weakNavigation = navigationController;
+    [ApolloPaneTransitionObserver observeOwner:pane key:@"primaryPop" timeout:6.0
+        ready:^BOOL(__unused id owner) { return weakNavigation.transitionCoordinator == nil; }
+        completion:^(ApolloPaneSplitViewController *owner, BOOL timedOut) {
+            [owner apollo_primaryNavigationPopDidSettle:token beforeStack:beforeStack cancelled:timedOut];
+        }];
 }
 
 static void ApolloPaneObservePrimaryPopSettlement(
@@ -196,8 +193,9 @@ static void ApolloPaneObservePrimaryPopSettlement(
         NSArray<UIViewController *> *beforeStack,
         NSUInteger token) {
     if (!pane || !navigationController || beforeStack.count == 0 || token == 0) return;
+    __weak ApolloPaneSplitViewController *weakPane = pane;
     void (^settle)(BOOL) = ^(BOOL cancelled) {
-        [pane apollo_primaryNavigationPopDidSettle:token
+        [weakPane apollo_primaryNavigationPopDidSettle:token
                                        beforeStack:beforeStack
                                           cancelled:cancelled];
     };
@@ -270,6 +268,7 @@ static BOOL ApolloPaneReplaceDetailRoot(ApolloPaneSplitViewController *pane,
         [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
     if (!destination || !viewController) return NO;
 
+    ApolloPaneTraceBegin(pane, @"selectionToDisplayFrame");
     viewController.extendedLayoutIncludesOpaqueBars = YES;
     NSArray<UIViewController *> *oldDestinationStack = destination.viewControllers;
     __block BOOL replacementSucceeded = NO;
@@ -295,7 +294,13 @@ static BOOL ApolloPaneReplaceDetailRoot(ApolloPaneSplitViewController *pane,
             sPaneRouterReentrant = NO;
         }
     }];
-    if (!replacementSucceeded) return NO;
+    if (!replacementSucceeded) { ApolloPaneTraceEnd(pane, @"selectionToDisplayFrame"); return NO; }
+    if (ApolloPaneTraceEnabled()) {
+        ApolloPaneFrameScheduler *firstFrame = [[ApolloPaneFrameScheduler alloc] initWithOwner:pane update:^(id owner) {
+            ApolloPaneTraceEnd(owner, @"selectionToDisplayFrame");
+        }];
+        [firstFrame request];
+    }
 
     // Readable-width settings/forms must have their final safe-area insets
     // before the first detail frame is committed. The ordinary pane geometry
@@ -339,36 +344,16 @@ static void ApolloPaneSchedulePostsScopeReconciliation(UIViewController *posts,
     });
 }
 
-static void ApolloPaneCollectLivePanes(UIViewController *controller,
-                                       NSHashTable<ApolloPaneSplitViewController *> *panes) {
-    if (!controller || [panes containsObject:(id)controller]) return;
-    if ([controller isKindOfClass:[ApolloPaneSplitViewController class]]) {
-        [panes addObject:(ApolloPaneSplitViewController *)controller];
-    }
-    for (UIViewController *child in controller.childViewControllers) {
-        ApolloPaneCollectLivePanes(child, panes);
-    }
-    ApolloPaneCollectLivePanes(controller.presentedViewController, panes);
-}
-
 static NSArray<ApolloPaneSplitViewController *> *ApolloPaneAllLivePanes(void) {
-    NSHashTable<ApolloPaneSplitViewController *> *panes = [NSHashTable weakObjectsHashTable];
-    for (UIWindow *window in ApolloAllWindows()) {
-        ApolloPaneCollectLivePanes(window.rootViewController, panes);
-    }
-    return panes.allObjects;
+    return (id)ApolloPaneRegisteredSplits();
 }
 
 static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavigationItem *item) {
-    for (ApolloPaneSplitViewController *pane in ApolloPaneAllLivePanes()) {
-        UINavigationController *primary =
-            [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
-        for (UIViewController *controller in primary.viewControllers) {
-            if (controller.navigationItem == item) return pane;
-        }
-    }
-    return nil;
+    return (id)ApolloPanePrimarySplitForNavigationItem(item);
 }
+
+extern "C" void *ApolloSwiftListAdapterSectionController(const void *storage, const void *indexPath);
+static char kApolloPaneConfiguredPostSection;
 
 %group ApolloPaneRouterGroup
 
@@ -425,6 +410,33 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
 %end
 
 %hook ApolloPaneListAdapter
+
+- (id)tableNode:(id)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
+    id block = %orig;
+    if (!block || !NSThread.isMainThread || !ApolloPaneLayoutActive()) return block;
+    UIViewController *controller = ApolloPaneLoadSwiftWeak(self, "viewController");
+    block = ApolloPanePrepareNodeFactory(block, controller);
+    ApolloPaneSplitViewController *pane = ApolloPaneForPrimaryController(controller);
+    if (!pane) return block;
+    const void *storage = ApolloPaneSwiftIvarStorage(self, "indexPathToSectionControllerMapping");
+    void *value = ApolloSwiftListAdapterSectionController(storage, (__bridge const void *)indexPath);
+    id section = value ? CFBridgingRelease(value) : nil;
+    Class postSection = objc_getClass("_TtC6Apollo21PostSectionController");
+    if (!postSection || [section class] != postSection ||
+        objc_getAssociatedObject(section, &kApolloPaneConfiguredPostSection)) return block;
+    Ivar compact = class_getInstanceVariable(postSection, "isCompact");
+    Ivar next = class_getInstanceVariable(postSection, "isInModQueue");
+    // Verified in Apollo 1.15.11 sub_10056248c: ldrb from this ivar
+    // chooses the complete native compact/large initializer. Set it once,
+    // before returning the node block to Texture's worker queues. Never
+    // replace the block, bypass action delegates, or mutate NSUserDefaults.
+    if (!compact || !next || ivar_getOffset(next) != ivar_getOffset(compact) + 1) return block;
+    uint8_t *slot = (uint8_t *)(__bridge void *)section + ivar_getOffset(compact);
+    *slot = ApolloPanePrefersCompactFeed(controller) ? 1 : 0;
+    objc_setAssociatedObject(section, &kApolloPaneConfiguredPostSection, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return block;
+}
+
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     UIViewController *source = ApolloPaneLoadSwiftWeak((id)self, "viewController") ?:
@@ -565,12 +577,13 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
         return;
     }
 
-    // During collapse UIKit appends this pane's exact secondary navigation
-    // controller to the surviving primary stack as structural bridge state.
+    // During collapse UIKit appends the secondary column (sometimes wrapped in
+    // its own navigation controller) to the surviving primary stack. Recognize
+    // our exact host identity through that public containment, not a UIKit class
+    // name or a blanket navigation-controller exemption.
     // It is not an app destination and must pass through untouched; treating it
     // as a Settings detail route recursively installs the nav inside itself.
-    if (viewController ==
-        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary]) {
+    if ([pane apollo_isColumnBridgeController:viewController]) {
         %orig;
         return;
     }
@@ -612,6 +625,9 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
     BOOL fromListColumn =
         (navigationController == [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]);
     UIViewController *sourceViewController = navigationController.topViewController;
+    if (fromListColumn && [pane apollo_isColumnBridgeController:sourceViewController]) {
+        sourceViewController = pane.apollo_primaryContextViewController;
+    }
     id routeMasterSelectionIntent = sPaneRouterReplayedMasterSelectionIntent;
     if (!routeMasterSelectionIntent &&
         sPaneRouterPendingMasterSelectionSource == sourceViewController) {
@@ -626,7 +642,7 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
     BOOL explicitlyClassified = NO;
     ApolloPaneColumn sourceColumn = fromListColumn
         ? ApolloPaneColumnPrimary : ApolloPaneColumnSecondary;
-    ApolloPaneColumn column = ApolloPaneResolveLogicalColumn(navigationController.topViewController,
+    ApolloPaneColumn column = ApolloPaneResolveLogicalColumn(sourceViewController,
                                                               viewController,
                                                               sourceColumn,
                                                               &explicitlyClassified);
@@ -713,6 +729,16 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
 
         UIViewController *beforeTop = navigationController.topViewController;
         NSUInteger beforeDepth = navigationController.viewControllers.count;
+        if (fromListColumn && !sourceBelongsToDetail && column == ApolloPaneColumnSecondary &&
+            !pane.apollo_detailIsEmpty) {
+            // A collapsed host still has a real secondary stack. A new primary
+            // selection replaces that branch just as it does while expanded;
+            // pushing above UIKit's wrapper would leave two competing detail
+            // branches and expose the older one again on expansion.
+            ApolloPaneReplaceDetailRoot(pane, viewController, sourceViewController,
+                                       routeMasterSelectionIntent);
+            return;
+        }
         %orig;
         BOOL pushSucceeded = navigationController.topViewController == viewController &&
             (beforeTop != viewController || navigationController.viewControllers.count != beforeDepth);
@@ -1103,6 +1129,8 @@ static ApolloPaneSplitViewController *ApolloPaneForPrimaryNavigationItem(UINavig
           ApolloPaneInboxListViewController=inboxListClass,
           ApolloPaneListAdapter=listAdapterClass,
           ApolloPaneTableNode=tableNodeClass);
+
+    ApolloPaneRouterSetReady();
 
     NSArray<NSString *> *accountNotifications = @[
         @"com.christianselig.RedditCurrentAccountChanged",

--- a/src/ipad/ApolloPaneSidebar.h
+++ b/src/ipad/ApolloPaneSidebar.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+__BEGIN_DECLS
+void ApolloPaneInstallSidebar(UITabBarController *tabs);
+void ApolloPaneSidebarFirstAppearance(UITabBarController *tabs);
+BOOL ApolloPaneCanOpenDetailInNewWindow(UISplitViewController *pane);
+void ApolloPaneOpenDetailInNewWindow(UISplitViewController *pane);
+void ApolloPaneInstallLinkInteractions(UISplitViewController *pane);
+BOOL ApolloPaneReceiveSceneActivity(UIWindowScene *scene, NSUserActivity *activity);
+void ApolloPaneOpenPendingSceneLink(UIWindowScene *scene);
+__END_DECLS

--- a/src/ipad/ApolloPaneSidebar.m
+++ b/src/ipad/ApolloPaneSidebar.m
@@ -1,0 +1,319 @@
+#import "ApolloPaneSidebar.h"
+#import "ApolloPaneLayout.h"
+#import "ApolloPaneSplitViewController.h"
+#import <objc/message.h>
+#import "../ApolloCommon.h"
+#import "../ApolloThemeRuntime.h"
+#import <objc/runtime.h>
+
+static NSString *const kPins = @"ApolloPanePinnedCommunities";
+static char kFirstSidebarAppearance;
+static char kPendingSceneLink;
+static NSString *const kPaneLinkActivity = @"app.apolloreborn.pane.open-link";
+
+BOOL ApolloPaneReceiveSceneActivity(UIWindowScene *scene, NSUserActivity *activity) {
+    if (![activity.activityType isEqualToString:kPaneLinkActivity]) return NO;
+    NSURL *url = ApolloURLByConvertingResolvedURLToApolloScheme(activity.webpageURL);
+    if (scene && url) objc_setAssociatedObject(scene, &kPendingSceneLink, url, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    return YES;
+}
+void ApolloPaneOpenPendingSceneLink(UIWindowScene *scene) {
+    if (!scene || scene.activationState != UISceneActivationStateForegroundActive) return;
+    NSURL *url = objc_getAssociatedObject(scene, &kPendingSceneLink);
+    if (!url) return;
+    // Claim once before entering native code. Scene activation can be reentrant;
+    // a second activation must not duplicate the route or keep a stale link.
+    objc_setAssociatedObject(scene, &kPendingSceneLink, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    BOOL routed = ApolloRouteURLThroughAppInScene(url, scene);
+    ApolloLog(@"[PaneSidebar] receiving scene link routed=%d", routed);
+}
+
+static NSString *ApolloPaneCommunityName(NSString *input) {
+    NSString *name = [input stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if ([name hasPrefix:@"r/"]) name = [name substringFromIndex:2];
+    NSCharacterSet *allowed = [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"];
+    if (name.length == 0 || name.length > 21 || [name rangeOfCharacterFromSet:allowed.invertedSet].location != NSNotFound) return nil;
+    return name;
+}
+
+static NSArray<NSString *> *ApolloPanePins(void) {
+    NSMutableArray *pins = [NSMutableArray array];
+    for (id candidate in [NSUserDefaults.standardUserDefaults arrayForKey:kPins]) {
+        NSString *name = [candidate isKindOfClass:NSString.class] ? ApolloPaneCommunityName(candidate) : nil;
+        if (name && ![pins containsObject:name.lowercaseString] && pins.count < 12) [pins addObject:name.lowercaseString];
+    }
+    return pins;
+}
+
+static NSURL *ApolloPaneCommunityURL(NSString *name) {
+    return [NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", name]];
+}
+
+static void ApolloPaneChangePin(UITabBarController *tabs, NSString *name, BOOL remove) {
+    if (!tabs) return;
+    name = ApolloPaneCommunityName(name).lowercaseString;
+    if (!name) return;
+    NSMutableArray *pins = [ApolloPanePins() mutableCopy];
+    [pins removeObject:name];
+    if (!remove && pins.count < 12) [pins addObject:name];
+    [NSUserDefaults.standardUserDefaults setObject:pins forKey:kPins];
+    NSMutableSet *owners = [NSMutableSet setWithObject:tabs];
+    for (UISplitViewController *pane in ApolloPaneRegisteredSplits()) if (pane.tabBarController) [owners addObject:pane.tabBarController];
+    for (UITabBarController *owner in owners) ApolloPaneInstallSidebar(owner);
+}
+
+static void ApolloPaneOpenCommunity(UITabBarController *tabs, NSString *name, BOOL newWindow) {
+    UIWindowScene *scene = tabs.viewIfLoaded.window.windowScene;
+    if (!scene) return;
+    NSURL *url = ApolloPaneCommunityURL(name);
+    if (newWindow) {
+        NSUserActivity *activity = [[NSUserActivity alloc] initWithActivityType:kPaneLinkActivity];
+        activity.webpageURL = url;
+        activity.title = [@"r/" stringByAppendingString:name];
+        [UIApplication.sharedApplication requestSceneSessionActivation:nil userActivity:activity options:nil
+            errorHandler:^(__unused NSError *error) {
+                ApolloLog(@"[PaneSidebar] new-window activation unavailable");
+            }];
+    } else {
+        ApolloRouteURLThroughAppInScene(ApolloURLByConvertingResolvedURLToApolloScheme(url),
+                                       scene);
+    }
+}
+
+@class ApolloPaneSidebarView;
+API_AVAILABLE(ios(18.0))
+@interface ApolloPaneSidebarConfiguration : NSObject <UIContentConfiguration>
+@property (nonatomic, weak) UITabBarController *tabs;
+@property (nonatomic, copy) NSArray<NSString *> *communities;
+@end
+
+API_AVAILABLE(ios(18.0))
+@interface ApolloPaneSidebarView : UIView <UIContentView, UIDragInteractionDelegate, UIDropInteractionDelegate>
+@property (nonatomic, copy) id<UIContentConfiguration> configuration;
+@property (nonatomic, strong) UIStackView *stack;
+@end
+
+@implementation ApolloPaneSidebarConfiguration
+- (id)copyWithZone:(NSZone *)zone {
+    ApolloPaneSidebarConfiguration *copy = [ApolloPaneSidebarConfiguration new];
+    copy.tabs = self.tabs;
+    copy.communities = self.communities;
+    return copy;
+}
+- (id<UIContentConfiguration>)updatedConfigurationForState:(id<UIConfigurationState>)state { return self; }
+- (UIView<UIContentView> *)makeContentView {
+    ApolloPaneSidebarView *view = [ApolloPaneSidebarView new];
+    view.configuration = self;
+    return view;
+}
+@end
+
+@implementation ApolloPaneSidebarView
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        _stack = [UIStackView new];
+        _stack.axis = UILayoutConstraintAxisVertical;
+        _stack.spacing = 4;
+        _stack.translatesAutoresizingMaskIntoConstraints = NO;
+        [self addSubview:_stack];
+        [NSLayoutConstraint activateConstraints:@[
+            [_stack.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor],
+            [_stack.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor],
+            [_stack.topAnchor constraintEqualToAnchor:self.topAnchor constant:16],
+            [_stack.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-12]
+        ]];
+        [self addInteraction:[[UIDropInteraction alloc] initWithDelegate:self]];
+    }
+    return self;
+}
+- (void)setConfiguration:(id<UIContentConfiguration>)configuration {
+    _configuration = [(id)configuration copy];
+    for (UIView *view in self.stack.arrangedSubviews) [view removeFromSuperview];
+    ApolloPaneSidebarConfiguration *config = (id)_configuration;
+    __weak UITabBarController *weakTabs = config.tabs;
+    UILabel *heading = [UILabel new];
+    heading.text = @"Communities";
+    heading.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    heading.adjustsFontForContentSizeCategory = YES;
+    heading.textColor = UIColor.secondaryLabelColor;
+    [self.stack addArrangedSubview:heading];
+    [config.communities enumerateObjectsUsingBlock:^(NSString *name, NSUInteger index, BOOL *stop) {
+        UIAction *open = [UIAction actionWithTitle:[@"r/" stringByAppendingString:name]
+            image:[UIImage systemImageNamed:@"number"] identifier:nil handler:^(__unused UIAction *action) {
+                ApolloPaneOpenCommunity(weakTabs, name, NO);
+            }];
+        UIButton *button = [UIButton buttonWithConfiguration:UIButtonConfiguration.plainButtonConfiguration primaryAction:open];
+        button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeading;
+        button.tintColor = ApolloThemeAccentColor() ?: UIColor.systemBlueColor;
+        button.tag = (NSInteger)index;
+        [button.heightAnchor constraintGreaterThanOrEqualToConstant:44].active = YES;
+        UIAction *window = [UIAction actionWithTitle:@"Open in new window" image:[UIImage systemImageNamed:@"plus.rectangle.on.rectangle"]
+            identifier:nil handler:^(__unused UIAction *action) { ApolloPaneOpenCommunity(weakTabs, name, YES); }];
+        UIAction *remove = [UIAction actionWithTitle:@"Unpin community" image:[UIImage systemImageNamed:@"pin.slash"]
+            identifier:nil handler:^(__unused UIAction *action) { ApolloPaneChangePin(weakTabs, name, YES); }];
+        button.menu = [UIMenu menuWithTitle:@"" children:@[window, remove]];
+        [button addInteraction:[[UIDragInteraction alloc] initWithDelegate:self]];
+        [self.stack addArrangedSubview:button];
+    }];
+    UIAction *add = [UIAction actionWithTitle:@"Pin community" image:[UIImage systemImageNamed:@"plus"]
+        identifier:nil handler:^(__unused UIAction *action) {
+            UITabBarController *tabs = weakTabs;
+            if (!tabs.view.window) return;
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Pin community" message:@"Enter a subreddit name."
+                preferredStyle:UIAlertControllerStyleAlert];
+            [alert addTextFieldWithConfigurationHandler:^(UITextField *field) {
+                field.placeholder = @"subreddit";
+                field.autocapitalizationType = UITextAutocapitalizationTypeNone;
+                field.autocorrectionType = UITextAutocorrectionTypeNo;
+            }];
+            __weak UIAlertController *weakAlert = alert;
+            UIAlertAction *pin = [UIAlertAction actionWithTitle:@"Pin" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+                ApolloPaneChangePin(weakTabs, weakAlert.textFields.firstObject.text, NO);
+            }];
+            pin.enabled = NO;
+            __weak UIAlertAction *weakPin = pin;
+            [alert.textFields.firstObject addAction:[UIAction actionWithHandler:^(__unused UIAction *action) {
+                weakPin.enabled = ApolloPaneCommunityName(weakAlert.textFields.firstObject.text) != nil;
+            }] forControlEvents:UIControlEventEditingChanged];
+            [alert addAction:pin];
+            [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+            UIViewController *presenter = tabs;
+            while (presenter.presentedViewController) presenter = presenter.presentedViewController;
+            [presenter presentViewController:alert animated:YES completion:nil];
+        }];
+    UIButton *addButton = [UIButton buttonWithConfiguration:UIButtonConfiguration.plainButtonConfiguration primaryAction:add];
+    addButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeading;
+    addButton.enabled = config.communities.count < 12;
+    [addButton.heightAnchor constraintGreaterThanOrEqualToConstant:44].active = YES;
+    [self.stack addArrangedSubview:addButton];
+}
+- (NSArray<UIDragItem *> *)dragInteraction:(UIDragInteraction *)interaction itemsForBeginningSession:(id<UIDragSession>)session {
+    ApolloPaneSidebarConfiguration *config = (id)self.configuration;
+    NSInteger index = interaction.view.tag;
+    if (index < 0 || index >= (NSInteger)config.communities.count) return @[];
+    NSURL *url = ApolloPaneCommunityURL(config.communities[index]);
+    return @[[[UIDragItem alloc] initWithItemProvider:[[NSItemProvider alloc] initWithObject:url]]];
+}
+- (BOOL)dropInteraction:(UIDropInteraction *)interaction canHandleSession:(id<UIDropSession>)session {
+    return [session canLoadObjectsOfClass:NSURL.class];
+}
+- (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction sessionDidUpdate:(id<UIDropSession>)session {
+    return [[UIDropProposal alloc] initWithDropOperation:UIDropOperationCopy];
+}
+- (void)dropInteraction:(UIDropInteraction *)interaction performDrop:(id<UIDropSession>)session {
+    __weak UITabBarController *weakTabs = ((ApolloPaneSidebarConfiguration *)self.configuration).tabs;
+    [session loadObjectsOfClass:NSURL.class completion:^(NSArray<id<NSItemProviderReading>> *objects) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            for (NSURL *url in objects) {
+                NSString *host = url.host.lowercaseString;
+                NSArray *parts = url.pathComponents;
+                if (([host isEqualToString:@"reddit.com"] || [host hasSuffix:@".reddit.com"]) &&
+                    parts.count >= 3 && [parts[1] isEqualToString:@"r"]) {
+                    ApolloPaneChangePin(weakTabs, parts[2], NO);
+                }
+            }
+        });
+    }];
+}
+@end
+
+void ApolloPaneInstallSidebar(UITabBarController *tabs) {
+    if (@available(iOS 18.0, *)) {
+        if (!tabs || !ApolloPaneLayoutActive()) return;
+        // Use the public footer slot: native tab identities and indices stay
+        // intact, and Apollo's existing sidebar delegate remains installed.
+        id existing = tabs.sidebar.footerContentConfiguration;
+        if (existing && ![existing isKindOfClass:ApolloPaneSidebarConfiguration.class]) return;
+        ApolloPaneSidebarConfiguration *configuration = [ApolloPaneSidebarConfiguration new];
+        configuration.tabs = tabs;
+        configuration.communities = ApolloPanePins();
+        tabs.sidebar.footerContentConfiguration = configuration;
+    }
+}
+
+void ApolloPaneSidebarFirstAppearance(UITabBarController *tabs) {
+    if (@available(iOS 18.0, *)) {
+        UIWindowScene *scene = tabs.viewIfLoaded.window.windowScene;
+        if (!scene || objc_getAssociatedObject(scene, &kFirstSidebarAppearance)) return;
+        objc_setAssociatedObject(scene, &kFirstSidebarAppearance, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // A single initial preference, never a resize/selection enforcement.
+        // UIKit owns subsequent visibility and the user's collapse choice.
+        if (CGRectGetWidth(tabs.view.bounds) >= 1100.0 &&
+            tabs.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) tabs.sidebar.hidden = NO;
+    }
+}
+
+// URL-only window workflows. Native controllers/models remain in their scene;
+// the receiving scene enters through Apollo's existing universal-link adapter.
+static NSURL *ApolloPanePostURL(UIViewController *controller) {
+    Class comments = objc_getClass("_TtC6Apollo22CommentsViewController");
+    if (!comments || ![controller isKindOfClass:comments]) return nil;
+    Ivar linkIvar = class_getInstanceVariable(controller.class, "link");
+    id link = linkIvar ? object_getIvar(controller, linkIvar) : nil;
+    SEL selector = NSSelectorFromString(@"permalink");
+    id value = [link respondsToSelector:selector] ? ((id (*)(id, SEL))objc_msgSend)(link, selector) : nil;
+    NSString *path = [value isKindOfClass:NSString.class] ? value : ([value isKindOfClass:NSURL.class] ? [value path] : nil);
+    if (![path hasPrefix:@"/"]) return nil;
+    NSURLComponents *components = [NSURLComponents new];
+    components.scheme = @"https";
+    components.host = @"www.reddit.com";
+    components.path = path;
+    return components.URL;
+}
+BOOL ApolloPaneCanOpenDetailInNewWindow(UISplitViewController *split) {
+    ApolloPaneSplitViewController *pane = (id)split;
+    return ApolloPanePostURL([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController) != nil;
+}
+void ApolloPaneOpenDetailInNewWindow(UISplitViewController *split) {
+    ApolloPaneSplitViewController *pane = (id)split;
+    NSURL *url = ApolloPanePostURL([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController);
+    if (!url || !pane.viewIfLoaded.window) return;
+    NSUserActivity *activity = [[NSUserActivity alloc] initWithActivityType:kPaneLinkActivity];
+    activity.webpageURL = url;
+    [UIApplication.sharedApplication requestSceneSessionActivation:nil userActivity:activity options:nil errorHandler:^(NSError *error) {
+        ApolloLog(@"[PaneSidebar] detail new-window activation unavailable");
+    }];
+}
+@interface ApolloPaneLinkInteraction : NSObject <UIDropInteractionDelegate, UIDragInteractionDelegate>
+@property (nonatomic, weak) ApolloPaneSplitViewController *pane;
+@end
+@implementation ApolloPaneLinkInteraction
+- (BOOL)dropInteraction:(UIDropInteraction *)interaction canHandleSession:(id<UIDropSession>)session {
+    return session.items.count == 1 && [session canLoadObjectsOfClass:NSURL.class];
+}
+- (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction sessionDidUpdate:(id<UIDropSession>)session {
+    return [[UIDropProposal alloc] initWithDropOperation:UIDropOperationCopy];
+}
+- (void)dropInteraction:(UIDropInteraction *)interaction performDrop:(id<UIDropSession>)session {
+    __weak UIWindowScene *weakScene = self.pane.viewIfLoaded.window.windowScene;
+    [session loadObjectsOfClass:NSURL.class completion:^(NSArray<id<NSItemProviderReading>> *objects) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIWindowScene *scene = weakScene;
+            if (!scene || scene.activationState != UISceneActivationStateForegroundActive || objects.count != 1) return;
+            NSURL *url = ApolloURLByConvertingResolvedURLToApolloScheme((id)objects.firstObject);
+            if (url) ApolloRouteURLThroughAppInScene(url, scene);
+        });
+    }];
+}
+- (NSArray<UIDragItem *> *)dragInteraction:(UIDragInteraction *)interaction itemsForBeginningSession:(id<UIDragSession>)session {
+    UIView *bar = interaction.view;
+    UIView *hit = [bar hitTest:[session locationInView:bar] withEvent:nil];
+    // Title-region dragging must never steal a native action or text field.
+    for (UIView *view = hit; view && view != bar; view = view.superview)
+        if ([view isKindOfClass:UIControl.class]) return @[];
+    NSURL *url = ApolloPanePostURL([self.pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController);
+    return url ? @[[[UIDragItem alloc] initWithItemProvider:[[NSItemProvider alloc] initWithObject:url]]] : @[];
+}
+@end
+static char kLinkInteraction;
+void ApolloPaneInstallLinkInteractions(UISplitViewController *split) {
+    ApolloPaneSplitViewController *pane = (id)split;
+    if (!pane.isViewLoaded || objc_getAssociatedObject(pane, &kLinkInteraction)) return;
+    ApolloPaneLinkInteraction *owner = [ApolloPaneLinkInteraction new];
+    owner.pane = pane;
+    [pane.view addInteraction:[[UIDropInteraction alloc] initWithDelegate:owner]];
+    UINavigationController *detail = [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    // Installation occurs on the visible pane; never materialize hidden tabs.
+    [detail.navigationBar addInteraction:[[UIDragInteraction alloc] initWithDelegate:owner]];
+    objc_setAssociatedObject(pane, &kLinkInteraction, owner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}

--- a/src/ipad/ApolloPaneSplitViewController.h
+++ b/src/ipad/ApolloPaneSplitViewController.h
@@ -12,6 +12,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ApolloPaneSplitViewController : UISplitViewController
+- (void)apollo_sceneDidDisconnect;
+- (void)apollo_sceneBecameInactive;
+- (void)apollo_sceneBecameActive;
+- (void)apollo_resetPreferredPrimaryWidth;
 
 // `rootNavigationController` is the tab's ORIGINAL ApolloNavigationController,
 // moved verbatim into the primary column. Nothing about it is rebuilt: it keeps
@@ -64,6 +68,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)apollo_recordCompactViewController:(UIViewController *)viewController
                               logicalColumn:(ApolloPaneColumn)column;
 - (BOOL)apollo_compactViewControllerBelongsToDetail:(nullable UIViewController *)viewController;
+// Exact owned column/host identities, including UIKit's public nav wrapper.
+// Structural transfers must never enter the application route/intent queue.
+- (BOOL)apollo_isColumnBridgeController:(nullable UIViewController *)viewController;
 - (void)apollo_refreshCompactDetailChromeAfterRootReplacement;
 
 // The stable primary-context owner used by pending-route validation. Compact
@@ -131,6 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     cancelled:(BOOL)cancelled;
 
 #if APOLLO_SIM_BUILD
+- (NSDictionary *)apollo_simStructuredSnapshot;
 - (void)apollo_simSetCrossColumnNavigationBlocked:(BOOL)blocked;
 - (NSString *)apollo_simCrossColumnNavigationState;
 - (void)apollo_simSetResolvedLayoutMode:(NSString *)mode;

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -3,11 +3,32 @@
 #import "ApolloPaneSplitViewController.h"
 #import "ApolloPaneForwardHistory.h"
 #import "ApolloPaneRouting.h"
+#import "ApolloPaneGeometry.h"
+#import "ApolloPaneDiagnostics.h"
+#import "ApolloPaneChrome.h"
+#import "ApolloPaneFocus.h"
+#import "ApolloPaneSidebar.h"
+#import "ApolloPaneTransitionObserver.h"
+#import "ApolloPaneGeometryPolicy.h"
+#import "ApolloPaneColumnHostViewController.h"
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <string.h>
 #import "../ApolloCommon.h"        // ApolloLog
 #import "../ApolloThemeRuntime.h"  // ApolloThemeAccentColor
+
+extern void ApolloSwiftAssignInteractiveTransition(void *storage, const void *object);
+static BOOL ApolloPaneSetNativeInteractiveTransition(UINavigationController *nav,
+                                                      UIPercentDrivenInteractiveTransition *transition) {
+    Class native = objc_getClass("_TtC6Apollo26ApolloNavigationController");
+    if (nav.class != native) return NO;
+    Ivar slot = class_getInstanceVariable(native, "interactionController");
+    Ivar previous = class_getInstanceVariable(native, "poppedViewControllers");
+    if (!slot || !previous || ivar_getOffset(slot) - ivar_getOffset(previous) != sizeof(void *)) return NO;
+    ApolloSwiftAssignInteractiveTransition((uint8_t *)(__bridge void *)nav + ivar_getOffset(slot),
+                                           (__bridge const void *)transition);
+    return YES;
+}
 
 extern void *ApolloSwiftListAdapterIndexPathForModelIdentifier(
     const void *mappingStorage, const void *tokenObject);
@@ -58,61 +79,18 @@ static BOOL ApolloPaneStackStartsWithIdentityStack(NSArray<UIViewController *> *
 
 static BOOL ApolloPaneControllerIsAttached(UIViewController *controller);
 
-// `isCollapsed` answers whether UIKit merged columns into one navigation
-// topology; it does not answer whether an expanded primary is currently
-// visible. A constrained regular-width split can resolve to SecondaryOnly or
-// OneOverSecondary while remaining uncollapsed. Prefer iOS 26's direct query,
-// with the documented resolved display-mode mapping as the older-OS fallback.
-static BOOL ApolloPaneSplitShowsPrimary(UISplitViewController *split) {
-    if (!split) return NO;
-    if (@available(iOS 26.0, *)) {
-        return [split isShowingColumn:UISplitViewControllerColumnPrimary];
-    }
-    if (split.isCollapsed) {
-        UIViewController *primary = [split viewControllerForColumn:UISplitViewControllerColumnPrimary];
-        return ApolloPaneControllerIsAttached(primary);
-    }
-    switch (split.displayMode) {
-        case UISplitViewControllerDisplayModeOneBesideSecondary:
-        case UISplitViewControllerDisplayModeOneOverSecondary:
-            return YES;
-        case UISplitViewControllerDisplayModeSecondaryOnly:
-        default:
-            return NO;
-    }
-}
-
-static BOOL ApolloPaneSplitShowsTiledPrimary(UISplitViewController *split) {
-    if (!split || split.isCollapsed || !ApolloPaneSplitShowsPrimary(split)) return NO;
-    // For a double-column split this is the sole resolved mode in which both
-    // columns are side-by-side and interactive. OneOverSecondary is visible,
-    // but it is an overlay—not a divider that should receive our grabber or
-    // drive detail-column geometry.
-    return split.displayMode == UISplitViewControllerDisplayModeOneBesideSecondary &&
-        split.splitBehavior == UISplitViewControllerSplitBehaviorTile &&
-        split.transitionCoordinator == nil;
-}
-
-// Semantic scope for the one Apollo screen that reuses a controller while
-// changing feeds. `currentSubreddit` and `currentMultireddit` are asynchronous
-// and can retain stale values after reuse, so they cannot safely participate in
-// identity. The PostsType tag is synchronous and the displayed Jump Bar title
-// is the exact user-visible payload that changes for dropdown, typed, and
-// random navigation. Never log the returned value: it stays process-local.
+// The native semantic feed value owns identity. A localized/title/count change
+// cannot invalidate a selected thread. Keep strings process-local and unlogged.
+extern void *ApolloSwiftPanePostsScope(const void *storage);
 static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
-    Class postsClass = objc_getClass("_TtC6Apollo19PostsViewController");
-    if (!postsClass || ![controller isKindOfClass:postsClass]) return nil;
-    Ivar postsTypeIvar = class_getInstanceVariable([controller class], "currentPostsType");
-    if (!postsTypeIvar) return nil;
-    uint8_t tag = 0;
-    const uint8_t *bytes = (const uint8_t *)(__bridge const void *)controller;
-    memcpy(&tag, bytes + ivar_getOffset(postsTypeIvar) + 0x20, sizeof(tag));
-
-    NSString *title = controller.navigationItem.title ?: controller.title;
-    NSString *normalizedTitle = [[title stringByTrimmingCharactersInSet:
-        NSCharacterSet.whitespaceAndNewlineCharacterSet] lowercaseString];
-    if (normalizedTitle.length == 0) return nil;
-    return [NSString stringWithFormat:@"type=%u|title=%@", tag, normalizedTitle];
+    Class posts = objc_getClass("_TtC6Apollo19PostsViewController");
+    if (controller.class != posts) return nil;
+    Ivar current = class_getInstanceVariable(posts, "currentPostsType");
+    Ivar following = class_getInstanceVariable(posts, "links");
+    if (!current || !following || ivar_getOffset(following) - ivar_getOffset(current) != 40) return nil;
+    const void *storage = (const uint8_t *)(__bridge const void *)controller + ivar_getOffset(current);
+    void *scope = ApolloSwiftPanePostsScope(storage);
+    return scope ? CFBridgingRelease(scope) : nil;
 }
 
 #pragma mark - Detail placeholder
@@ -147,7 +125,7 @@ static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
 - (instancetype)initWithNibName:(NSString *)nib bundle:(NSBundle *)bundle {
     self = [super initWithNibName:nib bundle:bundle];
     if (self) {
-        _message = @"No Post Selected";
+        _message = @"Select a post";
         _symbolName = @"text.bubble";
     }
     return self;
@@ -167,13 +145,22 @@ static NSString *ApolloPanePrimaryContextScope(UIViewController *controller) {
     [_iconView.heightAnchor constraintEqualToConstant:44.0].active = YES;
 
     _label = [[UILabel alloc] init];
-    _label.text = _message ?: @"No Post Selected";
+    _label.text = _message ?: @"Select a post";
     _label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     _label.adjustsFontForContentSizeCategory = YES;
     _label.textAlignment = NSTextAlignmentCenter;
+    _label.numberOfLines = 0;
 
     [stack addArrangedSubview:_iconView];
     [stack addArrangedSubview:_label];
+    UILabel *hint = [UILabel new];
+    hint.text = @"Choose an item in the list to open it here.";
+    hint.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+    hint.adjustsFontForContentSizeCategory = YES;
+    hint.numberOfLines = 0;
+    hint.textAlignment = NSTextAlignmentCenter;
+    hint.textColor = UIColor.secondaryLabelColor;
+    [stack addArrangedSubview:hint];
     [self.view addSubview:stack];
 
     // Center on the safe area, not on the view. Under iOS 26 the split
@@ -311,541 +298,6 @@ static BOOL ApolloPaneGestureIsTransitioning(UIGestureRecognizer *gesture) {
         gesture.state == UIGestureRecognizerStateChanged;
 }
 
-#pragma mark - Column host
-
-// Insets a column's navigation controller to the part of the column the sidebar
-// is not covering.
-//
-// WHY THIS EXISTS. On iPadOS 26 a split view controller lays the secondary
-// column out at the FULL window width and floats the sidebar over it as a glass
-// panel — verified from a live hierarchy dump on an iPad Pro 13":
-//
-//   secondary  _UISplitViewControllerAdaptiveColumnView  (0, 0, 1032, 1312)
-//   primary    _UISplitViewControllerAdaptiveColumnView  (10, 86, 413, 1216)
-//
-// UIKit expects content to respect the resulting left safe-area inset. Apollo's
-// screens are Texture (AsyncDisplayKit) table nodes, and ASTableView measures
-// its nodes against its own bounds, not its adjusted content inset — so every
-// comment measured 1032pt wide, got pushed right by the inset, and ran off the
-// right edge of the screen.
-//
-// Rather than fight ASTableView's measurement, give the navigation controller a
-// view that is genuinely only as wide as the visible column. Leading/trailing
-// pin to the safe area (the uncovered region); top/bottom pin to the view so
-// the navigation bar still extends under the status bar as Apollo expects.
-@interface ApolloPaneColumnHostViewController : UIViewController
-- (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
-@property (nonatomic, strong, readonly) UINavigationController *hostedNavigationController;
-- (void)apollo_scheduleListColumnGeometryRefresh;
-- (void)apollo_prepareReadableWidthForTopController;
-#if APOLLO_SIM_BUILD
-- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset;
-#endif
-@end
-
-@implementation ApolloPaneColumnHostViewController {
-    NSLayoutConstraint *_topConstraint;
-    NSLayoutConstraint *_bottomConstraint;
-    BOOL _geometryRefreshScheduled;
-    BOOL _geometryRefreshWaitingForTransition;
-    BOOL _hasResolvedGeometry;
-    CGFloat _lastResolvedTop;
-    CGFloat _lastResolvedBottom;
-    __weak UIViewController *_readableWidthViewController;
-    CGFloat _readableWidthBaseLeft;
-    CGFloat _readableWidthBaseRight;
-    CGFloat _readableWidthAppliedInset;
-#if APOLLO_SIM_BUILD
-    NSUInteger _simLayoutPassCount;
-    NSUInteger _simGeometryRefreshCount;
-    NSUInteger _simGeometryWriteCount;
-#endif
-}
-
-- (instancetype)initWithNavigationController:(UINavigationController *)navigationController {
-    self = [super initWithNibName:nil bundle:nil];
-    if (self) {
-        _hostedNavigationController = navigationController;
-
-        // The same tab-bar reservation the pane itself has to opt out of (see
-        // the pane's configure method), one level further down.
-        //
-        // UISplitViewController wraps this host in a navigation controller of
-        // its own, and THAT controller applies the identical
-        // -[UITabBarController _frameForViewController:] rule to its child: it
-        // subtracts the opaque tab bar's height unless the child extends under
-        // it. The pane opting in did not help, because this host is a separate
-        // controller that never inherited the flag.
-        //
-        // Measured: the host's view came out (0,0,1376,968) inside a 1032pt
-        // wrapper, so the detail column ended at 968 while the list column ended
-        // at 1022 — the comment list stopping 54pt above the bottom of the
-        // screen with a band of background under it.
-        self.edgesForExtendedLayout = UIRectEdgeAll;
-        self.extendedLayoutIncludesOpaqueBars = YES;
-
-        [[NSNotificationCenter defaultCenter]
-            addObserver:self
-               selector:@selector(apollo_contentSizeCategoryDidChange:)
-                   name:UIContentSizeCategoryDidChangeNotification
-                 object:nil];
-    }
-    return self;
-}
-
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self apollo_restoreReadableWidthInsets];
-}
-
-- (void)viewDidLoad {
-    [super viewDidLoad];
-
-    // CLEAR, deliberately — this view must never paint.
-    //
-    // It is laid out at the FULL window width (iPadOS 26 gives the secondary
-    // column the whole window and floats the other columns over it), while the
-    // navigation controller inside it is inset to the visible column. Giving it
-    // a background therefore does not tint "the detail column", it tints the
-    // entire window: behind the floating sidebar, in the gap between columns,
-    // and above the list column.
-    //
-    // That is exactly what went wrong. It painted ApolloThemePageBackgroundColor(),
-    // which is black under a pure-black theme and so looked correct — until a
-    // themed palette made it #0B1F28 and the whole app turned teal behind
-    // Apollo's own black screens. Only the controllers actually occupying a
-    // column may paint; this one is scaffolding.
-    self.view.backgroundColor = UIColor.clearColor;
-
-    UINavigationController *nav = self.hostedNavigationController;
-    if (!nav) return;
-
-    [self addChildViewController:nav];
-    nav.view.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:nav.view];
-    // ALL FOUR edges pin to the safe area, vertically as well as horizontally.
-    //
-    // Leading/trailing is the Texture fix (see the class comment). Top/bottom
-    // used to pin to the view so the nav bar could extend under the status bar
-    // "as Apollo expects" — that was wrong, and it is what made the app read as
-    // three separate windows rather than one.
-    //
-    // Measured on an iPad Pro 13" landscape, the three navigation bars were:
-    //
-    //   sidebar   (10, 32, 270, 54)
-    //   list      (280, 32, 480, 54)
-    //   detail    (760, 86, 616, 54)   ← 54pt lower than both its neighbours
-    //
-    // UIKit positions the sidebar and the list column inside already-inset
-    // column views, so their bars start at the column's own top. The secondary
-    // column view spans the full window (0,0,1376,1032), so pinning the nav
-    // controller to its top told that controller it began at the very top of the
-    // screen and it applied the whole status-bar inset a second time. Pinning to
-    // the safe area gives it the same origin UIKit gave the other two, and the
-    // three bars line up.
-    // Leading/trailing follow the safe area — that is the Texture fix, and it is
-    // the only thing the safe area gets to decide here.
-    //
-    // Top/bottom are driven manually against the LIST column's real frame (see
-    // apollo_matchListColumnGeometry). The safe area is the wrong input for
-    // them: it produced a detail column running 32→1012 against the list
-    // column's 32→1022, and it cannot express the 10pt the navigation bar
-    // inserts above itself.
-    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
-    _topConstraint = [nav.view.topAnchor constraintEqualToAnchor:self.view.topAnchor
-                                                        constant:self.view.safeAreaInsets.top];
-    _bottomConstraint = [self.view.bottomAnchor constraintEqualToAnchor:nav.view.bottomAnchor
-                                                              constant:self.view.safeAreaInsets.bottom];
-    [NSLayoutConstraint activateConstraints:@[
-        [nav.view.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor],
-        [nav.view.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor],
-        _topConstraint,
-        _bottomConstraint,
-    ]];
-    [nav didMoveToParentViewController:self];
-}
-
-// UISplitViewController wraps any column view controller that is not already a
-// navigation controller in one of its own. This host is a plain UIViewController,
-// so the detail column ends up with TWO navigation bars stacked:
-//
-//   UIKit's wrapper bar   (0, 32, 1376, 54)   full width, empty, invisible
-//   Apollo's real bar     (760, 96, 616, 54)  pushed below it
-//
-// The wrapper bar is never seen, but it still reports itself through the safe
-// area — 86pt of top inset — which is what pushed Apollo's bar 54pt below the
-// sidebar's and the list column's bars and made the three columns read as three
-// separate windows. Its full-width background band was painting across the whole
-// app too.
-//
-// Hiding it costs nothing: the wrapper has no items, no title and no back
-// button, because everything the user interacts with lives on the real
-// navigation controller inside this host.
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    if (self.navigationController && !self.navigationController.navigationBarHidden) {
-        [self.navigationController setNavigationBarHidden:YES animated:NO];
-    }
-    [self apollo_scheduleListColumnGeometryRefresh];
-}
-
-// Lines the detail column up with the list column exactly, top and bottom.
-//
-// WHY NOT THE SAFE AREA. Both navigation controllers report a top safe-area
-// inset of ZERO, and yet:
-//
-//   list    view {0,0,480,990}     bar at y=0    (column starts at 32 → bar at 32)
-//   detail  view {760,32,616,980}  bar at y=10   (→ bar at 42)
-//
-// The 10pt is not an inset we can cancel — it is where Apollo's navigation
-// controller puts its own bar. UIKit's split view positions the list column's
-// navigation controller itself and gets y=0; the same class, parented into this
-// host, lays its bar at y=10. So the fix is not to argue with the bar but to
-// offset the view by exactly the gap the bar leaves, measured each layout.
-//
-// The bottom is the same idea from the other side: the safe area put the detail
-// column's bottom at 1012 against the list column's 1022, which is the band of
-// empty background under the comment list. Matching the list column's maxY
-// removes it, and matching is more robust than any constant since it tracks
-// whatever inset the platform applies to that column.
-//
-// Constraint writes must not originate from viewDidLayoutSubviews: even a
-// value-checked write there can invalidate the same layout transaction during
-// rotation or continuous window resize. Safe-area and transition callbacks
-// coalesce into one post-layout sample instead.
-- (void)viewSafeAreaInsetsDidChange {
-    [super viewSafeAreaInsetsDidChange];
-    [self apollo_scheduleListColumnGeometryRefresh];
-
-    ApolloPaneSplitViewController *pane =
-        [self.splitViewController isKindOfClass:[ApolloPaneSplitViewController class]]
-            ? (ApolloPaneSplitViewController *)self.splitViewController : nil;
-    [pane apollo_resolvedDisplayStateMayHaveChanged];
-}
-
-- (void)viewWillTransitionToSize:(CGSize)size
-       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    __weak ApolloPaneColumnHostViewController *weakSelf = self;
-    [coordinator animateAlongsideTransition:nil
-        completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
-            [weakSelf apollo_scheduleListColumnGeometryRefresh];
-        }];
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-    [self apollo_scheduleListColumnGeometryRefresh];
-}
-
-- (void)apollo_contentSizeCategoryDidChange:(NSNotification *)notification {
-    (void)notification;
-    [self apollo_scheduleListColumnGeometryRefresh];
-}
-
-- (UITableView *)apollo_tableInView:(UIView *)view depth:(NSUInteger)depth {
-    if (!view || depth > 10) return nil;
-    if ([view isKindOfClass:[UITableView class]]) return (UITableView *)view;
-    for (UIView *subview in view.subviews) {
-        UITableView *table = [self apollo_tableInView:subview depth:depth + 1];
-        if (table) return table;
-    }
-    return nil;
-}
-
-- (id)apollo_firstCommentsHeaderNode:(UIViewController *)controller {
-    if (!controller.isViewLoaded) return nil;
-    UITableView *table = [self apollo_tableInView:controller.view depth:0];
-    SEL backingNodeSelector = NSSelectorFromString(@"asyncdisplaykit_node");
-    id tableNode = table && [table respondsToSelector:backingNodeSelector]
-        ? ((id (*)(id, SEL))objc_msgSend)(table, backingNodeSelector) : nil;
-    SEL rowNodeSelector = NSSelectorFromString(@"nodeForRowAtIndexPath:");
-    if (!tableNode || ![tableNode respondsToSelector:rowNodeSelector]) return nil;
-    @try {
-        return ((id (*)(id, SEL, id))objc_msgSend)(
-            tableNode, rowNodeSelector, [NSIndexPath indexPathForRow:0 inSection:0]);
-    } @catch (__unused NSException *exception) {
-        return nil;
-    }
-}
-
-// Only screens whose primary purpose is reading prose opt into the cap. A
-// blanket secondary-column constraint would also narrow media viewers, web
-// content, profiles, feeds, and every future destination that inherits detail
-// ownership from a thread.
-- (BOOL)apollo_topControllerWantsReadableWidth:(UIViewController *)controller {
-    if (!controller) return NO;
-
-    ApolloPaneSplitViewController *pane =
-        [self.splitViewController isKindOfClass:[ApolloPaneSplitViewController class]]
-            ? (ApolloPaneSplitViewController *)self.splitViewController : nil;
-    UIViewController *primaryRoot =
-        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary]
-            .viewControllers.firstObject;
-    if ([NSStringFromClass(primaryRoot.class) hasSuffix:@"SettingsViewController"]) {
-        // Settings destinations are predominantly forms and table screens.
-        // Limit the policy to that concrete surface so a future gallery, web
-        // view, or other intentionally full-width child of Settings does not
-        // inherit prose geometry merely because of its tab.
-        return controller.isViewLoaded &&
-            [self apollo_tableInView:controller.view depth:0] != nil;
-    }
-
-    Class commentsClass = objc_getClass("_TtC6Apollo22CommentsViewController");
-    if (!commentsClass || ![controller isKindOfClass:commentsClass]) return NO;
-
-    // A media post's header shares the Comments ASTableView with the prose
-    // rows. Insetting that table would visibly letterbox the image/video too,
-    // so media threads remain full width. Self posts are the text-heavy case
-    // where constraining the whole table is both useful and internally
-    // consistent. Apollo's Swift Optional `link` storage is not reliably
-    // readable through the ObjC runtime, so prefer it when available and then
-    // identify the already-realized first Texture row: CommentsHeaderCellNode
-    // is prose, RichMediaHeaderCellNode is media. Fail open when neither signal
-    // is available rather than guessing that an unknown header is safe to
-    // narrow.
-    Ivar linkIvar = class_getInstanceVariable(controller.class, "link");
-    id link = nil;
-    @try {
-        const char *linkType = linkIvar ? ivar_getTypeEncoding(linkIvar) : NULL;
-        if (linkType && linkType[0] == '@') {
-            link = object_getIvar(controller, linkIvar);
-        }
-    } @catch (__unused NSException *exception) {}
-    SEL isSelfPostSelector = NSSelectorFromString(@"isSelfPost");
-    BOOL isSelfPost = link && [link respondsToSelector:isSelfPostSelector] &&
-        ((BOOL (*)(id, SEL))objc_msgSend)(link, isSelfPostSelector);
-    id headerNode = nil;
-    if (!link) {
-        headerNode = [self apollo_firstCommentsHeaderNode:controller];
-        NSString *headerClass = NSStringFromClass([headerNode class]);
-        if ([headerClass containsString:@"RichMediaHeaderCellNode"]) return NO;
-        if ([headerClass containsString:@"CommentsHeaderCellNode"]) isSelfPost = YES;
-    }
-#if APOLLO_SIM_BUILD
-    ApolloLog(@"[PaneReadableTest] classified comments link=%@ header=%@ selfPost=%d",
-              NSStringFromClass([link class]), NSStringFromClass([headerNode class]), isSelfPost);
-#endif
-    return isSelfPost;
-}
-
-- (void)apollo_restoreReadableWidthInsets {
-    UIViewController *controller = _readableWidthViewController;
-    if (controller) {
-        UIEdgeInsets additional = controller.additionalSafeAreaInsets;
-        additional.left = _readableWidthBaseLeft;
-        additional.right = _readableWidthBaseRight;
-        controller.additionalSafeAreaInsets = additional;
-    }
-    _readableWidthViewController = nil;
-    _readableWidthBaseLeft = 0.0;
-    _readableWidthBaseRight = 0.0;
-    _readableWidthAppliedInset = 0.0;
-}
-
-- (void)apollo_applyReadableWidthIfNeeded {
-    UIViewController *top = self.hostedNavigationController.topViewController;
-    BOOL wantsReadableWidth = _readableWidthViewController == top ||
-        [self apollo_topControllerWantsReadableWidth:top];
-    if (_readableWidthViewController != top || !wantsReadableWidth) {
-        [self apollo_restoreReadableWidthInsets];
-    }
-    if (!wantsReadableWidth || !top.isViewLoaded) return;
-
-    if (_readableWidthViewController != top) {
-        _readableWidthViewController = top;
-        _readableWidthBaseLeft = top.additionalSafeAreaInsets.left;
-        _readableWidthBaseRight = top.additionalSafeAreaInsets.right;
-    }
-
-    CGFloat width = CGRectGetWidth(top.view.bounds);
-    // A controller installed into a visible navigation stack has not always
-    // received its first bounds assignment yet. The navigation controller is
-    // already constrained to the real detail column, so its width is the exact
-    // pre-display fallback we need. Waiting for top.view.bounds to become
-    // nonzero would allow one unconstrained frame to reach the screen.
-    if (width <= 0.0 && self.hostedNavigationController.isViewLoaded) {
-        width = CGRectGetWidth(self.hostedNavigationController.view.bounds);
-    }
-    if (width <= 0.0) return;
-
-    // 680pt is close to UIKit's familiar readable measure while still leaving
-    // room for nested comment indentation. At accessibility text sizes the cap
-    // relaxes to 760pt so larger glyphs do not turn every sentence into a tall,
-    // narrow column. The nav bar and table/background remain full width; only
-    // safe-area-following cell content is inset.
-    UIContentSizeCategory category = top.traitCollection.preferredContentSizeCategory;
-    CGFloat maximumWidth = UIContentSizeCategoryIsAccessibilityCategory(category) ? 760.0 : 680.0;
-    UIEdgeInsets current = top.additionalSafeAreaInsets;
-    CGFloat systemLeft = MAX(0.0, top.view.safeAreaInsets.left - current.left);
-    CGFloat systemRight = MAX(0.0, top.view.safeAreaInsets.right - current.right);
-    CGFloat naturalWidth = MAX(0.0, width - systemLeft - systemRight -
-                               _readableWidthBaseLeft - _readableWidthBaseRight);
-    CGFloat inset = MAX(0.0, floor((naturalWidth - maximumWidth) / 2.0));
-    if (fabs(_readableWidthAppliedInset - inset) <= 0.5 &&
-        fabs(current.left - (_readableWidthBaseLeft + inset)) <= 0.5 &&
-        fabs(current.right - (_readableWidthBaseRight + inset)) <= 0.5) return;
-
-    _readableWidthAppliedInset = inset;
-    current.left = _readableWidthBaseLeft + inset;
-    current.right = _readableWidthBaseRight + inset;
-    top.additionalSafeAreaInsets = current;
-    ApolloLog(@"[PaneReadable] %@ width=%.0f max=%.0f inset=%.0f accessibility=%d",
-              NSStringFromClass(top.class), naturalWidth, maximumWidth, inset,
-              UIContentSizeCategoryIsAccessibilityCategory(category));
-}
-
-- (void)apollo_prepareReadableWidthForTopController {
-    UIViewController *top = self.hostedNavigationController.topViewController;
-    if (!top) {
-        [self apollo_restoreReadableWidthInsets];
-        return;
-    }
-
-    // This destination is about to become visible, so loading it here does not
-    // defeat the pane's lazy offscreen-tab policy. It does let us classify its
-    // table surface and install additionalSafeAreaInsets before Core Animation
-    // commits the navigation transaction's first frame.
-    [top loadViewIfNeeded];
-#if APOLLO_SIM_BUILD
-    ApolloLog(@"[PaneReadablePrepare] %@ topWidth=%.0f navWidth=%.0f table=%d window=%d",
-              NSStringFromClass(top.class), CGRectGetWidth(top.view.bounds),
-              CGRectGetWidth(self.hostedNavigationController.viewIfLoaded.bounds),
-              [self apollo_tableInView:top.view depth:0] != nil,
-              top.view.window != nil);
-#endif
-    [self apollo_applyReadableWidthIfNeeded];
-}
-
-#if APOLLO_SIM_BUILD
-- (void)viewDidLayoutSubviews {
-    [super viewDidLayoutSubviews];
-    _simLayoutPassCount++;
-}
-#endif
-
-- (void)apollo_scheduleListColumnGeometryRefresh {
-    if (!self.isViewLoaded || _geometryRefreshScheduled) return;
-
-    id<UIViewControllerTransitionCoordinator> coordinator =
-        self.splitViewController.transitionCoordinator;
-    if (coordinator) {
-        if (_geometryRefreshWaitingForTransition) return;
-        _geometryRefreshWaitingForTransition = YES;
-        __weak ApolloPaneColumnHostViewController *weakSelf = self;
-        [coordinator animateAlongsideTransition:nil
-            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
-                ApolloPaneColumnHostViewController *strongSelf = weakSelf;
-                if (!strongSelf) return;
-                strongSelf->_geometryRefreshWaitingForTransition = NO;
-                [strongSelf apollo_scheduleListColumnGeometryRefresh];
-            }];
-        return;
-    }
-
-    _geometryRefreshScheduled = YES;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self->_geometryRefreshScheduled = NO;
-        [self apollo_matchListColumnGeometry];
-    });
-}
-
-- (void)apollo_matchListColumnGeometry {
-    UINavigationController *nav = self.hostedNavigationController;
-    if (!nav.isViewLoaded || !_topConstraint || !_bottomConstraint) return;
-#if APOLLO_SIM_BUILD
-    _simGeometryRefreshCount++;
-#endif
-
-    CGFloat height = self.view.bounds.size.height;
-    if (height <= 0.0) return;
-
-    [self apollo_applyReadableWidthIfNeeded];
-
-    // Fall back to the safe area whenever the list column cannot be measured —
-    // collapsed, mid-transition, or not yet loaded.
-    CGFloat top = self.view.safeAreaInsets.top;
-    CGFloat bottom = self.view.safeAreaInsets.bottom;
-
-    UISplitViewController *split = self.splitViewController;
-    UIViewController *list = [split isKindOfClass:[UISplitViewController class]]
-        ? [split viewControllerForColumn:UISplitViewControllerColumnPrimary]
-        : nil;
-    if (list.isViewLoaded && list.view.superview && ApolloPaneSplitShowsTiledPrimary(split)) {
-        CGRect listFrame = [list.view.superview convertRect:list.view.frame toView:self.view];
-        CGRect splitBoundsInHost = [split.view convertRect:split.view.bounds toView:self.view];
-        if (!CGRectIsEmpty(listFrame) && CGRectIntersectsRect(listFrame, splitBoundsInHost)) {
-            bottom = height - CGRectGetMaxY(listFrame);
-
-            // Align the two NAVIGATION BARS, not the two view origins.
-            //
-            // The list column's bar is not always flush with the top of its
-            // column, and how far in it sits depends on the mode: with the
-            // sidebar showing, column and bar both start at y=32; with the
-            // sidebar collapsed to the floating tab bar, the column starts at
-            // y=86 and its bar at y=140, 54pt inside. Matching view origins got
-            // the sidebar case right and then put our bar 54pt ABOVE the list's
-            // in the tab bar case. So take the list bar's real position as the
-            // target and back out our own bar's offset within its view.
-            UINavigationBar *listBar = [list isKindOfClass:[UINavigationController class]]
-                ? ((UINavigationController *)list).navigationBar : nil;
-            CGFloat targetBarY = CGRectGetMinY(listFrame);
-            if (listBar && !listBar.isHidden && listBar.superview) {
-                targetBarY = CGRectGetMinY([listBar.superview convertRect:listBar.frame toView:self.view]);
-            }
-            top = targetBarY - nav.navigationBar.frame.origin.y;
-        }
-    }
-
-    BOOL changed = !_hasResolvedGeometry ||
-        fabs(_lastResolvedTop - top) > 0.5 ||
-        fabs(_lastResolvedBottom - bottom) > 0.5;
-    if (!changed) return;
-
-    _hasResolvedGeometry = YES;
-    _lastResolvedTop = top;
-    _lastResolvedBottom = bottom;
-    BOOL wroteConstraint = NO;
-    if (fabs(_topConstraint.constant - top) > 0.5) {
-        _topConstraint.constant = top;
-        wroteConstraint = YES;
-    }
-    if (fabs(_bottomConstraint.constant - bottom) > 0.5) {
-        _bottomConstraint.constant = bottom;
-        wroteConstraint = YES;
-    }
-#if APOLLO_SIM_BUILD
-    if (wroteConstraint) _simGeometryWriteCount++;
-#else
-    (void)wroteConstraint;
-#endif
-}
-
-#if APOLLO_SIM_BUILD
-- (NSString *)apollo_simLayoutPassStateReset:(BOOL)reset {
-    NSString *state = [NSString stringWithFormat:
-        @"hostPasses=%lu hostRefreshes=%lu hostWrites=%lu top=%.1f bottom=%.1f",
-        (unsigned long)_simLayoutPassCount,
-        (unsigned long)_simGeometryRefreshCount,
-        (unsigned long)_simGeometryWriteCount,
-        _topConstraint.constant, _bottomConstraint.constant];
-    if (reset) {
-        _simLayoutPassCount = 0;
-        _simGeometryRefreshCount = 0;
-        _simGeometryWriteCount = 0;
-    }
-    return state;
-}
-#endif
-
-// The hosted navigation controller owns the chrome; forwarding these keeps the
-// host transparent to UIKit rather than having it answer for an empty view.
-- (UIViewController *)childViewControllerForStatusBarStyle { return self.hostedNavigationController; }
-- (UIViewController *)childViewControllerForStatusBarHidden { return self.hostedNavigationController; }
-- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden { return self.hostedNavigationController; }
-
-@end
-
 #pragma mark - Pane split controller
 
 @interface ApolloPaneMasterSelectionIntent : NSObject
@@ -969,8 +421,7 @@ static char kApolloPaneScenePreferredWidthKey;
 @interface ApolloPaneSplitViewController () <UISplitViewControllerDelegate, UIGestureRecognizerDelegate> {
     BOOL _apollo_loggedResolvedLayout;
     ApolloPaneDividerControl *_apollo_grabber;
-    BOOL _apollo_geometryRefreshScheduled;
-    BOOL _apollo_geometryRefreshWaitingForTransition;
+    ApolloPaneGeometryScheduler *_apollo_geometryScheduler;
     BOOL _apollo_hasGrabberGeometry;
     BOOL _apollo_lastGrabberHidden;
     CGRect _apollo_lastGrabberFrame;
@@ -1052,12 +503,12 @@ static char kApolloPaneScenePreferredWidthKey;
     NSUInteger _apollo_crossColumnIntentSequence;
     NSUInteger _apollo_pendingCrossColumnSequence;
     BOOL _apollo_crossColumnDrainScheduled;
-    BOOL _apollo_transitionFallbackScheduled;
     BOOL _apollo_compactPrimaryRestoreInProgress;
     BOOL _apollo_executingCrossColumnNavigation;
     BOOL _apollo_topologyMutationInProgress;
     NSUInteger _apollo_topologyMutationGeneration;
     BOOL _apollo_compactBackInProgress;
+    UIPercentDrivenInteractiveTransition *_apollo_rootInteractiveTransition;
     __weak id<UIViewControllerTransitionCoordinator> _apollo_observedTransitionCoordinator;
     UIBarButtonItem *_apollo_showPrimaryItem;
     __weak UINavigationItem *_apollo_showPrimaryOwner;
@@ -1075,6 +526,9 @@ static char kApolloPaneScenePreferredWidthKey;
     // this value. Only the pane-owned divider, keyboard commands, or its
     // accessibility-adjustable actions publish a new intentional preference.
     CGFloat _apollo_dividerPanStartWidth;
+    CGFloat _apollo_dividerPanStartPreference;
+    CGFloat _apollo_pendingDividerWidth;
+    ApolloPaneFrameScheduler *_apollo_dividerFrameScheduler;
     CGFloat _apollo_lastAppliedPreferredPrimaryWidth;
 
     // Pane-owned master selection. The opaque intent retains only copied
@@ -1211,10 +665,23 @@ static char kApolloPaneScenePreferredWidthKey;
 
 @end
 
+static CGFloat ApolloPaneUsableWidth(UISplitViewController *pane) {
+    UIView *view = pane.viewIfLoaded;
+    CGFloat width = CGRectGetWidth(view.bounds);
+    if (@available(iOS 26.0, *)) {
+        UILayoutGuide *guide = pane.tabBarController.contentLayoutGuide;
+        if (guide.owningView.window && view.window) {
+            CGRect available = [guide.owningView convertRect:guide.layoutFrame toView:view];
+            CGRect intersection = CGRectIntersection(view.bounds, available);
+            if (!CGRectIsNull(intersection) && CGRectGetWidth(intersection) > 0.0)
+                return CGRectGetWidth(intersection);
+        }
+    }
+    return MAX(0.0, width - view.safeAreaInsets.left - view.safeAreaInsets.right);
+}
+
 static CGFloat ApolloPaneClampedPreferredPrimaryWidth(CGFloat width) {
-    if (!isfinite(width)) width = 0.0;
-    return MIN(kApolloPaneMaximumPrimaryWidth,
-               MAX(kApolloPaneMinimumPrimaryWidth, width));
+    return ApolloPanePreferredWidth(width);
 }
 
 static NSString *ApolloPaneWidthPersistenceSceneKey(UIWindowScene *scene) {
@@ -1238,12 +705,62 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
     if (!sceneKey) return;
     NSMutableDictionary *widths = [[NSUserDefaults.standardUserDefaults
         dictionaryForKey:kApolloPanePrimaryWidthsDefaultsKey] mutableCopy] ?: [NSMutableDictionary dictionary];
+    NSMutableSet *openSessions = [NSMutableSet set];
+    for (UISceneSession *session in UIApplication.sharedApplication.openSessions)
+        [openSessions addObject:session.persistentIdentifier];
+    for (NSString *key in widths.allKeys)
+        if (![openSessions containsObject:key]) [widths removeObjectForKey:key];
     widths[sceneKey] = @(ApolloPaneClampedPreferredPrimaryWidth(width));
     [NSUserDefaults.standardUserDefaults setObject:widths
                                             forKey:kApolloPanePrimaryWidthsDefaultsKey];
 }
 
 @implementation ApolloPaneSplitViewController
+
+- (void)apollo_sceneBecameInactive {
+    [_apollo_geometryScheduler cancel];
+    [_apollo_dividerFrameScheduler cancel];
+    [ApolloPaneTransitionObserver cancelOwner:self];
+    ApolloPaneTraceCancel(self);
+    [_apollo_rootInteractiveTransition cancelInteractiveTransition];
+    _apollo_observedTransitionCoordinator = nil;
+}
+- (void)apollo_sceneBecameActive {
+    if (_apollo_topologyMutationInProgress)
+        [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:_apollo_topologyMutationGeneration nilObservations:0];
+    [self apollo_synchronizePreferredPrimaryWidth];
+    [self apollo_scheduleResolvedGeometryRefresh];
+    [self apollo_navigationTransitionDidSettle];
+}
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // The bounded observer owns temporary closures only. Live navigation and
+    // native media/drafts belong to Apollo and are deliberately not evicted.
+    if (!self.viewIfLoaded.window) [self apollo_sceneBecameInactive];
+}
+- (void)apollo_sceneDidDisconnect {
+    ApolloPaneRestoreFocusPolicy(self);
+    ApolloPaneTraceCancel(self);
+    [_apollo_geometryScheduler cancel];
+    [ApolloPaneTransitionObserver cancelOwner:self];
+    [_apollo_rootInteractiveTransition cancelInteractiveTransition];
+    _apollo_rootInteractiveTransition = nil;
+    ApolloPaneSetNativeInteractiveTransition(self.apollo_primaryNav, nil);
+    _apollo_pendingCrossColumnNavigation = nil;
+    _apollo_pendingCrossColumnSource = nil;
+    _apollo_pendingCrossColumnSemanticOwner = nil;
+    _apollo_pendingCrossColumnSourceScope = nil;
+    _apollo_pendingPrimaryPopToken = 0;
+    _apollo_pendingPrimaryPopExpectedRestoreStack = nil;
+    _apollo_compactPrimaryRestoreGeneration++;
+    _apollo_compactPrimaryRestoreInProgress = NO;
+    _apollo_topologyMutationGeneration++;
+    _apollo_topologyMutationInProgress = NO;
+    [_apollo_dividerFrameScheduler cancel];
+    _apollo_stagedMasterSelectionGeneration++;
+    _apollo_stagedMasterSelectionIntent = nil;
+    _apollo_observedTransitionCoordinator = nil;
+}
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -1255,6 +772,7 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
     [self apollo_installNavigationGestureObservers];
     [self apollo_applyGroundTheme];
     [self apollo_installColumnGrabber];
+    ApolloPaneInstallFocus(self);
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(apollo_activeThemeChanged:)
                                                name:@"com.christianselig.ApolloSpecificThemeChanged"
@@ -1517,6 +1035,11 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+    ApolloPaneInstallLinkInteractions(self);
+    ApolloPaneSidebarFirstAppearance(self.tabBarController);
+    ApolloPaneRefreshFocus(self);
+    ApolloPaneInstallChromeForController(self.apollo_primaryNav.topViewController);
+    ApolloPaneInstallChromeForController(self.apollo_detailNav.topViewController);
     [self apollo_synchronizePreferredPrimaryWidth];
     [self apollo_refreshMasterSelection];
     [self apollo_scheduleResolvedGeometryRefresh];
@@ -1787,9 +1310,20 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
 
 - (void)apollo_scheduleCompactPrimaryRestoreReconciliation:(NSUInteger)generation
                                                observations:(NSUInteger)observations {
-    NSTimeInterval delay = observations < 120 ? 0.05 : 0.25;
+    if (observations >= 120) {
+        _apollo_compactPrimaryRestoreInProgress = NO;
+        _apollo_expectUIKitCompactPrimaryStackReplacement = NO;
+        _apollo_expectOneLateUIKitCompactPrimaryStackReplacement = NO;
+        ApolloLog(@"[PaneTransition] compact restoration timed out; preserving current stacks");
+        [self apollo_navigationTransitionDidSettle];
+        return;
+    }
+    __weak ApolloPaneSplitViewController *weakSelf = self;
+    NSTimeInterval delay = 0.05;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
+        ApolloPaneSplitViewController *self = weakSelf;
+        if (!self) return;
         if (self->_apollo_compactPrimaryRestoreGeneration != generation ||
             !self->_apollo_compactPrimaryRestoreInProgress) return;
         BOOL transitionStillActive = self->_apollo_pendingPrimaryPopToken != 0 ||
@@ -2015,14 +1549,14 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
     // The empty state names what THIS tab puts in the detail column. "No Post
     // Selected" beside a settings index or a search field is just wrong, and it
     // was a large part of why those two tabs read as nonsense on iPad.
-    NSString *message = @"No Post Selected";
+    NSString *message = @"Select a post";
     NSString *symbol = @"text.bubble";
     NSString *rootClass = NSStringFromClass([rootNav.viewControllers.firstObject class]) ?: @"";
     if ([rootClass hasSuffix:@"SettingsViewController"]) {
-        message = @"No Setting Selected";
+        message = @"Choose a setting";
         symbol = @"gearshape";
     } else if ([rootClass hasSuffix:@"InboxListViewController"]) {
-        message = @"No Message Selected";
+        message = @"Choose a conversation";
         symbol = @"envelope";
     } else if ([rootClass hasSuffix:@"SearchViewController"]) {
         message = @"Search Reddit";
@@ -2030,7 +1564,7 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
     } else if ([rootClass hasSuffix:@"ProfileViewController"]) {
         // The profile's detail column holds whatever row you picked — a post
         // list, trophies, friends — so it cannot promise a post.
-        message = @"Nothing Selected";
+        message = @"Explore your profile";
         symbol = @"person.crop.circle";
     }
 
@@ -2114,6 +1648,7 @@ static void ApolloPanePersistPrimaryWidth(CGFloat width, UIWindowScene *scene) {
     self.preferredPrimaryColumnWidthFraction = kApolloPaneDefaultPrimaryWidthFraction;
     self.minimumPrimaryColumnWidth = kApolloPaneMinimumPrimaryWidth;
     self.maximumPrimaryColumnWidth = kApolloPaneMaximumPrimaryWidth;
+    if (@available(iOS 26.0, *)) self.minimumSecondaryColumnWidth = 420.0;
 
     // Apollo installs its own screen-edge pans on every navigation controller
     // (left = interactive pop, right = "go forward", re-pushing from the per-nav
@@ -2526,7 +2061,9 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
     CGRect visibleBounds = self.view.bounds;
     BOOL listIntersects = CGRectIntersectsRect(listFrame, visibleBounds);
     BOOL detailIntersects = CGRectIntersectsRect(detailFrame, visibleBounds);
-    BOOL primaryOnLeadingEdge = self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading;
+    BOOL primaryOnLeadingEdge = ApolloPanePrimaryIsPhysicallyLeft(
+        self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading,
+        self.view.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft);
     CGFloat listBoundary = primaryOnLeadingEdge ? CGRectGetMaxX(listFrame) : CGRectGetMinX(listFrame);
     CGFloat detailBoundary = primaryOnLeadingEdge ? CGRectGetMinX(detailFrame) : CGRectGetMaxX(detailFrame);
     if (CGRectIsEmpty(listFrame) || CGRectIsEmpty(detailFrame) ||
@@ -2570,7 +2107,7 @@ apply:
 #pragma mark - Shared divider width
 
 - (void)apollo_applyScenePreferredPrimaryWidth:(CGFloat)width {
-    CGFloat clamped = ApolloPaneClampedPreferredPrimaryWidth(width);
+    CGFloat clamped = ApolloPaneResolvedWidth(width, ApolloPaneUsableWidth(self));
     if (fabs(_apollo_lastAppliedPreferredPrimaryWidth - clamped) <= 0.5 &&
         fabs(self.preferredPrimaryColumnWidth - clamped) <= 0.5) return;
     _apollo_lastAppliedPreferredPrimaryWidth = clamped;
@@ -2590,7 +2127,7 @@ apply:
     if (!sceneWidth) {
         sceneWidth = ApolloPanePersistedPrimaryWidth(scene);
         if (!sceneWidth) {
-            CGFloat availableWidth = CGRectGetWidth(self.viewIfLoaded.bounds);
+            CGFloat availableWidth = ApolloPaneUsableWidth(self);
             CGFloat defaultWidth = availableWidth > 0.0
                 ? availableWidth * kApolloPaneDefaultPrimaryWidthFraction : 420.0;
             sceneWidth = @(ApolloPaneClampedPreferredPrimaryWidth(defaultWidth));
@@ -2601,15 +2138,7 @@ apply:
                   sceneWidth.doubleValue, ApolloPanePersistedPrimaryWidth(scene) != nil);
     }
 
-    UITabBarController *tabs = self.tabBarController;
-    BOOL appliedSibling = NO;
-    for (UIViewController *child in tabs.viewControllers) {
-        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
-        [(ApolloPaneSplitViewController *)child
-            apollo_applyScenePreferredPrimaryWidth:sceneWidth.doubleValue];
-        appliedSibling = YES;
-    }
-    if (!appliedSibling) [self apollo_applyScenePreferredPrimaryWidth:sceneWidth.doubleValue];
+    [self apollo_applyScenePreferredPrimaryWidth:sceneWidth.doubleValue];
 }
 
 - (void)apollo_publishPreferredPrimaryWidth:(CGFloat)width persist:(BOOL)persist {
@@ -2621,14 +2150,7 @@ apply:
         if (persist) ApolloPanePersistPrimaryWidth(clamped, scene);
     }
 
-    UITabBarController *tabs = self.tabBarController;
-    BOOL appliedSibling = NO;
-    for (UIViewController *child in tabs.viewControllers) {
-        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
-        [(ApolloPaneSplitViewController *)child apollo_applyScenePreferredPrimaryWidth:clamped];
-        appliedSibling = YES;
-    }
-    if (!appliedSibling) [self apollo_applyScenePreferredPrimaryWidth:clamped];
+    [self apollo_applyScenePreferredPrimaryWidth:clamped];
     if (persist) {
         ApolloLog(@"[PaneWidth] tab %ld committed scene preference %.0f (resolved %.0f)",
                   (long)self.apollo_tabIndex, clamped, self.primaryColumnWidth);
@@ -2636,8 +2158,13 @@ apply:
 }
 
 - (void)apollo_dividerPanChanged:(UIPanGestureRecognizer *)gesture {
-    CGFloat direction = self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading ? 1.0 : -1.0;
+    CGFloat direction = ApolloPanePrimaryIsPhysicallyLeft(
+        self.primaryEdge == UISplitViewControllerPrimaryEdgeLeading,
+        self.view.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) ? 1.0 : -1.0;
     if (gesture.state == UIGestureRecognizerStateBegan) {
+        ApolloPaneTraceBegin(self, @"divider");
+        NSNumber *saved = objc_getAssociatedObject(self.view.window.windowScene, &kApolloPaneScenePreferredWidthKey);
+        _apollo_dividerPanStartPreference = saved ? saved.doubleValue : self.preferredPrimaryColumnWidth;
         _apollo_dividerPanStartWidth = ApolloPaneClampedPreferredPrimaryWidth(
             self.primaryColumnWidth > 0.0 ? self.primaryColumnWidth
                                           : self.preferredPrimaryColumnWidth);
@@ -2648,31 +2175,47 @@ apply:
     switch (gesture.state) {
         case UIGestureRecognizerStateBegan:
         case UIGestureRecognizerStateChanged:
-            [self apollo_publishPreferredPrimaryWidth:target persist:NO];
+            _apollo_pendingDividerWidth = target;
+            if (!_apollo_dividerFrameScheduler) {
+                _apollo_dividerFrameScheduler = [[ApolloPaneFrameScheduler alloc] initWithOwner:self
+                    update:^(ApolloPaneSplitViewController *pane) {
+                        [pane apollo_publishPreferredPrimaryWidth:pane->_apollo_pendingDividerWidth persist:NO];
+                    }];
+            }
+            [_apollo_dividerFrameScheduler request];
             break;
         case UIGestureRecognizerStateEnded:
+            [_apollo_dividerFrameScheduler cancel];
+            ApolloPaneTraceEnd(self, @"divider");
             [self apollo_publishPreferredPrimaryWidth:target persist:YES];
             break;
         case UIGestureRecognizerStateCancelled:
         case UIGestureRecognizerStateFailed:
-            [self apollo_publishPreferredPrimaryWidth:_apollo_dividerPanStartWidth persist:NO];
+            [_apollo_dividerFrameScheduler cancel];
+            ApolloPaneTraceEnd(self, @"divider");
+            [self apollo_publishPreferredPrimaryWidth:_apollo_dividerPanStartPreference persist:NO];
             break;
         default:
             break;
     }
 }
 
+- (void)apollo_resetPreferredPrimaryWidth {
+    CGFloat width = ApolloPaneUsableWidth(self) * kApolloPaneDefaultPrimaryWidthFraction;
+    [self apollo_publishPreferredPrimaryWidth:width persist:YES];
+}
+
 - (void)apollo_nudgePreferredPrimaryWidth:(CGFloat)delta {
     if (!ApolloPaneSplitShowsTiledPrimary(self)) return;
-    CGFloat current = _apollo_lastAppliedPreferredPrimaryWidth > 0.0
-        ? _apollo_lastAppliedPreferredPrimaryWidth : self.preferredPrimaryColumnWidth;
+    NSNumber *saved = objc_getAssociatedObject(self.viewIfLoaded.window.windowScene, &kApolloPaneScenePreferredWidthKey);
+    CGFloat current = saved ? saved.doubleValue : self.preferredPrimaryColumnWidth;
     [self apollo_publishPreferredPrimaryWidth:current + delta persist:YES];
     [_apollo_grabber refreshAccessibilityValue];
 }
 
 - (NSString *)apollo_primaryWidthAccessibilityValue {
-    CGFloat preferred = _apollo_lastAppliedPreferredPrimaryWidth > 0.0
-        ? _apollo_lastAppliedPreferredPrimaryWidth : self.preferredPrimaryColumnWidth;
+    NSNumber *saved = objc_getAssociatedObject(self.viewIfLoaded.window.windowScene, &kApolloPaneScenePreferredWidthKey);
+    CGFloat preferred = saved ? saved.doubleValue : self.preferredPrimaryColumnWidth;
     CGFloat resolved = self.primaryColumnWidth;
     if (preferred <= 0.0 || preferred == UISplitViewControllerAutomaticDimension) return @"Automatic";
     if (resolved > 0.0 && fabs(preferred - resolved) > 1.0) {
@@ -2685,15 +2228,40 @@ apply:
 - (NSArray<UIKeyCommand *> *)keyCommands {
     NSMutableArray<UIKeyCommand *> *commands = [[super keyCommands] mutableCopy] ?: [NSMutableArray array];
     UIKeyCommand *narrow = [UIKeyCommand keyCommandWithInput:UIKeyInputLeftArrow
-                                              modifierFlags:UIKeyModifierAlternate
+                                              modifierFlags:UIKeyModifierControl | UIKeyModifierAlternate
                                                      action:@selector(apollo_narrowPrimaryColumn:)];
     narrow.discoverabilityTitle = @"Narrow List Column";
     UIKeyCommand *widen = [UIKeyCommand keyCommandWithInput:UIKeyInputRightArrow
-                                             modifierFlags:UIKeyModifierAlternate
+                                             modifierFlags:UIKeyModifierControl | UIKeyModifierAlternate
                                                     action:@selector(apollo_widenPrimaryColumn:)];
     widen.discoverabilityTitle = @"Widen List Column";
     [commands addObjectsFromArray:@[ narrow, widen ]];
+    UIKeyCommand *list = [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand | UIKeyModifierAlternate action:@selector(apollo_focusList:)];
+    list.discoverabilityTitle = @"Focus list";
+    UIKeyCommand *detail = [UIKeyCommand keyCommandWithInput:@"2" modifierFlags:UIKeyModifierCommand | UIKeyModifierAlternate action:@selector(apollo_focusDetail:)];
+    detail.discoverabilityTitle = @"Focus detail";
+    [commands addObjectsFromArray:@[list, detail]];
+    UIViewController *focused = ApolloPaneFocusedController(self);
+    if (focused.navigationItem.searchController ||
+        [NSStringFromClass(focused.class) hasSuffix:@"CommentsViewController"]) {
+        UIKeyCommand *find = [UIKeyCommand keyCommandWithInput:@"f" modifierFlags:UIKeyModifierCommand action:@selector(apollo_findInFocusedPane:)];
+        find.discoverabilityTitle = @"Find in focused pane";
+        [commands addObject:find];
+    }
     return commands;
+}
+
+- (BOOL)canBecomeFirstResponder { return YES; }
+- (void)apollo_focusList:(id)sender { ApolloPaneFocusColumn(self, NO, YES); }
+- (void)apollo_focusDetail:(id)sender { ApolloPaneFocusColumn(self, YES, YES); }
+- (void)apollo_findInFocusedPane:(id)sender {
+    UIViewController *controller = ApolloPaneFocusedController(self);
+    if (ApolloPanePresentCommentsFind(controller)) return;
+    UISearchController *search = controller.navigationItem.searchController;
+    if (search) {
+        search.active = YES;
+        [search.searchBar becomeFirstResponder];
+    }
 }
 
 - (void)apollo_narrowPrimaryColumn:(UIKeyCommand *)command {
@@ -2791,28 +2359,12 @@ apply:
 #endif
 
 - (void)apollo_scheduleResolvedGeometryRefresh {
-    if (!self.isViewLoaded || _apollo_geometryRefreshScheduled) return;
-
-    id<UIViewControllerTransitionCoordinator> coordinator = self.transitionCoordinator;
-    if (coordinator) {
-        if (_apollo_geometryRefreshWaitingForTransition) return;
-        _apollo_geometryRefreshWaitingForTransition = YES;
-        __weak ApolloPaneSplitViewController *weakSelf = self;
-        [coordinator animateAlongsideTransition:nil
-            completion:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
-                ApolloPaneSplitViewController *strongSelf = weakSelf;
-                if (!strongSelf) return;
-                strongSelf->_apollo_geometryRefreshWaitingForTransition = NO;
-                [strongSelf apollo_scheduleResolvedGeometryRefresh];
-            }];
-        return;
+    if (!_apollo_geometryScheduler) {
+        _apollo_geometryScheduler = [[ApolloPaneGeometryScheduler alloc] initWithOwner:self update:^(id owner) {
+            [owner apollo_applyResolvedGeometry];
+        }];
     }
-
-    _apollo_geometryRefreshScheduled = YES;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self->_apollo_geometryRefreshScheduled = NO;
-        [self apollo_applyResolvedGeometry];
-    });
+    [_apollo_geometryScheduler requestAfterCoordinator:self.transitionCoordinator];
 }
 
 - (void)apollo_applyResolvedGeometry {
@@ -2953,11 +2505,20 @@ apply:
         ApolloPaneColumnSecondary;
 }
 
+- (BOOL)apollo_isColumnBridgeController:(UIViewController *)controller {
+    if (!controller) return NO;
+    if (controller == self.apollo_detailHost || controller == self.apollo_detailNav) return YES;
+    if (![controller isKindOfClass:UINavigationController.class]) return NO;
+    NSArray *stack = ((UINavigationController *)controller).viewControllers;
+    return stack.count == 1 && stack.firstObject == self.apollo_detailHost;
+}
+
 - (NSArray<UIViewController *> *)apollo_logicalPrimaryControllers {
     NSArray<UIViewController *> *stack = self.apollo_primaryNav.viewControllers;
     NSUInteger detailStart = NSNotFound;
     for (NSUInteger index = 0; index < stack.count; index++) {
-        if ([self apollo_compactViewControllerBelongsToDetail:stack[index]]) {
+        if ([self apollo_isColumnBridgeController:stack[index]] ||
+            [self apollo_compactViewControllerBelongsToDetail:stack[index]]) {
             detailStart = index;
             break;
         }
@@ -3008,7 +2569,7 @@ apply:
 #if APOLLO_SIM_BUILD
     if (_apollo_simCrossColumnNavigationBlocked) return YES;
 #endif
-    return _apollo_executingCrossColumnNavigation || _apollo_topologyMutationInProgress ||
+    return _apollo_executingCrossColumnNavigation || _apollo_compactBackInProgress || _apollo_topologyMutationInProgress ||
         _apollo_compactPrimaryRestoreInProgress || _apollo_pendingPrimaryPopToken != 0 ||
         self.apollo_activeTransitionCoordinator ||
         [self apollo_navigationControllerIsTransitioning:self.apollo_primaryNav] ||
@@ -3079,19 +2640,17 @@ apply:
             });
         }];
     if (!accepted && _apollo_observedTransitionCoordinator == coordinator) {
-        _apollo_observedTransitionCoordinator = nil;
-        // Some UIKit coordinators reject late completion registration. Gesture
-        // terminal callbacks normally wake the queue, but a stock/programmatic
-        // coordinator may have no gesture at all. Resample at a bounded cadence
-        // until the coordinator detaches instead of stranding the latest intent.
-        if (!_apollo_transitionFallbackScheduled) {
-            _apollo_transitionFallbackScheduled = YES;
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
-                           dispatch_get_main_queue(), ^{
-                self->_apollo_transitionFallbackScheduled = NO;
-                [self apollo_navigationTransitionDidSettle];
-            });
-        }
+        // Bounded, weak fallback. A held interactive gesture has no deadline:
+        // after this watchdog expires its terminal event wakes the queue.
+        // Retain the observed coordinator identity to prevent repeated polling.
+        [ApolloPaneTransitionObserver observeOwner:self key:@"pendingNavigation" timeout:6.0
+            ready:^BOOL(ApolloPaneSplitViewController *pane) {
+                return ![pane apollo_navigationOrTopologyTransitionIsActive];
+            } completion:^(ApolloPaneSplitViewController *pane, BOOL timedOut) {
+                if (timedOut) return;
+                pane->_apollo_observedTransitionCoordinator = nil;
+                [pane apollo_navigationTransitionDidSettle];
+            }];
     }
 }
 
@@ -3158,9 +2717,11 @@ apply:
     if (!NSThread.isMainThread) {
         __weak ApolloPaneSplitViewController *weakSelf = self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf apollo_deferCrossColumnNavigationIfNeeded:navigation
-                                            sourceViewController:sourceViewController
-                                                          reason:reason];
+            ApolloPaneSplitViewController *pane = weakSelf;
+            if (pane && ![pane apollo_deferCrossColumnNavigationIfNeeded:navigation
+                sourceViewController:sourceViewController reason:reason]) {
+                [pane apollo_performCrossColumnNavigationTransaction:navigation];
+            }
         });
         return YES;
     }
@@ -3193,6 +2754,17 @@ apply:
 }
 
 - (void)apollo_navigationTransitionDidSettle {
+    ApolloPaneRefreshFocus(self);
+    ApolloPaneRegisterNavigationItems(self.apollo_primaryNav);
+    ApolloPaneRegisterNavigationItems(self.apollo_detailNav);
+    ApolloPaneInstallChromeForController(self.apollo_primaryNav.topViewController);
+    ApolloPaneInstallChromeForController(self.apollo_detailNav.topViewController);
+    if (_apollo_compactDetailChromeActive) {
+        BOOL nested = self.apollo_detailNav.viewControllers.count > 1;
+        self.apollo_detailNav.interactivePopGestureRecognizer.enabled = nested && _apollo_detailPopGestureWasEnabled;
+        _apollo_detailApolloBackGesture.enabled = nested && _apollo_detailApolloBackGestureWasEnabled;
+    }
+
     _apollo_observedTransitionCoordinator = nil;
     [self apollo_scheduleShowPrimaryItemRefresh];
     [self apollo_scheduleCrossColumnNavigationDrain];
@@ -3327,6 +2899,36 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
     [self apollo_resolvedDisplayStateMayHaveChanged];
 }
 
+- (NSDictionary *)apollo_simStructuredSnapshot {
+    NSMutableArray *columns = [NSMutableArray array];
+    NSUInteger loaded = 0, visible = 0;
+    for (UINavigationController *nav in @[self.apollo_primaryNav, self.apollo_detailNav]) {
+        UIView *view = nav.viewIfLoaded;
+        UIView *bar = nav.isViewLoaded ? nav.navigationBar : nil;
+        UIView *search = nav.topViewController.navigationItem.searchController.searchBar;
+        CGRect frame = view.window ? [view convertRect:view.bounds toView:self.viewIfLoaded] : CGRectZero;
+        CGRect context = bar.window ? [bar convertRect:bar.bounds toView:self.viewIfLoaded] : CGRectZero;
+        CGRect searchFrame = search.window ? [search convertRect:search.bounds toView:self.viewIfLoaded] : CGRectZero;
+        for (UIViewController *controller in nav.viewControllers) {
+            loaded += controller.isViewLoaded;
+            visible += controller.viewIfLoaded.window != nil;
+        }
+        [columns addObject:@{@"depth": @(nav.viewControllers.count), @"frame": NSStringFromCGRect(frame),
+            @"navigationContainer": NSStringFromCGRect(context), @"search": NSStringFromCGRect(searchFrame),
+            @"barHidden": @(nav.navigationBarHidden)}];
+    }
+    return @{@"tab": @(self.apollo_tabIndex), @"collapsed": @(self.isCollapsed),
+        @"bounds": NSStringFromCGRect(self.viewIfLoaded.bounds), @"displayMode": @(self.displayMode),
+        @"tabContentGuide": NSStringFromCGRect(self.tabBarController.contentLayoutGuide.layoutFrame),
+        @"columns": columns, @"logicalPrimaryDepth": @(self.apollo_logicalPrimaryControllers.count),
+        @"emptyDetail": @(self.apollo_detailIsEmpty), @"loaded": @(loaded), @"visible": @(visible),
+        @"pendingNavigation": @(_apollo_pendingCrossColumnNavigation != nil),
+        @"watchdogs": @([ApolloPaneTransitionObserver activeCountForOwner:self] + [ApolloPaneTransitionObserver activeCountForOwner:self.apollo_primaryNav] + [ApolloPaneTransitionObserver activeCountForOwner:self.apollo_detailNav]),
+        @"layoutPasses": @(_apollo_simLayoutPassCount), @"geometryRefreshes": @(_apollo_simGeometryRefreshCount),
+        @"geometryWrites": @(_apollo_simGeometryWriteCount),
+        @"preferredWidth": [self apollo_primaryWidthAccessibilityValue]};
+}
+
 - (NSString *)apollo_simResolvedLayoutState {
     UIViewController *primary = [self viewControllerForColumn:UISplitViewControllerColumnPrimary];
     CGRect primaryFrame = CGRectZero;
@@ -3393,7 +2995,7 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
         (unsigned long)_apollo_simGeometryRefreshCount,
         (unsigned long)_apollo_simGeometryWriteCount,
         _apollo_grabber.hidden, NSStringFromCGRect(_apollo_grabber.frame), hostState,
-        !_apollo_geometryRefreshScheduled && !_apollo_geometryRefreshWaitingForTransition];
+        !_apollo_geometryScheduler.isPending];
     if (reset) {
         _apollo_simLayoutPassCount = 0;
         _apollo_simGeometryRefreshCount = 0;
@@ -3798,6 +3400,10 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
 }
 
 - (void)apollo_stopTrackingCompactPrimaryPopGesture {
+    // While our percent-driven return owns the native transition, its gesture
+    // must keep receiving samples and Apollo's competing recognizers must stay
+    // disabled. Restore their original states only after commit/cancellation.
+    if (_apollo_rootInteractiveTransition) return;
     UIGestureRecognizer *primaryPop = self.apollo_primaryNav.interactivePopGestureRecognizer;
     if (_apollo_trackingCompactPrimaryPopGesture) {
         [primaryPop removeTarget:self action:@selector(apollo_compactPrimaryPopGestureChanged:)];
@@ -3813,7 +3419,7 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
         _apollo_detailApolloBackGesture.enabled = _apollo_detailApolloBackGestureWasEnabled;
         _apollo_detailApolloBackGesture = nil;
     }
-    if (_apollo_compactBackEdgeGesture) {
+    if (_apollo_compactBackEdgeGesture && !_apollo_rootInteractiveTransition) {
         [_apollo_compactBackEdgeGesture.view removeGestureRecognizer:_apollo_compactBackEdgeGesture];
         _apollo_compactBackEdgeGesture.delegate = nil;
         _apollo_compactBackEdgeGesture = nil;
@@ -3898,12 +3504,13 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
     _apollo_primaryApolloBackGestureWasEnabled = _apollo_primaryApolloBackGesture.enabled;
     _apollo_detailApolloBackGestureWasEnabled = _apollo_detailApolloBackGesture.enabled;
     _apollo_primaryApolloBackGesture.enabled = NO;
-    _apollo_detailApolloBackGesture.enabled = NO;
+    _apollo_detailApolloBackGesture.enabled = detail.viewControllers.count > 1 &&
+        _apollo_detailApolloBackGestureWasEnabled;
+    detailPopGesture.enabled = detail.viewControllers.count > 1 && _apollo_detailPopGestureWasEnabled;
 
     UIPanGestureRecognizer *edge = [[UIPanGestureRecognizer alloc]
         initWithTarget:self action:@selector(apollo_compactBackEdgeGestureChanged:)];
-    UIUserInterfaceLayoutDirection direction = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:
-        detail.view.semanticContentAttribute];
+    UIUserInterfaceLayoutDirection direction = detail.view.effectiveUserInterfaceLayoutDirection;
     _apollo_compactBackUsesRightEdge = direction == UIUserInterfaceLayoutDirectionRightToLeft;
     edge.minimumNumberOfTouches = 1;
     edge.maximumNumberOfTouches = 1;
@@ -3960,7 +3567,12 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
     [detail setNavigationBarHidden:YES animated:NO];
     [primary setNavigationBarHidden:restorePrimaryHidden animated:NO];
 
+    __weak ApolloPaneSplitViewController *weakOwner = self;
     void (^complete)(void) = ^{
+        ApolloPaneSplitViewController *self = weakOwner;
+        if (!self) return;
+        self->_apollo_rootInteractiveTransition = nil;
+        ApolloPaneSetNativeInteractiveTransition(primary, nil);
         if (detail.viewControllers.firstObject != detailRoot) {
             self->_apollo_compactBackInProgress = NO;
             UIViewController *currentRoot = detail.viewControllers.firstObject;
@@ -4019,6 +3631,11 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
                   (long)self.apollo_tabIndex);
     };
     void (^restoreCancelled)(void) = ^{
+        ApolloPaneSplitViewController *self = weakOwner;
+        if (!self) return;
+        [self->_apollo_rootInteractiveTransition cancelInteractiveTransition];
+        self->_apollo_rootInteractiveTransition = nil;
+        ApolloPaneSetNativeInteractiveTransition(primary, nil);
         self->_apollo_compactBackInProgress = NO;
         if (!self.isCollapsed || self.apollo_detailIsEmpty) {
             [primary setNavigationBarHidden:restorePrimaryHidden animated:NO];
@@ -4072,25 +3689,15 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
         // and an accepted coordinator is not contractually required to call a
         // late completion. Poll to the terminal stack as an idempotent watchdog
         // rather than leaving compact chrome permanently half-torn-down.
-        __block dispatch_block_t pollBackSettlement = nil;
-        pollBackSettlement = ^{
-            if (backResolutionFinished) {
-                pollBackSettlement = nil;
-                return;
-            }
-            if ([self apollo_navigationControllerIsTransitioning:primary]) {
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
-                    (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(),
-                    pollBackSettlement);
-                return;
-            }
-            BOOL committed = primary.topViewController == anchor;
-            dispatch_block_t retainedPoll = pollBackSettlement;
-            pollBackSettlement = nil;
-            resolveBack(!committed);
-            (void)retainedPoll;
-        };
-        dispatch_async(dispatch_get_main_queue(), pollBackSettlement);
+        [ApolloPaneTransitionObserver observeOwner:self key:@"compactBack" timeout:6.0
+            ready:^BOOL(ApolloPaneSplitViewController *pane) {
+                return ![pane apollo_navigationControllerIsTransitioning:pane.apollo_primaryNav];
+            } completion:^(ApolloPaneSplitViewController *pane, BOOL timedOut) {
+                // A person may hold an interactive Back for longer than the
+                // watchdog. Never cancel or restore chrome under their finger.
+                if (timedOut && pane->_apollo_rootInteractiveTransition) return;
+                resolveBack(timedOut || primary.topViewController != anchor);
+            }];
     } else {
         complete();
     }
@@ -4102,6 +3709,10 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
 
 - (BOOL)accessibilityPerformEscape {
     if (!_apollo_compactDetailChromeActive) return [super accessibilityPerformEscape];
+    if (self.apollo_detailNav.viewControllers.count > 1) {
+        [self.apollo_detailNav popViewControllerAnimated:!UIAccessibilityIsReduceMotionEnabled()];
+        return YES;
+    }
     ApolloLog(@"[PaneSplit] tab %ld compact accessibility escape accepted",
               (long)self.apollo_tabIndex);
     [self apollo_finishCompactBackToPrimary];
@@ -4117,7 +3728,8 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
     }
     if (gestureRecognizer != _apollo_compactBackEdgeGesture) return YES;
     if (!_apollo_compactDetailChromeActive || !self.isCollapsed ||
-        self.apollo_detailNav.viewControllers.count != 1) return NO;
+        self.apollo_detailNav.viewControllers.count != 1 ||
+        [self apollo_navigationOrTopologyTransitionIsActive]) return NO;
     UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
     CGPoint location = [pan locationInView:pan.view];
     CGPoint translation = [pan translationInView:pan.view];
@@ -4135,26 +3747,37 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
         shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)other {
-    // UIKit may keep its private separator recognizer beneath our 44pt control.
-    // Let both observe the same drag; our absolute preferred-width write is the
-    // authoritative result and this avoids disabling UIKit's own transition
-    // bookkeeping on releases where the separator still participates.
-    return gestureRecognizer.view == _apollo_grabber || other.view == _apollo_grabber;
+    // The divider/root Back owns its touch exclusively. UIKit's column
+    // bookkeeping remains intact without sharing scrolling or voting gestures.
+    return NO;
 }
 
 - (void)apollo_compactBackEdgeGestureChanged:(UIPanGestureRecognizer *)gesture {
-    if (gesture.state != UIGestureRecognizerStateEnded) return;
     CGFloat direction = _apollo_compactBackUsesRightEdge ? -1.0 : 1.0;
-    CGFloat distance = [gesture translationInView:gesture.view].x * direction;
-    CGFloat velocity = [gesture velocityInView:gesture.view].x * direction;
-    CGFloat threshold = MAX(72.0, gesture.view.bounds.size.width * 0.18);
-    if (distance >= threshold || velocity >= 500.0) {
-        ApolloLog(@"[PaneSplit] tab %ld compact edge Back accepted distance=%.0f velocity=%.0f",
-                  (long)self.apollo_tabIndex, distance, velocity);
-        [self apollo_finishCompactBackToPrimary];
-    } else {
-        ApolloLog(@"[PaneSplit] tab %ld compact edge Back cancelled distance=%.0f velocity=%.0f",
-                  (long)self.apollo_tabIndex, distance, velocity);
+    CGFloat width = MAX(1.0, CGRectGetWidth(gesture.view.bounds));
+    CGFloat progress = MIN(1.0, MAX(0.0, [gesture translationInView:gesture.view].x * direction / width));
+    if (gesture.state == UIGestureRecognizerStateBegan) {
+        if (!_apollo_compactPrimaryAnchor ||
+            ![self.apollo_primaryNav.viewControllers containsObject:_apollo_compactPrimaryAnchor]) return;
+        UIPercentDrivenInteractiveTransition *transition = [UIPercentDrivenInteractiveTransition new];
+        transition.completionCurve = UIViewAnimationCurveEaseOut;
+        if (!ApolloPaneSetNativeInteractiveTransition(self.apollo_primaryNav, transition)) return;
+        _apollo_rootInteractiveTransition = transition;
+        // Apollo's native animator and delegate consume its typed interaction
+        // slot. The existing transactional root Back owns commit/cancel; there
+        // is no second simulated animation or speculative stack mutation.
+        [self apollo_performCrossColumnNavigationTransaction:^{ [self apollo_finishCompactBackToPrimary]; }];
+    } else if (gesture.state == UIGestureRecognizerStateChanged) {
+        [_apollo_rootInteractiveTransition updateInteractiveTransition:progress];
+    } else if (gesture.state == UIGestureRecognizerStateEnded ||
+               gesture.state == UIGestureRecognizerStateCancelled ||
+               gesture.state == UIGestureRecognizerStateFailed) {
+        CGFloat velocity = [gesture velocityInView:gesture.view].x * direction;
+        BOOL commit = gesture.state == UIGestureRecognizerStateEnded &&
+            (progress >= 0.35 || (velocity >= 500.0 && progress >= 0.05));
+        if (commit) [_apollo_rootInteractiveTransition finishInteractiveTransition];
+        else [_apollo_rootInteractiveTransition cancelInteractiveTransition];
+        ApolloPaneSetNativeInteractiveTransition(self.apollo_primaryNav, nil);
     }
 }
 
@@ -4218,31 +3841,19 @@ static NSString *ApolloPaneSimColorDescription(UIColor *color, UITraitCollection
 
 - (void)apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:(NSUInteger)generation
                                              nilObservations:(NSUInteger)nilObservations {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-        if (!self->_apollo_topologyMutationInProgress ||
-            self->_apollo_topologyMutationGeneration != generation) return;
-        // A real collapse/expansion delegate callback clears this in @finally.
-        // If a split coordinator is still alive, wait for it rather than
-        // mistaking an ordinary child-navigation coordinator for topology.
-        if (self.transitionCoordinator) {
-            [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:generation
-                                                        nilObservations:0];
-            return;
-        }
-        // UIKit can ask for policy just before attaching its coordinator. Two
-        // consecutive coordinator-free samples avoid releasing the gate in
-        // that hand-off gap, while still recovering an abandoned policy call.
-        if (nilObservations == 0) {
-            [self apollo_releaseOrphanedTopologyGateAfterCollapsePolicy:generation
-                                                        nilObservations:1];
-            return;
-        }
-        self->_apollo_topologyMutationInProgress = NO;
-        ApolloLog(@"[PaneTransition] tab %ld released abandoned topology gate collapsed=%d",
-                  (long)self.apollo_tabIndex, self.isCollapsed);
-        [self apollo_navigationTransitionDidSettle];
-    });
+    (void)nilObservations;
+    __block NSUInteger stableSamples = 0;
+    [ApolloPaneTransitionObserver observeOwner:self key:@"topologyPolicy" timeout:6.0
+        ready:^BOOL(ApolloPaneSplitViewController *pane) {
+            if (!pane->_apollo_topologyMutationInProgress || pane->_apollo_topologyMutationGeneration != generation) return YES;
+            if (pane.transitionCoordinator) { stableSamples = 0; return NO; }
+            return ++stableSamples >= 2;
+        } completion:^(ApolloPaneSplitViewController *pane, BOOL timedOut) {
+            if (pane->_apollo_topologyMutationGeneration != generation) return;
+            pane->_apollo_topologyMutationInProgress = NO;
+            ApolloLog(@"[PaneTransition] topology policy released timeout=%d", timedOut);
+            [pane apollo_navigationTransitionDidSettle];
+        }];
 }
 
 // Collapsing to compact (Slide Over, a narrow Stage Manager window, portrait on

--- a/src/ipad/ApolloPaneTransitionObserver.h
+++ b/src/ipad/ApolloPaneTransitionObserver.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+// Event-local fallback for native transitions that reject late completion
+// registration. No idle timer and no retained controller lifetime.
+@interface ApolloPaneTransitionObserver : NSObject
++ (void)observeOwner:(id)owner key:(NSString *)key timeout:(NSTimeInterval)timeout
+              ready:(BOOL (^)(id owner))ready
+         completion:(void (^)(id owner, BOOL timedOut))completion;
++ (void)cancelOwner:(id)owner;
++ (NSUInteger)activeCountForOwner:(id)owner;
+@end

--- a/src/ipad/ApolloPaneTransitionObserver.m
+++ b/src/ipad/ApolloPaneTransitionObserver.m
@@ -1,0 +1,81 @@
+#import "ApolloPaneTransitionObserver.h"
+#import "ApolloPaneDiagnostics.h"
+#import <objc/runtime.h>
+#import <os/signpost.h>
+
+static char kObservers;
+static os_log_t ApolloPaneTransitionLog(void) {
+    static os_log_t log;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ log = os_log_create("apollofix", "PaneTransitions"); });
+    return log;
+}
+
+@implementation ApolloPaneTransitionObserver {
+    __weak id _owner;
+    NSString *_key;
+    BOOL (^_ready)(id);
+    void (^_completion)(id, BOOL);
+    NSTimeInterval _deadline;
+    BOOL _finished;
+    os_signpost_id_t _signpost;
+}
++ (void)observeOwner:(id)owner key:(NSString *)key timeout:(NSTimeInterval)timeout
+              ready:(BOOL (^)(id))ready completion:(void (^)(id, BOOL))completion {
+    NSAssert(NSThread.isMainThread, @"Pane transitions are main-thread owned");
+    if (!owner) return;
+    NSMutableDictionary *observers = objc_getAssociatedObject(owner, &kObservers);
+    if (!observers) {
+        observers = [NSMutableDictionary dictionary];
+        objc_setAssociatedObject(owner, &kObservers, observers, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    [observers[key] cancel];
+    ApolloPaneTransitionObserver *observer = [self new];
+    observer->_owner = owner;
+    observer->_key = [key copy];
+    observer->_ready = [ready copy];
+    observer->_completion = [completion copy];
+    observer->_deadline = NSProcessInfo.processInfo.systemUptime + MAX(0.1, MIN(timeout, 10.0));
+    if (ApolloPaneTraceEnabled()) {
+        observer->_signpost = os_signpost_id_generate(ApolloPaneTransitionLog());
+        os_signpost_interval_begin(ApolloPaneTransitionLog(), observer->_signpost, "PaneSettlement");
+    }
+    observers[key] = observer;
+    [observer scheduleTick];
+}
+- (void)cancel {
+    if (_finished) return;
+    _finished = YES;
+    _ready = nil;
+    _completion = nil;
+    if (_signpost) os_signpost_interval_end(ApolloPaneTransitionLog(), _signpost, "PaneSettlement");
+}
++ (void)cancelOwner:(id)owner {
+    NSDictionary *observers = objc_getAssociatedObject(owner, &kObservers);
+    for (ApolloPaneTransitionObserver *observer in observers.allValues) [observer cancel];
+    objc_setAssociatedObject(owner, &kObservers, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
++ (NSUInteger)activeCountForOwner:(id)owner {
+    NSDictionary *observers = objc_getAssociatedObject(owner, &kObservers);
+    return observers.count;
+}
+- (void)scheduleTick {
+    __weak ApolloPaneTransitionObserver *weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
+        [weakSelf tick];
+    });
+}
+- (void)tick {
+    if (_finished) return;
+    id owner = _owner;
+    if (!owner) { [self cancel]; return; }
+    BOOL expired = NSProcessInfo.processInfo.systemUptime >= _deadline;
+    if (!expired && !_ready(owner)) { [self scheduleTick]; return; }
+    void (^completion)(id, BOOL) = _completion;
+    [self cancel];
+    NSMutableDictionary *observers = objc_getAssociatedObject(owner, &kObservers);
+    if (observers[_key] == self) [observers removeObjectForKey:_key];
+    completion(owner, expired);
+}
+- (void)dealloc { [self cancel]; }
+@end

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -56,6 +56,13 @@ static NSString *const kApolloRebornFeatureRequestsURL = @"https://apolloreborn.
 static __weak UIViewController *sApolloLastSettingsVC = nil;
 static char kApolloRootNativeSurfaceKey;
 
+static void ApolloRootSettingsPreparePaneText(UITableViewCell *cell, UIViewController *controller) {
+    if (!ApolloPaneSplitControllerFor(controller)) return;
+    cell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody compatibleWithTraitCollection:controller.traitCollection];
+    cell.textLabel.adjustsFontForContentSizeCategory = YES;
+    cell.textLabel.numberOfLines = 0;
+}
+
 static void ApolloApplyRootNativeSurface(UITableViewCell *cell, UIColor *surface) {
     if (!cell || !surface) return;
     cell.backgroundColor = surface;
@@ -250,8 +257,10 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     %orig;
     UIViewController *controller = (UIViewController *)self;
-    if (!previousTraitCollection ||
-        previousTraitCollection.userInterfaceStyle == controller.traitCollection.userInterfaceStyle) return;
+    BOOL sizeChanged = ApolloPaneSplitControllerFor(controller) &&
+        ![previousTraitCollection.preferredContentSizeCategory isEqualToString:controller.traitCollection.preferredContentSizeCategory];
+    if (!previousTraitCollection || (!sizeChanged &&
+        previousTraitCollection.userInterfaceStyle == controller.traitCollection.userInterfaceStyle)) return;
 
     // The native surface captured below may be a trait-resolved color. Drop
     // it before rebuilding so the native rows donate their new appearance,
@@ -285,6 +294,7 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseID];
         }
         cell.textLabel.text = indexPath.row == 0 ? @"Apollo Reborn" : @"Buy Us a Coffee";
+        ApolloRootSettingsPreparePaneText(cell, (UIViewController *)self);
         UIColor *primaryText = ApolloThemeRuntimeColor(ApolloThemeTokenLabel);
         if (primaryText) cell.textLabel.textColor = primaryText;
         cell.imageView.image = indexPath.row == 0
@@ -306,6 +316,7 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseID];
         }
         cell.textLabel.text = title;
+        ApolloRootSettingsPreparePaneText(cell, (UIViewController *)self);
         UIColor *primaryText = ApolloThemeRuntimeColor(ApolloThemeTokenLabel);
         if (primaryText) cell.textLabel.textColor = primaryText;
         cell.imageView.image = indexPath.row == 0
@@ -406,8 +417,16 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == 0) return 52.0;
-    if (indexPath.section == 2) return 52.0;
+    if (indexPath.section == 0 || indexPath.section == 2) {
+        // Native cell text grows at accessibility sizes. Let UIKit measure the
+        // multiline label instead of clipping it inside the ordinary 52pt row.
+        // This is the existing single owner of the root table, not a second
+        // delegate/remapper layered onto Apollo's General screen.
+        if (ApolloPaneSplitControllerFor((UIViewController *)self) &&
+            UIContentSizeCategoryIsAccessibilityCategory(tableView.traitCollection.preferredContentSizeCategory))
+            return UITableViewAutomaticDimension;
+        return 52.0;
+    }
     return %orig;
 }
 


### PR DESCRIPTION
Unify navigation chrome and contextual search, give detail content a readable width, and coalesce geometry work. Add sidebar workflows, focus support, and explicit transition observation.

Stacked on `je/ipad-04-coordination`; review this PR against that base.

Validation: Simulator target compiled and linked. Pure width policy and transition-observer checks pass at the validation tip.

Part of the replacement stack for #886. The complete runtime stack remains experimental and opt-in. These draft slices are for review in order; do not ship an intermediate navigation implementation. Foldable/resizable-phone support is a separate follow-up. Existing device-only and performance validation gaps remain recorded in the validation PR.

Review order: #1053 → #1054 → #1055 → #1056 → #1057 → #1058; resizable iPhone support: #1059.
