### PR TITLE
iPad panes: simulator probes, policy tests and audit records

### DIFF
--- a/IPAD_PANE_PR_886_IMPLEMENTATION.md
+++ b/IPAD_PANE_PR_886_IMPLEMENTATION.md
@@ -1,0 +1,1039 @@
+# iPad Pane Layout PR #886 — Implementation and Verification Tracker
+
+## Redesign follow-up — 7 September 2026
+
+All fourteen redesign work packages and seventeen audit findings now have source
+implementations in the working tree; see
+[the implementation/verification ledger](plans/003-ipad-pane-implementation-results.md).
+This includes unified chrome and system Find, compact list density, interactive
+Back, scene ownership, bounded settlement, visible-only divider scheduling,
+readable text, input ownership, sidebar links and a simulator-only phone probe.
+
+The existing task evidence below remains historical. **Device/OS/peripheral and
+Instruments gates A–G remain open.** New simulator evidence must not be treated
+as a physical 120 Hz performance result or actual continuous window resizing.
+
+Reviewed branch: `je/ipad-pane-layout`
+Review baseline: `5f6ea269d14904d02817d4335ef2535e708b0d70`
+
+This tracked file is the source of truth for taking the experimental iPad pane layout
+from review findings to merge-ready behavior. Tasks are ordered by dependency,
+not by the numbering in the review report.
+
+## Completion rules
+
+- `[ ]` — not started.
+- `[~]` — implementation or verification is in progress.
+- `[x]` — implementation is complete and its focused simulator scenario plus
+  the standard pane smoke checks passed.
+- `[!]` — implementation may be complete, but the task still requires a real
+  device, OS version, external service, accessibility peripheral, or Instruments
+  verification that the simulator cannot honestly provide.
+- Every completed task records the tested commit, commands/scenario, evidence,
+  and any remaining coverage limitation.
+- A successful build alone is not enough to mark a behavioral task complete.
+- After every task, re-run the standard pane smoke checks before moving on.
+
+## Standard pane smoke checks
+
+1. Build and launch with `scripts/run-in-sim.sh --glass --drive`.
+2. Confirm `apollofix` logs show pane installation for all five tabs.
+3. Open a Home post in detail; verify primary remains visible and usable.
+4. Switch Home → Search → Inbox → Profile → Settings → Home.
+5. Exercise Back in detail, then select a different primary item.
+6. Exercise regular → compact → regular and confirm the visible destination,
+   Back path, primary/detail ownership, and navigation-bar geometry.
+7. Relaunch once without rebuilding and confirm pane/sidebar state is coherent.
+8. Inspect the captured screenshot and recent `apollofix` logs for exceptions,
+   UIKit hierarchy warnings, routing loops, or layout regressions.
+9. Reset every simulator-only presentation override (including forced compact
+   mode) and capture a final regular-width screenshot. A task is not complete
+   while the shared simulator is still displaying a synthetic test state.
+
+## Dependency-ordered implementation tasks
+
+### Navigation foundations
+
+- [x] **01 — Return the real primary and detail navigation controllers.**
+  Replace direct-column class inference in the shared helpers with the pane's
+  explicit column API, while preserving a generic UIKit fallback for unrelated
+  split controllers. Audit AutoHideTabBar, Liquid Glass, User Avatars, and
+  Direct Chat callers against the returned stacks.
+  - Focused simulator test: populate detail; prove enumeration returns primary
+    and the inner detail nav exactly once, never the wrapper; repeat collapsed.
+  - Evidence: `navdump` returned exactly two controllers for every pane. Home's
+    secondary was the inner Apollo nav with `[Apollo.CommentsViewController]`,
+    parented by `ApolloPaneColumnHostViewController`; UIKit's wrapper was absent.
+    The result remained correct through compact collapse and re-expansion. The
+    stock iPhone layout still returned exactly one controller per tab.
+
+- [x] **02 — Make compact navigation a coherent, escapable stack.**
+  Preserve a native Back path from a root detail destination to its list when
+  the split collapses, without exposing duplicate nested navigation bars.
+  - Focused simulator test: open a root-only thread, collapse, use button Back,
+    edge Back, VoiceOver escape equivalent where available, then expand.
+
+- [x] **03 — Make visible-controller discovery match the actual compact column.**
+  Return the populated detail controller when secondary survives collapse and
+  the list controller otherwise; require an attached visible view where useful.
+  - Focused simulator test: present alert/share-sheet probes from populated and
+    empty compact panes and verify their presenter hierarchy.
+
+- [x] **04 — Classify navigation performed while compact.**
+  Preserve logical list/detail ownership through compact pushes and migrate it
+  correctly when the window expands.
+  - Focused simulator test: collapse empty → open post → expand; repeat with an
+    existing detail stack and with Back/Forward history.
+  - Evidence: on the worktree based on `5f6ea269`, an empty compact pane built
+    `[RedditList, Posts, Comments]` in the one physical stack and expansion
+    migrated the logical detail suffix to `[Comments]`, leaving
+    `[RedditList, Posts]` in primary. Popping Comments before expansion left
+    detail empty. Apollo's own Forward action re-pushed the popped Comments
+    controller through the router and expansion again produced the correct two
+    stacks. A detail populated before collapse survived secondary collapse and
+    re-expansion unchanged. All five tab panes attached in regular width, a
+    no-build relaunch restored regular two-column state, `git diff --check`
+    passed, and `make package` produced
+    `com.apollo.reborn_3.5.1-27+debug_iphoneos-arm.deb`.
+
+- [!] **05 — Repair deep links, handoff, notification/Siri entry points, and
+  cold-start stack normalization.**
+  Update Apollo-facing hierarchy assumptions and classify stacks created before
+  pane installation.
+  - Simulator coverage: killed/warm universal links and debug route injection.
+  - Device/external coverage: notification taps, handoff, Siri, restoration.
+  - Evidence: the native AppDelegate URL route now sees a scoped compatibility
+    hierarchy and routed a warm Reddit thread into detail without replacing the
+    real split/tab hierarchy. A pre-install cold injection built Apollo's stock
+    `[RedditList, Posts, Comments]` stack; pane construction normalized it to
+    primary `[RedditList, Posts]` and detail `[Comments]`. Cold and warm
+    `apollo://reborn/settings/theme-manager` routes selected Settings and put
+    Theme Manager in its detail column. Native `Search` and
+    `FavoriteSubreddit` UIApplication shortcuts completed successfully; Search
+    selected tab 3 and focused through Apollo's indexed-child path, while the
+    favourite route pushed Posts on the selected primary stack. The router now
+    hooks ApolloNavigationController's actual ObjC push shim, and a weak owner
+    map kept routing correct during the synchronous interval after an offscreen
+    tab was selected but before UIKit reattached its containment tree. Compact
+    URL routing expanded with Comments in detail, all five tabs switched and
+    reattached, a clean relaunch ended in regular width with no forced compact
+    override, and the final screenshot showed the normal two-column empty
+    state. `git diff --check` passed and the device build produced
+    `com.apollo.reborn_3.5.1-28+debug_iphoneos-arm.deb`.
+  - Remaining gate: Xcode 27 did not deliver `simctl openurl` custom-scheme
+    callbacks to the re-signed app, so deterministic simulator-only injections
+    exercised the exact AppDelegate/SceneDelegate methods instead. Real APNs
+    notification taps, cross-device Handoff, Siri intents, and UIKit state
+    restoration still require their external/device environments.
+
+- [x] **06 — Complete Inbox and remaining index/detail routing.**
+  Route messages, author profiles, subreddit/rules destinations, and modern
+  Inbox quick actions consistently using the rightward-only ownership rule.
+  - Focused simulator test: each tab's index remains on the left while each
+    classified destination opens on the right with correct Back behavior.
+  - Evidence: the real signed-in Inbox opened with Boxes alone in primary and
+    Inbox in detail. Selecting Messages replaced detail with its Inbox list;
+    selecting a real thread produced `[InboxView, PrivateMessage]`, and the
+    column-aware Back probe returned to Inbox without touching Boxes. Tapping
+    that conversation's username appended Profile in detail. Independently,
+    tapping a feed author replaced stale detail with Profile while preserving
+    the complete RedditList/Posts/subreddit stack on the left. A real subreddit
+    menu routed Sidebar to detail, Sidebar's Rules button appended Rules, Back
+    returned to Sidebar, and the direct Rules menu route correctly replaced the
+    detail root. Modern Chat and Modmail notification URLs each produced one
+    `ApolloDirectChatWebViewController` in detail and kept InboxList primary;
+    native Modmail with the modern preference off produced the native
+    ModmailInbox detail instead. Native-Modmail normalization now happens before
+    cross-column re-homing, removing the old source-order dependency between the
+    pane and modern-mailbox hooks. A compact/regular cycle preserved populated
+    Home and Inbox primary/detail stacks exactly. That cycle also exposed and
+    fixed iPadOS truncating an empty-detail primary stack from
+    `[RedditList, Posts]` to `[RedditList]`: collapse now transactionally restores
+    only a strict prefix of the captured primary stack. The simulator ended in
+    regular width. `git diff --check` passed and the device build produced
+    `com.apollo.reborn_3.5.1-29+debug_iphoneos-arm.deb`.
+
+### State, history, and transition safety
+
+- [x] **07 — Centralize and preserve sidebar visibility ownership.**
+  Prevent per-pane state from fighting the global tab sidebar; do not overwrite
+  a user's persistent choice or strand an automatically hidden sidebar after
+  relaunch. Reconsider whether automatic hiding should exist at all.
+  - Focused simulator test: manual and automatic show/hide across all tabs,
+    detail clear, rotation/compact transitions, termination, and relaunch.
+  - Evidence: removed pane-driven auto-hide entirely. UIKit's one global
+    `UITabBarControllerSidebar` is now the sole visibility owner; production has
+    no `sidebar.hidden` writer and no per-pane ownership flags. This fixes the
+    concrete failure where one populated tab hid the global sidebar, another
+    pane could not restore it, and UIKit carried that stranded state into a
+    later launch. Using UIKit's real `Toggle sidebar` control, the visible
+    sidebar stayed visible while Comments filled detail, through all five tab
+    selections, and across forced compact/regular transitions; navigation
+    stacks were unchanged and logs contained no pane visibility writes. With
+    the sidebar closed, classified detail routing and all tabs remained
+    reachable through UIKit's floating tab bar. A no-build termination/relaunch
+    restored UIKit's own closed-overlay state while the two content columns
+    remained intact, confirming the tweak no longer forces or persists a
+    competing preference. The simulator ended regular with no compact override.
+    `git diff --check` passed and the device build produced
+    `com.apollo.reborn_3.5.1-30+debug_iphoneos-arm.deb`.
+
+- [x] **08 — Clear Apollo forward history when detail is replaced.**
+  Invalidate `poppedViewControllers` or introduce a detail-history generation
+  when a new primary selection starts a new branch.
+  - Focused simulator test: A → child → Back → select B → Forward must not
+    resurrect A; repeat with keyboard/gesture routing where available.
+  - Evidence: Apollo's private history is a native Swift
+    `[UIViewController]`, not an Objective-C `NSArray`. Added an ABI-safe Swift
+    bridge and a runtime-gated pane helper that validates the exact Apollo
+    navigation class, main-thread access, and the expected one-word ivar layout
+    before clearing it. Semantic detail replacements, detail-to-placeholder
+    clears, and compact logical ownership migrations now invalidate only the
+    affected physical histories; ordinary push/pop and current-branch Forward
+    remain Apollo-native. The simulator bridge now accepts
+    `navforward primary|detail`. On a signed-in simulator, the exact real-data
+    chain Inbox → Comments → Back → Moderator Mail → Forward cleared native
+    history `1 -> 0` and remained exactly `[ModmailInbox]`; a fresh Inbox →
+    Comments → Back → Forward restored `[Inbox, Comments]`. A separate Home
+    primary Back/Forward survived an Inbox detail replacement. Comments →
+    Profile → Back → new subreddit feed cleared detail to the placeholder and
+    Forward stayed on the placeholder. A compact Chat route migrated back to
+    regular width as detail, cleared the prior detail history, and Forward did
+    not resurrect the old controller in either column. The simulator ended in
+    regular width with compact override off. `git diff --check` passed and the
+    device build produced
+    `com.apollo.reborn_3.5.1-31+debug_iphoneos-arm.deb`.
+
+- [x] **09 — Clear or reconcile stale detail when primary context changes.**
+  Cover pops, tab reset/reselection, in-place feed changes, title menus, and
+  primary-root replacement—not only classified Posts pushes.
+  - Focused simulator test: change every supported primary context and verify
+    detail is retained only when it still belongs to that context.
+  - Evidence: detail ownership is now tracked against both the exact primary
+    source and its semantic feed controller, with a stable synchronous feed
+    scope and coalesced reconciliation after navigation settles. Detail was
+    retained across tab switches, title-menu cancellation, sort changes, a
+    no-op primary stack replacement, and regular/compact/regular migration.
+    It was cleared after primary pop, primary push/root replacement, native tab
+    reselection reset, an in-place Home → Apple feed change, and account changes
+    on the account-scoped Home/Inbox/Profile tabs while Settings detail stayed
+    intact. Compact account clearing removed the logical detail suffix from
+    `[RedditList, Posts, Comments]`, invalidated Forward, and expanded to clean
+    primary `[RedditList, Posts]` plus the detail placeholder. All five tabs
+    passed the final regular-width smoke, recent logs had no navigation/hierarchy
+    warnings, `git diff --check` passed, and the device build produced
+    `com.apollo.reborn_3.5.1-32+debug_iphoneos-arm.deb`.
+
+- [x] **10 — Stop mutating navigation items for arbitrary pushes.**
+  Restrict forced Back/leading-item behavior to known pane destinations.
+  - Focused simulator test: known detail, known list, composer, settings, login,
+    and modal-like controllers retain their intended leading items.
+  - Evidence: the two blanket post-push mutations were replaced by one shared
+    logical-detail policy whose exact allowlist contains only the demonstrated
+    tab-root exception, `ProfileViewController`. Deterministic unknown probes on
+    both primary and detail preserved `hidesBackButton=YES`,
+    `leftItemsSupplementBackButton=NO`, and the identical native left item. Real
+    Comments roots, a rightward Posts list, Reborn Settings → Theme Manager,
+    Web Login, New Comment, alert, and share flows all retained their native
+    leading controls and stack ownership. Regular and compact Comments → Profile
+    produced exactly one Back plus Profile's Accounts/action items, and Back
+    returned to Comments. Compact chrome now removes only its injected item by
+    identity instead of restoring stale item/flag snapshots: a simulated native
+    `Dynamic` item and both changed Back flags survived expansion, two cycles
+    produced no duplicate pane item, and the final regular-width five-tab smoke
+    was clean. `git diff --check` passed, the warning scan found no navigation or
+    hierarchy diagnostics, and the device build produced
+    `com.apollo.reborn_3.5.1-33+debug_iphoneos-arm.deb`.
+
+- [x] **11 — Serialize cross-column changes with interactive transitions.**
+  Defer or coalesce replacements until detail push/pop transitions complete.
+  - Focused simulator test: completed and cancelled detail pops while rapidly
+    selecting multiple primary rows (latest wins), plus route/clear ordering.
+    Repeat through empty-primary-survivor and populated-secondary-survivor
+    regular → compact → regular transitions. Prove stale/deallocated sources are
+    dropped, Forward/context ownership is correct, compact Back/chrome remains
+    coherent, the queue drains, and no nested/unbalanced transition, hierarchy,
+    crash, or dead-gesture diagnostics appear.
+  - Completed 2026-08-10. Cross-column mutations now use a latest-intent queue
+    gated by navigation gestures, transition coordinators, topology changes and
+    compact Back settlement. Public primary pushes, pops and stack replacements
+    carry source-aware mutation provenance; committed app navigation always
+    invalidates stale repair work. The iPadOS 26 compact merge is repaired only
+    for its observed `popToViewController:animated:YES` identity shape under the
+    same immutable restore lineage, expected stack and mutation owner, including
+    the compact→regular generation handoff. Rejected coordinator registration,
+    cancelled gestures and late UIKit writes cannot strand the queue or chrome.
+    Simulator coverage passed deterministic latest-wins gating, real Apollo edge
+    cancel and commit, compact Back followed immediately by expansion, a newer
+    route arriving during compact Back, and account-context clearing. The exact
+    regression that reduced Home from `[subreddit list, feed]` to the root now
+    logs the topology normalization capture and finishes with primary depth 2;
+    the newer-route race finishes with `Transition Probe NewDuringBackFinal` in
+    detail and `{blocked=0 active=0 pending=0}`. The final screenshot is
+    `.sim/task11-final-regular.png`; `git diff --check` passed, no Task 11 error,
+    hierarchy or dead-gesture diagnostics appeared, and the device build produced
+    `com.apollo.reborn_3.5.1-35+debug_iphoneos-arm.deb`.
+
+- [x] **12 — Make pane installation atomic and exception-safe.**
+  Construct and validate before committing, isolate sidebar setup, and restore
+  the original hierarchy on failure so opt-in cannot create a launch crash loop.
+  - Focused simulator test: injected construction/configuration failures at
+    each phase leave all original tab children intact and launchable.
+  - Evidence: installation is now an explicit per-tab-controller transaction.
+    It snapshots the exact child identities/order, selected child/index, every
+    original navigation stack, and each controller's opaque-bar flag; detaches
+    stock children before staging so no navigation controller has two parents;
+    requires every eligible tab to construct; validates primary/detail
+    containment, owner registrations, tab-item identity, and exact cold-stack
+    reconstruction; and publishes the converted array only after all five panes
+    pass. Factory exceptions clean up gesture targets/owner-map entries and
+    containment, pending callbacks are invalidated, mixed or partial hierarchies
+    are rejected, and any core exception restores the complete stock snapshot.
+    Sidebar setup has its own exception boundary and restores the prior mode,
+    retaining the coherent floating-tab-bar fallback rather than undoing valid
+    panes. Simulator-only launch injection covered `preflight`, stock detach,
+    construction begin/nil/complete, detail creation, cold normalization,
+    primary/secondary attachment, staging validation, child-array commit,
+    selection commit, and final postcondition; every core phase reported five
+    original `ApolloNavigationController` children, zero panes, and
+    `rollbackExact=true`. Both sidebar-before/after failures retained five live
+    panes with `active=true` and mode 0. A rollback launch selected all five
+    original tabs successfully and stayed alive; the injection-free control
+    selected all five pane tabs and ended with 5/5 panes active. Final screenshot:
+    `.sim/task12-final.png`. `git diff --check` passed, the simulator build passed,
+    and the pinned iOS 26 device build produced
+    `com.apollo.reborn_3.5.1-36+debug_iphoneos-arm.deb`.
+
+- [x] **13 — Use resolved column/display state at constrained regular widths.**
+  Stop treating `!isCollapsed` as proof that primary is tiled and visible;
+  provide a recoverable show-list affordance whenever UIKit hides it.
+  - Focused simulator test: regular, compact, overlay, and secondary-only debug
+    modes; real Stage Manager validation remains a device gate.
+  - Evidence: centralized resolved-state helpers now use iOS 26's
+    `isShowingColumn:` (with documented display-mode fallback below iOS 26) and
+    distinguish tiled `OneBesideSecondary`, foreground `OneOverSecondary`,
+    hidden-primary `SecondaryOnly`, and true compact collapse. Detail geometry
+    and the divider grabber operate only on a settled, intersecting tiled
+    boundary; overlay/hidden frames can no longer drive constraints or display a
+    fake resize handle. Visible-controller lookup now presents from primary in
+    overlay, detail/placeholder in SecondaryOnly, and the semantic populated
+    column when tiled. Hidden-primary deferred sources are rejected, and a
+    primary-overlay row selection dismisses the overlay after committing detail.
+    Because UIKit documents `displayModeButtonItem` as unsupported for
+    column-style splits (and Apollo hides the wrapper bar), the visible inner
+    detail nav owns one identity-merged native bar button only in resolved
+    SecondaryOnly. It is labelled `Show List`, calls public `showColumn:Primary`,
+    preserves destination items/Back policy, and is absent from tiled, visible
+    overlay and compact states; regular display transitions are logged and
+    reconciled outside layout passes. The simulator reproduced the exact former
+    trap (`collapsed=0 primaryAPI=0 primaryGeometry=0`) with one enabled button;
+    idb exposed `ApolloPaneShowPrimary`, label `Show List`, Button trait and the
+    correct hint. Activation resolved to overlay with primary API/geometry 1,
+    item count 0 and idle navigation state. Five repeated hide/recover cycles
+    never duplicated the item. Populated compact had regular item count 0 and
+    compact Back count 1; reset restored tiled mode and the same detail stack.
+    Empty-detail SecondaryOnly moved the item to the placeholder and recovered;
+    tab 0 → 4 → 0 preserved each pane's independent mode; the native-item
+    mutation probe remained `retained=1`; and visible presentation in
+    SecondaryOnly resolved to the attached placeholder rather than hidden
+    primary. Screenshots: `.sim/task13-regular.png`, `task13-overlay.png`,
+    `task13-secondary.png`, `task13-recovered-overlay.png`, `task13-compact.png`,
+    and `task13-final.png`. Real Stage Manager continuous resizing remains the
+    stated device gate. `git diff --check`, simulator build and pinned iOS 26
+    device build passed; package:
+    `com.apollo.reborn_3.5.1-37+debug_iphoneos-arm.deb`.
+
+- [x] **14 — Preserve master selection semantics.**
+  Keep the row corresponding to visible detail selected in Settings, Inbox, and
+  other list/detail sources, including the VoiceOver selected trait.
+  - Focused simulator test: selection follows detail replacement, Back, clear,
+    tab changes, and compact/expanded transitions.
+  - Evidence: pane-owned selection intents now retain a stable item identity
+    for Texture/ListAdapter sources, re-resolve rows after updates, and keep
+    exactly one visible master row selected while its detail branch remains
+    active. UIKit and Texture cells expose `UIAccessibilityTraitSelected` in
+    regular mode; compact mode retains only the logical selection and restores
+    the visual/accessibility selection on expansion. Real Home, Inbox, native
+    Settings, and the tweak-owned Apollo Reborn Settings row passed replacement,
+    detail continuation/Back, clear, five-tab switching, and compact/regular
+    scenarios. The injected Settings rows now explicitly stage an intent before
+    their early-return push path. A no-build relaunch restored five coherent
+    regular pane trees. `git diff --check`, the simulator build, and the pinned
+    iOS 26 device build passed; package:
+    `com.apollo.reborn_3.5.1-7+debug_iphoneos-arm.deb`.
+
+### Performance and layout polish
+
+- [x] **15 — Restore lazy loading for offscreen tabs.**
+  Move view-backed pane configuration into lifecycle methods so all five pane
+  hierarchies are not forced to load during scene connection.
+  - Focused simulator test: record which pane views load before/after visiting
+    each tab; compare cold-launch timing and resident memory.
+  - Evidence: pane theming, grabber creation, layout invalidation, and
+    navigation-gesture observation now begin in `viewDidLoad`; trait and display
+    refresh paths use `viewIfLoaded` and cannot materialize an offscreen pane.
+    A simulator-only `loadstatus` probe showed one loaded/attached pane after
+    cold launch, then loaded counts 2, 3, 4, and 5 only as the four untouched
+    tabs were first selected; exactly one pane remained attached throughout.
+    The comparable cold install interval fell from about 1.39s to 0.62–0.68s,
+    and a single fixed-window RSS sample fell from 563,920KB to 554,608KB
+    (informational simulator measurements, not release-gate performance data).
+    Deferred gesture observers remained functional through detail Back and
+    compact/regular transitions. Injected `configure-secondary:3` failure still
+    rolled back exactly without loading cleanup views. `git diff --check`, the
+    simulator build, and pinned iOS 26 device build passed; package:
+    `com.apollo.reborn_3.5.1-8+debug_iphoneos-arm.deb`.
+
+- [x] **16 — Remove hot-scroll allocations outside pane mode.**
+  Add direct-navigation/allocation-free fast paths for AutoHideTabBar scans.
+  - Focused simulator test: allocation/signpost comparison on iPhone layout-off
+    and iPad pane-on scrolling; behavior must remain unchanged.
+  - Evidence: the hot `setContentOffset:` predicate now checks stock tab
+    navigation controllers directly and pane tabs through their explicit
+    primary/detail accessors. It uses the allocating shared enumerator only for
+    an unrelated generic split-controller fallback. A bounded simulator probe
+    ran 50,000 aggregate scans on the stock iPhone layout (`directScans=50000`)
+    and 50,000 on the iPad pane layout (`paneScans=50000`); both reported
+    `genericFallbackArrayScans=0` and `pass=1`. Enabling/disabling the policy on
+    both layouts retained the requested predicate and resolved native behavior
+    (`OnScrollDown=2`, `Never=1`). Real feed swipes, the standard pane smoke,
+    no-build relaunch, `git diff --check`, simulator build, and pinned iOS 26
+    device build passed; package:
+    `com.apollo.reborn_3.5.1-9+debug_iphoneos-arm.deb`.
+
+- [x] **17 — Remove layout-driving writes from `viewDidLayoutSubviews`.**
+  Move host geometry and grabber synchronization to stable transition/safe-area
+  callbacks, caching resolved geometry to avoid feedback passes.
+  - Focused simulator test: repeated rotation and scripted compact/regular
+    changes with layout-pass logging; Stage Manager drag remains a device gate.
+  - Evidence: production builds no longer override `viewDidLayoutSubviews` in
+    either the detail-column host or pane container. Safe-area, size-transition,
+    split-display, collapse/expand, and appearance callbacks feed coalesced
+    post-transition refreshes; cached constraint constants, grabber visibility,
+    and grabber frames suppress redundant writes. Eight consecutive simulator
+    rotations produced eight pane passes/eight pane geometry writes and sixteen
+    read-only host passes with zero host constraint writes. Five consecutive
+    compact/regular cycles stayed bounded at fifteen pane passes and ten host
+    passes, with cached writes tracking only real topology changes and no
+    follow-on feedback passes. Populated-detail
+    portrait/landscape geometry and the standard pane smoke passed. Simulator
+    and pinned iOS 26 device builds passed; package:
+    `com.apollo.reborn_3.5.1-10+debug_iphoneos-arm.deb`. Continuous Stage
+    Manager divider dragging remains release gate D/F device coverage.
+
+- [x] **18 — Eliminate sidebar-triggered content reflow instability.**
+  Stabilize column widths when opening detail, preferably by leaving sidebar
+  visibility user-controlled.
+  - Focused simulator test: first and repeated detail loads show no large
+    sidebar-driven width jump or repeated Texture remeasurement.
+  - Evidence: Task 7's production fix already removed the causal mutation, so
+    Task 18 required no second sidebar policy: UIKit remains the only owner of
+    its global sidebar visibility. A simulator-only 12-second sampler observed
+    240 resolved frames while the real 280pt UIKit sidebar stayed visible and a
+    real Home text post ran empty detail → Comments → clear → Comments. Sidebar
+    state remained visible (`sidebarChanges=0`), the primary split/navigation
+    width stayed 760pt (`range=0`), and the live primary and detail ASTableViews
+    each recorded zero post-baseline width changes (`largestTextureWidthJump=0`,
+    `pass=1`). First/repeated screenshots retained identical three-region
+    geometry. The standard five-tab, detail continuation/Back,
+    regular/compact/escape/regular smoke and a no-build relaunch passed; the
+    simulator was returned to the user's original bottom-tab-bar preference.
+    `git diff --check`, the Liquid Glass simulator build, and the pinned iOS 26
+    device build passed; package:
+    `com.apollo.reborn_3.5.1-11+debug_iphoneos-arm.deb`.
+
+- [x] **19 — Add readable-width treatment for text-heavy detail content.**
+  Constrain comments/settings text to a centered readable guide without
+  restricting media and intentionally full-width surfaces.
+  - Focused simulator test: representative short/long comments, Settings,
+    Dynamic Type, media, portrait, and landscape screenshots.
+  - Evidence: the detail host now applies an owned horizontal
+    `additionalSafeAreaInsets` delta only to text-post Comments tables and
+    table-backed Settings destinations. The table and navigation/background
+    stay full width while safe-area-following cell content is centered at a
+    680pt maximum; accessibility Dynamic Type relaxes the maximum to 760pt.
+    Apollo's realized `CommentsHeaderCellNode`/`RichMediaHeaderCellNode`
+    identifies prose versus media when its Swift Optional `link` is not
+    ObjC-readable. A 756pt text thread resolved to 680pt content (38pt per
+    side), the same-width image thread stayed full width (zero inset), and a
+    744pt native Settings form resolved to 680pt (32pt per side). At
+    accessibility-large the Settings form expanded back to its full 744pt;
+    portrait text/settings widths recomputed to 680pt without clipping.
+    Landscape/portrait screenshots, compact/regular transitions, the Liquid
+    Glass simulator build, `git diff --check`, and the pinned iOS 26 device
+    build passed; package:
+    `com.apollo.reborn_3.5.1-12+debug_iphoneos-arm.deb`.
+
+- [x] **20 — Coordinate divider widths across tab panes.**
+  Maintain a coherent per-scene preferred primary width while allowing UIKit to
+  resolve constrained windows safely.
+  - Focused simulator test: resize one tab, switch through all tabs, relaunch,
+    and confirm intentional persistence without compact corruption.
+  - Evidence: each window scene now owns one clamped 340–480pt absolute list
+    preference. Intentional divider/accessibility/keyboard adjustments publish
+    it to every sibling pane and persist it under the scene session identifier;
+    UIKit's resolved width remains read-only, so rotation, compact mode, and
+    constrained windows cannot corrupt the preference. A 470pt simulator
+    preference propagated to all five panes without preloading the four cold
+    tabs, survived compact → regular unchanged, and restored at 470pt after a
+    full app relaunch. Simulator and pinned iOS 26 device builds passed;
+    package: `com.apollo.reborn_3.5.1-13+debug_iphoneos-arm.deb`.
+
+- [x] **21 — Make the divider/grabber native and accessible.**
+  Prefer UIKit's system affordance, or provide a real adjustable control with
+  label, value, hint, hit target, pointer, and keyboard behavior.
+  - Focused simulator test: accessibility tree, pointer/drag behavior, keyboard
+    resizing, and every resolved display mode.
+  - Evidence: the decorative 5x44pt marker is now centered inside a real
+    44x64pt `UIControl` with a horizontal pan recognizer, pointer highlight,
+    adjustable accessibility semantics (`Column Divider`, value, and hint),
+    and Option-Left/Option-Right keyboard commands. Accessibility increment and
+    keyboard narrow changed 460 → 480 → 460 through the production preference
+    path. idb exposed it as one Slider at the exact 44x64pt divider frame with
+    `AXValue="460 points"`; pointer/key-command introspection found one pointer
+    interaction and two commands. It was visible only in tiled regular mode
+    and hidden in overlay, secondary-only, and compact modes, returning at the
+    same position/value after reset. Xcode 27's known broken idb HID path could
+    not supply a physical drag, so final pointer/drag feel remains a device
+    gate. Simulator and pinned iOS 26 device builds passed; package:
+    `com.apollo.reborn_3.5.1-13+debug_iphoneos-arm.deb`.
+
+- [x] **22 — Refresh pane-owned colors on live theme changes.**
+  Observe the canonical theme notification rather than relying on trait changes.
+  - Focused simulator test: change stock/custom themes and light/dark appearance
+    with each tab both empty and populated.
+  - Evidence: every loaded pane now observes Apollo's canonical
+    `ApolloSpecificThemeChanged` notification and reapplies the scene ground,
+    divider accent, and any retained empty-detail placeholder background/icon;
+    observer removal is tied to pane deallocation. The existing trait callback
+    remains the light/dark dynamic-color path. A simulator state probe confirmed
+    the notification callback on every visited tab, including unloaded and
+    loaded placeholders plus populated Home and Inbox detail stacks, with the
+    active `#EAEBED` page and `#8839EF` accent consistently reapplied. The
+    Liquid Glass simulator build, `git diff --check`, and pinned iOS 26 device
+    build passed; package:
+    `com.apollo.reborn_3.5.1-14+debug_iphoneos-arm.deb`.
+
+### Settings, compatibility, privacy, and integration
+
+- [x] **23 — Make restart-deferred Settings rows reflect live state.**
+  Separate persisted desired state from active process state after choosing
+  Later so dependent rows do not lie about the current hierarchy.
+  - Focused simulator test: enable/disable, choose Later, revisit Settings, then
+    restart and verify both intermediate and final row sets.
+  - Evidence: the Multi-Column switch continues to represent the persisted
+    desired value, but its subtitle now explicitly says which change is pending
+    whenever desired and active state differ. The dependent Move Tab Bar to
+    Bottom row keys visibility from `ApolloPaneLayoutActive()`—the hierarchy
+    installed in this process—instead of the newly written default. Toggling
+    reloads the pane row and diffs visibility without mutating
+    `sIPadPaneLayout`, so choosing Later cannot make the screen claim that an
+    unapplied hierarchy is live. Liquid Glass simulator launch,
+    `git diff --check`, and the pinned iOS 26 device build passed; package:
+    `com.apollo.reborn_3.5.1-15+debug_iphoneos-arm.deb`.
+
+- [x] **24 — Correct pre-iOS 18 feature copy and fallback behavior.**
+  Use availability-specific copy or gate the experiment if the retained tab-bar
+  layout cannot meet the feature promise.
+  - Simulator coverage: current runtime copy/gating.
+  - Device/runtime gate: iPadOS 15 and 17.
+  - Evidence: production support is now explicitly gated to iPadOS 18+, where
+    the system tab sidebar exists. The Settings row uses the same support
+    predicate, calls the feature experimental in both title and detail copy,
+    and is absent on unsupported runtimes. Older iPads retain Apollo's native
+    hierarchy instead of receiving a layout that does not match the promise.
+
+- [!] **25 — Make PiP bounds respect actual tab-bar/sidebar visibility.**
+  Use visible intersection/presentation mode instead of `tabBar.window` alone.
+  - Focused simulator test: visible and hidden tab bar, sidebar, compact mode,
+    and videos intersecting the lower edge; real PiP remains a device gate.
+  - Evidence: the midpoint test now intersects the tab bar with the active
+    window and requires it to be visible, opaque, attached to that window, and
+    covering the bottom edge at the video's horizontal midpoint. Hidden,
+    translated, top-positioned, and side-only tab chrome no longer subtracts a
+    phantom full-width bottom inset. The simulator build passed; real PiP and a
+    playing-video lower-edge matrix remain device coverage.
+
+- [!] **26 — Route actions to the correct foreground scene.**
+  Prefer the originating scene and foreground-active key scene over unordered
+  `connectedScenes` enumeration.
+  - Focused simulator test: two simulated windows/scenes with distinct selected
+    tabs and stacks; route from each and verify isolation.
+  - Evidence: common tab discovery now accepts an originating UIWindowScene and
+    otherwise deterministically prefers a foreground-active key scene. Scene
+    URL callbacks preserve that scene through delayed retries and Settings or
+    mailbox routing. A warm Settings route selected tab 4 and placed Theme
+    Manager in its detail column with no hierarchy warning. Apollo's iPad build
+    exposes one scene here, so two-window isolation remains a visionOS/external-
+    display gate.
+
+- [!] **27 — Redact full Reddit destinations from diagnostics.**
+  Log route type and privacy-safe identifiers rather than full URLs.
+  - Focused simulator test: exercise every VisionOS/multiwindow route and inspect
+    exported `apollofix` logs for subreddit/post/comment URL leakage.
+  - Evidence: multiwindow delivery and timeout logs now record only a coarse
+    destination kind (`reddit-post`, `reddit-community`, `reddit-profile`,
+    `reddit-root`, `apollo-route`, or `external-web`). A static scan found no
+    remaining full-URL log in the pane or multiwindow implementation. End-to-end
+    visionOS window creation is still platform-gated.
+
+## Additional release gates
+
+- [ ] **A — Direct Chat return routing follows the actual destination stack.**
+  This is expected to become fixable through tasks 01 and 06, but gets its own
+  regression scenario because mailbox return state is user-visible.
+- [ ] **B — Tab reset, reselection, badges, account/profile item mutations, and
+  scroll-to-top behavior remain native after wrapping tab children.**
+- [ ] **C — Popovers, share sheets, alerts, login, composer, and media viewers
+  present from the visible scene and column in regular and compact layouts.**
+- [ ] **D — Full device/OS/window matrix passes:** iPad mini, 11-inch, 13-inch;
+  portrait/landscape; Split View; Slide Over; Stage Manager continuous resize;
+  external display; supported iPadOS fallback versions and current releases.
+- [ ] **E — Accessibility matrix passes:** VoiceOver, Full Keyboard Access,
+  pointer, Dynamic Type accessibility sizes, Reduce Motion, and RTL.
+- [ ] **F — Performance soak passes:** cold-launch/RSS comparison, scroll
+  allocations, frame-time spikes, main-thread Texture measurement, memory
+  warnings, and a ten-minute resize/rotation leak run.
+- [ ] **G — Simulator IPA bake fallback is transactional and tested for signing
+  failure, insufficient Mach-O padding, malformed/fat binaries, interrupted
+  writes, and idempotence.**
+
+## Verification log
+
+Add one entry per completed task. Never replace prior evidence; append a new
+entry if a later regression requires reopening and re-verifying a task.
+
+<!--
+### Task NN — YYYY-MM-DD — commit <sha>
+
+- Implementation:
+- Focused test:
+- Standard smoke checks:
+- Evidence:
+- Remaining device/external gate:
+-->
+
+### Task 01 — 2026-08-09 — baseline `5f6ea269` + task working tree
+
+- Implementation: `ApolloCommon` now dynamically asks a pane's explicit
+  `apollo_navigationControllerForColumn:` accessor before using its generic
+  UIKit column fallback. Added simulator-only `navdump` evidence tooling.
+- Focused test: launched the real `Apollo-iPad` simulator, opened an actual
+  `Apollo.CommentsViewController` from Home, dumped all five tab stacks in
+  regular mode, forced compact mode, dumped again, then expanded and dumped a
+  third time. Every pane returned primary plus the real nested detail nav once.
+- Standard smoke checks: Home detail routing passed; all five tabs selected via
+  their real floating-tab controls; regular → compact → regular retained the
+  Comments detail; a no-build relaunch installed five panes and enumerated two
+  stacks each. No new exception, hierarchy warning, routing loop, or crash was
+  present in the focused log window.
+- Stock regression check: the same simulator build on the default iPhone
+  returned one direct Apollo navigation controller for each of five tabs.
+- Known baseline issue observed, not introduced by task 01: the tab sidebar
+  relaunched hidden after an earlier automatic hide. This remains task 07.
+- Remaining device/external gate: none for the enumeration fix itself. Direct
+  Chat's return-marker behavior has a separate scenario under release gate A.
+
+### Task 02 — 2026-08-09 — baseline `5f6ea269` + task working tree
+
+- Implementation: compact collapse now hides UIKit's otherwise duplicated
+  outer navigation bar, installs one labelled detail-root Back item, and owns a
+  root-only leading-edge pan plus `accessibilityPerformEscape`. Apollo's private
+  left-edge recognizers and UIKit's nested pop recognizers are disabled only
+  while compact and restored to their exact prior state on Back or expansion.
+  Every successful cross-column escape returns to the captured primary anchor
+  and clears the detached detail stack.
+- Focused test: opened a real Home comments thread, forced compact traits, and
+  confirmed the accessibility hierarchy contained exactly one navigation bar.
+  Back-button tap hit `_UIButtonBarButton`; a 48pt edge drag cancelled without
+  navigating; a committed 788pt edge drag returned to the feed; and the exact
+  accessibility escape action reported `handled=1`. Button, committed edge,
+  and accessibility paths each logged detail clear plus compact Back completion.
+- Standard smoke checks: regular → populated compact → regular, all five real
+  floating-tab controls, detail Back, cancelled/committed gestures, and a
+  no-build relaunch passed. Relaunch installed panes on 5/5 tabs at 1376x1032,
+  restored a 480pt primary plus empty detail, and showed no relevant exception,
+  hierarchy, unbalanced-transition, nested-pop, or layout-loop diagnostics.
+- Build coverage: simulator Liquid Glass build/launch passed repeatedly;
+  `THEOS=/Users/Jordan.Earle/theos make package` passed for the pinned iOS 26
+  device SDK / iOS 14 deployment target.
+- Cleanup: forced compact mode was reset, Apollo was relaunched without a
+  rebuild, and the shared iPad simulator was left in regular two-column mode.
+- Remaining device/external gate: perform a physical VoiceOver two-finger scrub
+  during release accessibility validation; the underlying escape action itself
+  was invoked and verified directly in the simulator.
+
+### Task 03 — 2026-08-09 — baseline `5f6ea269` + task working tree
+
+- Implementation: pane visible-content selection no longer assumes every
+  compact collapse is displayed through primary. It returns the populated,
+  attached detail navigation controller when secondary survived collapse;
+  otherwise it returns the attached primary. Attachment checks use
+  `isViewLoaded`/`viewIfLoaded.window` and do not load detached columns merely
+  to answer a presenter lookup.
+- Focused test: the production `UIWindow.visibleViewController` recursion was
+  driven through simulator-only `visibleprobe` commands. Regular empty resolved
+  attached `PostsViewController`; empty compact resolved the attached primary
+  list; regular populated and populated compact both resolved attached
+  `CommentsViewController`; compact Back then resolved attached
+  `PostsViewController` again.
+- Presentation probes: real `UIAlertController` and `UIActivityViewController`
+  instances were requested from empty-primary and populated-detail compact
+  states. UIKit forwarded both through `ApolloTabBarController`, which was
+  verified as the same containment branch as the requested leaf. Both rendered
+  correctly (including an iPad popover anchor), and no detached-presenter or
+  window-hierarchy warning was logged.
+- Standard smoke checks: regular → compact → regular, compact Back, all five
+  floating-tab destinations, and a no-build relaunch passed. Relaunch installed
+  5/5 panes in regular width with a 480pt primary and emitted no relevant
+  exception, assertion, hierarchy, transition, or layout-loop diagnostics.
+- Build coverage: simulator Liquid Glass build/launch passed;
+  `THEOS=/Users/Jordan.Earle/theos make package` passed for the device target.
+- Cleanup: probe modals were dismissed, forced compact mode was reset, and the
+  shared simulator was relaunched in regular two-column mode.
+- Remaining device/external gate: none for visible-controller selection; the
+  tested alert/activity presentation APIs are the same on device.
+
+### Task 14 — 2026-08-12 — baseline `18d0f8c` + task working tree
+
+- Implementation: the pane tracks logical master selection independently from
+  UITableView/Texture presentation, uses stable ListAdapter item identities
+  across refreshes, suppresses Apollo's eager deselection while detail owns the
+  route, and applies/removes the selected accessibility trait with the visual
+  state. Added a narrow public staging handoff for screen-specific selection
+  owners; Apollo's two injected root Settings rows use it before their
+  early-return push path.
+- Focused test: selected two different real Home posts, continued and popped the
+  detail stack, cleared detail, and verified every state with
+  `selectionstatus`. Repeated with a real Inbox row, native General Settings,
+  and Apollo Reborn Settings. Every active regular case reported exactly one
+  selected row and `axSelected=1`; clear reported zero; compact reported a
+  retained logical selection with no hidden physical/AX selection; expansion
+  restored the same row with `pass=1`.
+- Standard smoke checks: switched Home → Search → Inbox → Profile → Settings →
+  Home, replaced detail, exercised Back and regular → compact → regular, reset
+  the compact override, and performed a no-build relaunch. The final navigation
+  dump contained exactly two navigation controllers for each of five tabs, and
+  the final 1032x1376 screenshot showed the normal regular two-column state.
+  Recent `apollofix` logs contained no relevant exception, assertion, hierarchy,
+  nested-transition, routing-loop, or dead-gesture diagnostic.
+- Build coverage: Liquid Glass simulator build/launch and `make package` for the
+  pinned iOS 26 device SDK / iOS 14 deployment target passed. Package:
+  `com.apollo.reborn_3.5.1-7+debug_iphoneos-arm.deb`.
+- Remaining device/external gate: the selected accessibility trait is proven in
+  the simulator; spoken VoiceOver output remains part of release gate E.
+
+### Task 15 — 2026-08-12 — baseline `18d0f8c` + task working tree
+
+- Implementation: moved every pane-owned view/gesture side effect out of the
+  five-tab construction transaction and into the pane's `viewDidLoad`.
+  Ground-theme refresh and resolved-layout invalidation now use `viewIfLoaded`,
+  and rollback removes gesture targets only when a pane had actually installed
+  them. Installation validation accepts the detail host's stored navigation
+  ownership while its view is unloaded, then requires concrete containment once
+  loaded. Added the simulator-only `loadstatus` probe, which itself never reads
+  `view` from an unloaded controller.
+- Focused test: a no-build cold launch reported `loadedPaneCount=1`, with Home
+  loaded/attached and tabs 1–4 unloaded/unattached. Visiting Search, Inbox,
+  Profile, and Settings in turn produced counts 2→3→4→5; returning Home retained
+  five loaded panes but exactly one attached pane. A fresh relaunch returned to
+  one loaded pane, proving visited panes are not eagerly recreated next process.
+- Performance sample: in comparable simulator launches, the interval from the
+  pane install hook to the five-pane commit changed from about 1.394s before the
+  change to 0.618–0.679s after it. One roughly fixed-window `ps` RSS comparison
+  changed from 563,920KB to 554,608KB. These are directional simulator samples;
+  the controlled cold-launch/RSS soak remains release gate F.
+- Standard smoke checks: opened a real Home post in detail, pushed and popped a
+  continuation, switched through all five tabs, and exercised regular → compact
+  → regular. Routing, selected-row state, deferred gesture observation, two-nav
+  ownership, and the final regular screenshot were coherent. A no-build
+  relaunch again installed 5/5 panes while loading only Home. Recent logs had no
+  relevant exception, assertion, hierarchy, nested transition, routing loop, or
+  dead-gesture diagnostic.
+- Rollback regression: simulator fault `configure-secondary:3` restored the
+  exact five stock navigation children with `rollbackExact=1`; cleanup did not
+  force unloaded pane views. A following normal relaunch installed all panes.
+- Build coverage: Liquid Glass simulator build/launch and `make package` for the
+  pinned iOS 26 device SDK / iOS 14 deployment target passed. Package:
+  `com.apollo.reborn_3.5.1-8+debug_iphoneos-arm.deb`.
+- Remaining device/external gate: controlled launch/RSS statistics and memory
+  pressure/soak coverage remain part of release gate F.
+
+### Task 16 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation: replaced AutoHideTabBar's per-scroll shared-array traversal
+  with allocation-free direct checks for Apollo's two real tab topologies:
+  stock navigation-controller children and pane primary/detail navigation
+  controllers. The generic enumerator remains only as a compatibility fallback
+  for unrelated split view controller children.
+- Focused test: a simulator-only bounded timing/counter probe ran the exact
+  production predicate 50,000 times. The iPhone layout-off run took 7.727ms,
+  used 50,000 direct scans, and entered the array fallback zero times. The iPad
+  pane-on run took 13.096ms, used 50,000 pane scans, and entered the array
+  fallback zero times. Both returned the enabled policy as true and `pass=1`.
+- Behavior test: on both form factors, setting every owned navigation stack's
+  request on/off made the aggregate predicate resolve 1/0 and UIKit's tab-bar
+  minimize behavior resolve `OnScrollDown`/`Never` (2/1), all with `pass=1`.
+  Up/down feed swipes delivered successfully with the same behavior active.
+- Standard smoke checks: opened a real Home comments route beside the feed,
+  verified retained selected-row/accessibility state, switched through all
+  five tabs, scrolled the live feed, exercised populated regular → compact →
+  Back via accessibility escape → regular, and reset the policy and compact
+  override. A no-build relaunch installed 5/5 panes and the final screenshot
+  showed the normal regular-width empty-detail state. Recent logs contained no
+  relevant exception, assertion, hierarchy, transition, routing-loop, or
+  dead-gesture diagnostics.
+- Build coverage: Liquid Glass simulator build/launch, `git diff --check`, and
+  `make package` for the pinned iOS 26 device SDK / iOS 14 deployment target
+  passed. Package: `com.apollo.reborn_3.5.1-9+debug_iphoneos-arm.deb`.
+- Remaining device/external gate: the source-path counters prove that the known
+  array constructors are absent from both production topologies; a full
+  Allocations/frame-time scroll soak remains part of release gate F.
+
+### Task 17 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation: removed every production layout-driving write from the
+  detail host and pane container's `viewDidLayoutSubviews`. Detail top/bottom
+  constraints and the divider grabber now update through coalesced main-queue
+  refreshes requested by safe-area, size-transition, split-display,
+  collapse/expand, trait, and appearance events. Active transition coordinators
+  defer sampling until completion. Resolved constraint constants, grabber
+  visibility, and grabber frame are cached with a half-point tolerance, and the
+  grabber uses a fixed layer order instead of repeated `bringSubviewToFront:`.
+- Focused rotation test: a simulator-only `layoutreset`/`layoutstatus` probe
+  counts layout passes, refreshes, and actual writes without changing production
+  behavior. Eight real Device Hub rotations returned `panePasses=8`,
+  `paneRefreshes=8`, `paneWrites=8`, `hostPasses=16`, `hostRefreshes=16`, and
+  `hostWrites=0`, with `pass=1`. The final portrait state retained aligned
+  columns and a centered divider grabber.
+- Focused topology test: five forced compact → regular cycles returned fifteen
+  pane layout passes and ten host passes—bounded work rather than recursive
+  growth. The cached geometry wrote only when compact visibility/host offsets
+  actually changed. A mixed latest-build run of four rotations plus two
+  compact/regular cycles also ended `pass=1` with coherent regular geometry.
+- Standard smoke checks: opened a real Home comments route, verified selected
+  row/accessibility state, pushed and popped a detail continuation, visited all
+  five tabs, exercised populated compact Back via accessibility escape, reset
+  compact mode, and relaunched without rebuilding. Portrait and landscape
+  screenshots showed aligned primary/detail navigation bars, usable content,
+  and the grabber on the real divider. The final regular screenshot showed the
+  expected empty-detail state. Recent logs contained no relevant constraint,
+  exception, assertion, hierarchy, unbalanced-transition, routing-loop,
+  layout-loop, or dead-gesture diagnostics.
+- Build coverage: Liquid Glass simulator build/launch, `git diff --check`, and
+  `make package` for the pinned iOS 26 device SDK / iOS 14 deployment target
+  passed. Package: `com.apollo.reborn_3.5.1-10+debug_iphoneos-arm.deb`.
+- Remaining device/external gate: continuous Stage Manager resizing and a
+  ten-minute rotation/resize leak soak remain release gates D and F.
+
+### Task 18 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation audit: the instability's production cause was the old
+  `apollo_reconcileSidebarForDetailContent` policy, which hid the one global tab
+  sidebar whenever detail filled. Task 7 removed that method, its ownership
+  flags, and every `sidebar.hidden` writer. The current detail replacement path
+  changes only the detail navigation stack and selection state; no additional
+  production mutation was needed or added for Task 18.
+- Focused width test: added a simulator-only `reflowreset`/`reflowstatus` probe
+  that samples the selected pane, global sidebar, primary navigation geometry,
+  and every visible primary/detail ASTableView without writing layout. With the
+  real UIKit sidebar visible, a real Home text post was opened, cleared, and
+  opened again during 240 samples. The final state was
+  `sidebarInitialHidden=0 sidebarFinalHidden=0 sidebarChanges=0`,
+  `primaryColumnInitial=760 primaryColumnFinal=760 primaryColumnRange=0`,
+  `primaryNavRange=0`, `primaryTextureWidthChanges=0`,
+  `detailTextureWidthChanges=0`, `largestTextureWidthJump=0`, and `pass=1`.
+- Visual/behavior checks: `.sim/task18-first-comments-visible-sidebar.png` and
+  `.sim/task18-repeated-comments-visible-sidebar.png` show identical sidebar,
+  list-divider, and comment-column geometry. A detail continuation pushed and
+  popped correctly, all five tabs remained reachable, and populated regular →
+  compact → accessibility escape → regular restored the two-deep primary stack
+  and cleared detail. Layout counters ended `pass=1`; recent logs contained no
+  relevant constraint, hierarchy, assertion, routing-loop, transition, or
+  dead-gesture diagnostics.
+- Relaunch/state cleanup: a no-build launch installed 5/5 panes in regular
+  width. The temporary sidebar-visible test configuration was removed and the
+  simulator's original `IPadTabBarBottom=YES` preference was restored before
+  the final screenshot.
+- Build coverage: `git diff --check`, the Liquid Glass simulator build/launch,
+  and `make package` for the pinned iOS 26 device SDK / iOS 14 deployment target
+  passed. Package: `com.apollo.reborn_3.5.1-11+debug_iphoneos-arm.deb`.
+
+### Task 19 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation: the detail-column host owns a reversible horizontal
+  `additionalSafeAreaInsets` delta for prose surfaces. It caps ordinary text at
+  680pt, relaxes to 760pt for accessibility Dynamic Type categories, preserves
+  any pre-existing additional insets, recomputes from stable geometry/content-
+  size callbacks, and restores the original edges when the navigation top
+  changes. Navigation chrome, table frames, scroll indicators, and background
+  fills stay full width; only cell content that already follows the safe area is
+  centered.
+- Scope: table-backed destinations under the Settings index opt in. Comments
+  opt in only for self/text posts. Apollo's Swift Optional `link` ivar is often
+  nil through ObjC runtime access, so the policy also reads the realized first
+  Texture row: `CommentsHeaderCellNode` is prose and
+  `RichMediaHeaderCellNode` is media. Unknown headers, media threads, viewers,
+  galleries, web views, feeds, profiles, and non-table Settings descendants
+  fail open at full width.
+- Focused geometry/visual tests on the 13-inch iPad simulator: a real 756pt
+  text thread with short and long/nested comments resolved to
+  `safeInsets={86,38,64,38}` and 680pt cell content; an image-post thread at the
+  same 756pt width resolved to zero horizontal inset and full-width media. A
+  native 744pt Settings General form resolved to 32pt per side/680pt content.
+  At `accessibility-large`, the same form expanded to its full 744pt width and
+  its rows grew normally; the simulator was returned to `large`. Portrait
+  Comments (692pt) resolved to 6pt per side/680pt, while portrait Settings at
+  680pt needed no inset. Screenshots:
+  `.sim/task19-text-readable-landscape.png`,
+  `.sim/task19-media-fullwidth.png`,
+  `.sim/task19-settings-readable-landscape.png`,
+  `.sim/task19-settings-accessibility-large.png`,
+  `.sim/task19-text-comments-portrait.png`, and
+  `.sim/task19-settings-portrait.png`.
+- Transition/build coverage: populated compact → regular recomputed the cap
+  from the resolved width and the existing layout probe remained `pass=1` with
+  bounded passes/writes. The final Liquid Glass simulator build/launch,
+  `git diff --check`, and `make package` for the pinned iOS 26 device SDK / iOS
+  14 deployment target passed. Package:
+  `com.apollo.reborn_3.5.1-12+debug_iphoneos-arm.deb`.
+
+### Tasks 20–21 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Width ownership: an attached pane initializes one scene-associated preferred
+  primary width from that scene session's persisted value, or from the existing
+  42% default clamped to 340–480pt. It applies the absolute preference to every
+  sibling pane without loading any cold pane views. UIKit's
+  `primaryColumnWidth` remains an observed resolved value only, so compact,
+  rotation, sidebar overlap, and constrained-window results never persist as
+  user intent.
+- Persistence/coordination test: a simulator-only `widthset 470` command used
+  the same production publication path as the control. All five tab panes
+  reported `requested=470`; the four unvisited panes remained unloaded until
+  selected. After visiting every tab, forced compact mode reported
+  `scenePreferred=470 requested=470` while UIKit resolved the single compact
+  column to 1032pt. Expansion restored the tiled layout without changing the
+  preference. Killing/reinstalling-over/relaunching the app initialized the
+  scene from the persisted 470pt value and resolved the list to 470pt.
+- Accessible divider: the pane marker is now a transparent 44x64pt `UIControl`
+  around its original centred 5x44pt accent pill. It owns horizontal pan input,
+  a pointer highlight interaction, `UIAccessibilityTraitAdjustable` with a
+  descriptive label/value/hint, and Option-Left/Option-Right commands. All
+  inputs clamp and publish through the scene coordinator; cancelled pans return
+  to their starting preference.
+- Focused interaction test: accessibility increment changed 460 → 480 and the
+  keyboard narrow command changed it back to 460. idb's accessibility tree
+  exposed one `AXSlider` at `{{438,656},{44,64}}`, label `Column Divider`, hint
+  `Adjusts the width of the list column`, and value `460 points`. Runtime state
+  confirmed one pointer interaction and two key commands. The control was
+  visible in tiled regular mode and hidden in overlay, secondary-only, and
+  compact states; reset restored it at the same divider coordinate and value.
+- Environment limitation: Xcode 27's idb HID swipe returned without delivering
+  the physical drag, matching the repository's documented Device Hub/idb
+  limitation. The production pan path is installed and compiled, but final
+  mouse/trackpad drag feel remains release-gate device coverage.
+- Build coverage: Liquid Glass simulator build/launch, `git diff --check`, and
+  `make package` for the pinned iOS 26 device SDK / iOS 14 deployment target
+  passed. Package: `com.apollo.reborn_3.5.1-13+debug_iphoneos-arm.deb`.
+
+### Task 22 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation: each loaded pane registers for Apollo's canonical
+  `com.christianselig.ApolloSpecificThemeChanged` notification in
+  `viewDidLoad` and removes itself in `dealloc`. The callback reapplies every
+  color owned by the pane layer: the ground behind floating columns, the
+  divider marker accent, and retained placeholder page/icon colors. Hosted
+  Apollo controllers continue to handle their own copy of the same
+  notification. Existing trait callbacks remain responsible for resolving the
+  dynamic providers when light/dark appearance changes.
+- Focused test: a simulator-only `themenotify` command posts the exact canonical
+  notification and records resolved pane colors/callback counts. Empty Home
+  advanced from zero to one callback while retaining a coherent `#EAEBED` page
+  ground/placeholder and `#8839EF` divider/icon accent. Visiting every tab and
+  notifying after each visit showed every loaded pane receiving subsequent
+  notifications; unloaded placeholder views remained unloaded. Home was then
+  populated with a real routed detail replacement and received another live
+  notification with its pane ground/divider refreshed; Inbox's populated
+  detail behaved the same way. This covers empty, populated, foreground, and
+  loaded-background pane ownership without forcing cold views to load.
+- Build coverage: the Liquid Glass simulator compiled and launched,
+  `git diff --check` passed, and `make package` passed against the pinned iOS 26
+  device SDK / iOS 14 deployment target. Package:
+  `com.apollo.reborn_3.5.1-14+debug_iphoneos-arm.deb`.
+
+### Task 23 — 2026-08-12 — baseline `d9a17a6` + task working tree
+
+- Implementation: Settings now treats the saved `UDKeyIPadPaneLayout` value as
+  desired next-launch state and `ApolloPaneLayoutActive()` as current-process
+  hierarchy. The switch reads desired state. Its detail text reports either the
+  normal description, “will turn on after Apollo quits and reopens,” or “will
+  turn off…” according to the desired/active matrix. The dependent Move Tab Bar
+  to Bottom row is visible only when the pane hierarchy is not currently active.
+- Later-state behavior: after writing the desired value, the handler leaves
+  `sIPadPaneLayout` untouched, diffs conditional visibility from active state,
+  and identity-reloads `gen.iPadPaneLayout` so the pending subtitle appears
+  immediately. Thus enable + Later retains the still-relevant bottom-tab row;
+  disable + Later keeps it hidden while panes remain installed; toggling back
+  to active state cancels the pending subtitle. Relaunch naturally makes desired
+  and active agree and returns the final row set.
+- Build coverage: the updated form compiled and launched in the Liquid Glass
+  iPad simulator, `git diff --check` passed, and `make package` passed against
+  the pinned iOS 26 device SDK / iOS 14 deployment target. Package:
+  `com.apollo.reborn_3.5.1-15+debug_iphoneos-arm.deb`.
+
+### Tasks 24–27 and main integration — 2026-09-03 — baseline `d4c0f70` + task working tree
+
+- Main integration: merged current `main`, retained both the pane simulator
+  harness and all newer main-only diagnostics, and reconciled the Settings
+  information-architecture changes. Main's current native search/header work
+  also removed the stale top-inset overlap seen on the unmerged branch.
+- Compatibility/privacy hardening: limited the opt-in to iPadOS 18+, made its
+  experimental status explicit, changed PiP bottom-occlusion detection to use
+  real visible geometry, made custom URL/mailbox/Settings routes scene-scoped,
+  and replaced multiwindow URL logging with coarse destination kinds.
+- Simulator matrix: loaded the credential-bearing backup on iPad mini, 11-inch,
+  and 13-inch iPadOS 27 simulators. Portrait and landscape rendered aligned
+  primary/detail navigation and search chrome. A real Home post stayed selected
+  in primary while Comments opened in detail. Two populated compact/regular
+  cycles retained both columns and ended with `PaneLayoutPassTest pass=1`; the
+  lazy-load probe reported `loadedPaneCount=1 attachedPaneCount=1 pass=1`, while
+  the all-tabs run reported five loaded panes and one attached pane.
+- Integration probes: the pane-only `loadstatus`, `panestatus`, and compact
+  commands still worked, as did main's `floattab` command. A warm
+  `apollo://reborn/settings/theme-manager` route selected Settings and opened
+  Theme Manager in detail. That route exposed a UIKit visibleCells-during-update
+  assertion in the newly merged Settings surface propagation; deferring the
+  propagation until the table committed removed the assertion on rerun.
+- Visual evidence: `.sim/pr886-merged-mini-settings.png`,
+  `.sim/pr886-merged-11-final.png`, `.sim/pr886-merged-13-portrait.png`,
+  `.sim/pr886-merged-13-landscape.png`,
+  `.sim/pr886-merged-13-after-compact-cycles.png`, and
+  `.sim/pr886-merged-13-scene-route-fixed.png`.
+- Remaining gates: real PiP, two simultaneous scenes, visionOS window creation,
+  notification/Handoff/Siri device delivery, Stage Manager continuous resizing,
+  external display, full accessibility/pointer coverage, and the performance
+  soak remain explicit experimental-release follow-ups rather than claims made
+  by this simulator pass.
+
+### Theme/detail first-frame fixes — 2026-09-04 — baseline `b819421` + task working tree
+
+- Theme surfaces: Theme Manager and Theme Gallery now resolve page, card, and
+  separator colors from the canonical stock/custom theme helpers before trying
+  navigation-context inheritance. This removes the pure-black page fallback
+  when either controller is the root of the iPad detail navigation stack.
+- Readable-width timing: settings forms now receive their final centered safe-
+  area insets synchronously during detail stack replacement, push, pop, and
+  stack replacement. The deferred geometry pass remains as reconciliation for
+  resizing, but no longer owns the destination's first visible width.
+- Focused simulator coverage: a cold Accounts & API Keys route, an attached
+  settings route, the exact Apollo Reborn → Accounts & API Keys nested push,
+  and its reverse pop all logged the 896pt → 680pt readable inset before the
+  navigation operation completed. A screenshot captured during the nested push
+  already had the incoming table at its final width; its settled screenshot did
+  not move. Replacing it with the non-table Link Companion restored the intended
+  full-width detail surface.
+- Visual evidence: `.sim/pr886-theme-manager-background-fixed.png`,
+  `.sim/pr886-theme-gallery-background-fixed.png`,
+  `.sim/pr886-readable-nested-first.png`,
+  `.sim/pr886-readable-nested-settled.png`, and
+  `.sim/pr886-non-readable-full-width.png`.

--- a/docs/ipad-pane-layout-plan.md
+++ b/docs/ipad-pane-layout-plan.md
@@ -1,0 +1,836 @@
+# iPad Pane Layout — Engineering Plan
+
+## Current implementation — 7 September 2026
+
+The original proposal below is retained as historical RE/design context. Current
+source implements **two content columns per tab**, inside Apollo's existing
+five-destination tab/sidebar controller. The system sidebar is a destination
+surface, not a third content navigation stack. Production eligibility is opt-in
+on iPadOS 18+, while the device tweak's deployment floor remains iOS 14.
+
+Primary selection replaces the detail root; navigation started in detail pushes
+within detail. Compact root Back uses a reversible native interactive transition;
+UIKit column wrappers are structural containment, never application routes.
+Scene-owned registration and native URL entry restore the exact originating tab
+hierarchy. Required runtime capabilities are checked before installation.
+
+The primary feed uses Apollo's compact native nodes by default, with a pane-local
+Comfortable option. `ApolloPaneChrome` owns native search/title policy. Comments
+Find uses one system `UIFindInteraction` adapter over Apollo's matcher; the old
+extra Find toolbar is suppressed. Context geometry follows actual native bars and
+the tab content guide, not a fixed 54-point constant. Text constraints and additive
+Settings insets are separate from full-width media layout.
+
+Host geometry, scheduling, settlement, chrome, content, focus, sidebar and tracing
+now live in separate `src/ipad/ApolloPane*` modules. No display link runs
+continuously for idle panes, and live divider samples update only the visible tab.
+The adaptive-phone switch is simulator-only and retains the phone idiom; it is
+preparation for resizable phones, not certified foldable support.
+
+See [Plan 002](../plans/002-ipad-pane-redesign.md) and
+[implementation results](../plans/003-ipad-pane-implementation-results.md) for the
+current specification and evidence. Physical-device performance/accessibility/OS
+gates remain open; the experiment must not be promoted from simulator results.
+
+## Historical proposal and reverse-engineering notes
+
+Branch: `je/ipad-pane-layout` (experimental, off `main`)
+
+Tracking issues: [#225](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/225) (iPad support),
+[#635](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/635) (tab bar over search bar),
+[#782](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/782) (jump bar hover jank),
+[#387](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/387) (floating menu placement — closed, stopgap shipped as #557).
+
+> This is the largest UI change the tweak has attempted. The plan is deliberately
+> staged so that every phase is independently shippable and independently
+> revertable, and so that the riskiest assumption is tested before any
+> architecture is committed to.
+
+---
+
+## 1. What we are building
+
+A three-column, opt-in iPad layout:
+
+```
+┌────────────┬───────────────────┬──────────────────────┐
+│  SIDEBAR   │   POST LIST       │   COMMENTS / DETAIL  │
+│            │                   │                      │
+│ ◉ Home     │ r/apple      ⌄ ⋯  │  ← Post title        │
+│ ○ Search   │ ───────────────── │  ══════════════════  │
+│ ○ Profile  │ ▸ Post one        │  [ media / body ]    │
+│ ○ Inbox    │ ▸ Post two        │                      │
+│ ○ Settings │ ▸ Post three      │  ┌ u/abc   ▲ 42      │
+│ ────────── │ ▸ Post four       │  │ comment text…     │
+│ ⭐ Home    │ ▸ Post five       │  │ ┌ u/def  ▲ 12     │
+│ 🔥 Popular │ ▸ Post six        │  │ │ reply text…     │
+│ 🌐 All     │ ▸ Post seven      │  └ u/ghi   ▲ 3       │
+│ ────────── │ ▸ Post eight      │                      │
+│ r/apple    │ ▸ Post nine       │  ┌ u/jkl   ▲ 8       │
+│ r/ios      │ ▸ Post ten        │  │ comment text…     │
+└────────────┴───────────────────┴──────────────────────┘
+```
+
+Non-goals for this branch: a bespoke iPad *visual* design language, a Mac
+Catalyst build, or reimplementing any Apollo screen. Every column hosts a real
+Apollo view controller.
+
+### Design principles
+
+1. **Opt-in and reversible.** Default OFF, iPad-only, iPhone code paths never
+   execute the new code. A user who never enables it must not be able to tell
+   this shipped.
+2. **Reuse Apollo's real view controllers.** We re-host, never reimplement. The
+   subreddit list keeps its section index, edit mode, multireddits and
+   drag-reorder because it *is* `RedditListViewController`.
+3. **Compact width must equal today's app.** `UISplitViewController` collapse
+   already folds a triple-column layout into a single navigation stack —
+   sidebar → list → detail — which is exactly today's push hierarchy. The
+   fallback is free and correct, and it covers Slide Over, small Stage Manager
+   windows, and portrait on smaller iPads.
+4. **Allowlist routing, never blocklist.** Only view controller classes we have
+   explicitly classified get routed to a different column. Everything else
+   pushes in place, i.e. behaves exactly as it does today. Apollo has ~90 view
+   controllers and the tweak adds its own; an allowlist is the only safe default.
+5. **`ApolloTabBarController` keeps its identity and index space.** It stays the
+   window's root view controller with the same five children in the same order.
+   This is what keeps deep links, quick actions, the settings router, the crash
+   prompt coordinator and `ApolloMainTabBarController()` working.
+
+---
+
+## 2. Ground truth (verified, not assumed)
+
+Everything in this section was confirmed against the shipping binary,
+`Apollo.app/Info.plist`, or the existing tweak source.
+
+### App capabilities
+
+| Fact | Value | Source | Why it matters |
+|---|---|---|---|
+| `UIDeviceFamily` | `[1, 2]` | `Apollo.app/Info.plist` | Apollo is already a native iPad app, not in compatibility mode. |
+| `UIRequiresFullScreen` | absent | `Apollo.app/Info.plist` | Multitasking is already on, so Apollo **already survives compact width on iPad today**. The compact fallback is proven code, not new risk. |
+| `UIApplicationSupportsMultipleScenes` | `true` | `Apollo.app/Info.plist` | Stage Manager / multi-window is available for free later. |
+| `MinimumOSVersion` | `15.0` | `Apollo.app/Info.plist` | The real floor is iOS 15, not the tweak's 14.0 target. |
+
+### Container hierarchy
+
+Recovered from `-[SceneDelegate scene:willConnectToSession:options:]`
+(`sub_1000879c0`) and the tab bar factory (`sub_100087244`):
+
+- `sub_100087244()` builds `ApolloTabBarController` and sets exactly **five**
+  `ApolloNavigationController` children.
+- The scene delegate then does `[window setRootViewController:tabBarController]`,
+  stores it in its own `tabBarController` ivar, and calls `makeKeyAndVisible`.
+- **Consequence:** hooking `scene:willConnectToSession:options:` and
+  post-processing after `%orig` is a clean install point. The scene delegate's
+  `tabBarController` ivar still points at the real tab bar controller, so
+  `ApolloMainTabBarController()` keeps working untouched.
+- Tab index 2 is Profile (`-[ApolloTabBarController goToProfileTab]` →
+  `setSelectedIndex:2`), matching `ApolloProfileTabIndex` in `ApolloUserAvatars.xm`.
+- Tab 0's root is `RedditListViewController` — asserted with `isMemberOfClass:`
+  by `ApolloQuickActions.xm`.
+- Tab 0 can launch with a **two-deep** stack (subreddit list + a restored
+  `PostsViewController`). That restore state maps one-to-one onto
+  sidebar + list columns, which is a useful signal that the split is natural.
+- The factory calls `loadViewIfNeeded` and `waitUntilAllUpdatesAreProcessed` on
+  several roots — Apollo pre-warms these synchronously at launch, so any
+  restructuring must happen *after* `%orig` returns.
+
+### Push pipeline internals (`sub_10015c720`)
+
+`-[ApolloNavigationController pushViewController:animated:]` is a thin ObjC shim
+over one Swift body, `sub_10015c720`. Decompiled, it:
+
+1. **Silently drops duplicate pushes** — if the incoming VC is already in
+   `viewControllers`, the whole body no-ops. A router that moves a VC between
+   columns must remove it from the source stack first, or later Apollo-side
+   pushes of that same instance will silently do nothing.
+2. Sets `extendedLayoutIncludesOpaqueBars = YES` on every pushed VC before
+   calling super.
+3. Sets the `pushing` ivar, which the custom `ApolloNavigationAnimator` and the
+   interactive-pop machinery read.
+4. If the nav bar is hidden and the `HideBarsOnScroll` default is set, it
+   schedules ~100 escalating `asyncAfter` re-layout attempts on the main queue.
+   With hide-bars active in three columns, these timer storms run per column.
+
+**Consequence for the router:** reroute by *calling the destination column's
+navigation controller's normal `pushViewController:`*, never by splicing
+`viewControllers` arrays. That way Apollo's own body runs on the destination —
+dedupe, extended-layout, `pushing` flag, nav-bar re-show — and every per-nav
+invariant stays coherent. (This is also why the ObjC-level hook is the right
+interception point: Logos hooks the shim, so a reroute can return without ever
+running Apollo's Swift body on the wrong nav.)
+
+### Forward stack: `poppedViewControllers` + `goForward`
+
+Confirmed by decompiling `-[ApolloNavigationController goForward]`: every pop
+appends to a per-nav `poppedViewControllers` array, and `goForward` re-pushes
+its tail through the same push body. This powers keyboard "go forward" **and the
+right-screen-edge pan gesture**. Two consequences:
+
+- **Per-column forward stacks.** If the router clears the secondary column when
+  a new list loads, those cleared VCs land in that column's forward stack.
+  Policy needed: clear the forward stack on cross-column reroutes (recommended —
+  a "forward" that re-pushes a comments VC for a post no longer in the list
+  column is disorienting), or accept per-column forward history.
+- **The gesture conflict is now concrete, not hypothetical** (see §5.4): Apollo
+  installs pans on *both* edges of every nav controller, so every interior
+  column boundary in a triple-column layout has an Apollo recognizer on each
+  side of it, plus UIKit's own split-view show/hide gesture.
+
+### Width-change handling — what Apollo actually does
+
+Searched the full procedure list: **no** `viewWillTransitionToSize:` and **no**
+`traitCollectionDidChange:` overrides exist on `ASTableViewController`,
+`PostsViewController`, or `CommentsViewController`. (Only
+`ApolloNavigationController` and `MediaViewerController` implement the former.)
+All width adaptation in the content controllers is passive:
+`viewDidLayoutSubviews` re-frames overlays (dark overlay, jump-bar dropdown —
+both computed from `view.bounds` with a max-width clamp and centering, so they
+are already column-relative), and the actual cell re-measure is Texture
+framework behavior — `ASTableView.layoutSubviews` re-measures every node when
+its constrained width changes (`AsyncDisplayKit.framework` is embedded in
+`Apollo.app/Frameworks/`).
+
+Two readings of this:
+
+- **Good:** there is no custom rotation/resize code in the content controllers
+  to fight. Resize correctness comes for free from Texture.
+- **Correction to an earlier claim:** the `restoredViewWidth` ivars on
+  Posts/Comments/Inbox are **state-restoration** bookkeeping (scale the saved
+  scroll offset when the restored width differs), *not* live-resize support.
+  They are evidence Apollo tolerates width differences across launches, not
+  evidence the live re-measure is cheap. The entire live-resize cost is
+  Texture's full re-measure, there is no incremental path, and Phase 0's
+  measurement of it is *the* number this project hangs on.
+
+### Custom presentation controllers are window-anchored
+
+Apollo ships ~20 custom `UIPresentationController` subclasses (ActionController,
+SubredditSelector, Sourdough, FlairAlert, TipJar, AccountManager, …).
+Decompiled `ActionControllerPresentationController
+frameOfPresentedViewInContainerView`: it sizes from **`containerView.bounds`**
+(the window in a standard presentation) with a max-width clamp (`fminnm`) and
+`(containerWidth − width) / 2` centering. So in the pane layout, action menus
+and card sheets present **centered over the whole window**, not over the source
+column. Not a crash risk — the max-width clamp means they don't stretch — but a
+UX note: long-press menus on a post in the list column appear window-centered.
+Acceptable for v1; column-anchored presentation would mean re-parenting Apollo's
+presentation controllers and is explicitly out of scope.
+
+Related standard-iPad requirement for tweak-drawn UI: `UIActivityViewController`
+and alert-sheet presentations on iPad require a popover `sourceView`/`sourceRect`
+or they throw. Apollo handles its own; every *tweak* share-sheet call site that
+becomes reachable from a new column context needs a popover source audit.
+
+### UIKit API availability
+
+| API | Introduced | Usable here? |
+|---|---|---|
+| `UISplitViewController(style: .tripleColumn)` | iOS 14 | **Yes** — this is the backbone. Covers the whole iOS 15+ floor. |
+| `UITabBarController.mode` / `.sidebar` | **iOS 18** | Optional enhancement only. Cannot be the backbone. |
+| `UITab` / `UITabGroup` / `UISearchTab` | **iOS 18** | Not used — see below. |
+
+**Why not build on `mode = .tabSidebar`.** It renders a sidebar from static
+`UITab`/`UITabGroup` objects. Apollo's sidebar content is the *subreddit list*:
+dynamic, sectioned, editable, reorderable, with multireddits and a section index.
+Expressing that as `UITab` objects would mean reimplementing subscription
+management, which violates principle 2 and would regress behavior users rely on.
+It is also iOS 18+, so it could never be the only path. We may offer it later as
+a cosmetic variant for the destinations rail specifically.
+
+---
+
+## 3. Architecture
+
+### Topology
+
+The app has exactly **one** persistent navigation surface, and it belongs to the
+tab bar controller rather than to any tab. `UITabBarController.mode =
+.tabSidebar` turns the floating tab bar into UIKit's own sidebar; each tab then
+contributes only a list and a detail column.
+
+```
+UIWindow.rootViewController
+└── ApolloTabBarController                    ← unchanged object
+    │   mode = .tabSidebar                    ← UIKit draws the sidebar: FIXED, identical on every tab
+    ├── tab 0  ApolloPaneSplitViewController  (.doubleColumn)
+    │            ├─ .primary    ApolloNavigationController  ← the tab's OWN stack, verbatim
+    │            │                (RedditListViewController → PostsViewController → …)
+    │            └─ .secondary  ApolloNavigationController  ← detail stack (CommentsViewController…)
+    ├── tab 1  ApolloPaneSplitViewController  (Inbox:    thread list → message)
+    ├── tab 2  ApolloPaneSplitViewController  (Profile:  sections   → detail)
+    ├── tab 3  ApolloPaneSplitViewController  (Search:   results    → post)
+    └── tab 4  ApolloPaneSplitViewController  (Settings: sections   → detail)
+```
+
+Which reads on screen as three stable regions:
+
+```
+[ sidebar: destinations ] [ list ]              [ detail ]
+   UIKit, never changes     the tab's own stack   comment thread
+```
+
+**Why the sidebar is UIKit's and not ours.** `mode = .tabSidebar` brings the
+platform's own selection, hover, drag-and-drop and keyboard behavior, a system
+toggle back to the floating tab bar, and — critically — automatic adaptation:
+in portrait UIKit collapses the sidebar back into a floating tab bar with a
+reveal button, so the destinations are never unreachable. A hand-drawn rail in a
+split view column could not do that (see §6a, which is why it was blocked).
+
+**Verified, and worth recording because the documentation does not say so:**
+this works with tabs that came from the **legacy `viewControllers` array**.
+Apollo never adopted the iOS 18 `tabs`/`UITab` API — it assigns five navigation
+controllers the old way — and UIKit still synthesizes the tab model and renders a
+full sidebar from them. Confirmed on an iPad Pro 13" simulator: mode resolved to
+2, a live `UITabBarControllerSidebar`, `hidden=0`, all five destinations with
+their titles, icons and the inbox badge. Had it required `tabs`, the alternative
+would have been rebuilding Apollo's tab model by hand.
+
+**Why every pane is two columns.** With destinations in the sidebar, a third
+column would be a *fourth* region on screen. The Home tab briefly had one — a
+subreddit-list column — and the result was four columns plus a floating tab bar
+plus our own sidebar-toggle button: three navigation surfaces competing at once,
+and a left pane whose contents changed identity per tab. It also duplicated
+Apollo's existing "Home ⌄" title menu, which already switches subreddits. The
+tab's navigation controller now goes into the list column verbatim, so the
+subreddit list pushes to a feed *inside that one column* exactly as on iPhone.
+
+**Why per-tab split views rather than one global one.** Each tab keeps its own
+column state, so leaving Inbox and coming back restores the post you were
+reading. It also means the tab bar controller's children array is the only thing
+that changes shape, which keeps the audit surface to one list of call sites (§5).
+
+**No `.compact` column is set.** `UISplitViewController` collapses a double
+column by pushing the secondary onto the primary's navigation controller, which
+reproduces today's push hierarchy exactly. Setting an explicit compact controller
+would mean maintaining a second layout by hand.
+
+**Panes must set `extendedLayoutIncludesOpaqueBars`.** Recovered from UIKit's
+`-[UITabBarController _frameForViewController:]`: the tab bar's height is
+subtracted from a child's frame unless the tab bar is hidden, the child extends
+under the bottom edge, or — for an *opaque* tab bar, which Apollo's is — the
+child sets `extendedLayoutIncludesOpaqueBars`. Apollo sets that flag on
+everything it pushes, so its stock screens run full height. A pane is a
+controller we construct, so it never inherited the flag and UIKit reserved room
+for a tab bar that sidebar mode had already taken off screen — a dead 64pt strip
+along the bottom of every column. Confirmed both ways: the stock hierarchy gives
+the tab child the full 1032pt, and the pane went 968 → 1032 once the flag was set.
+
+### Column routing
+
+A single interception point classifies pushes and redirects them.
+
+`ApolloSwipeUpComments.xm` already proves this technique in this codebase: it
+hooks `-[UINavigationController pushViewController:animated:]`, recognizes
+`_TtC6Apollo22CommentsViewController`, intercepts it before it lands, and
+re-presents it somewhere else. The pane router is the same mechanism with a
+class table instead of a single class.
+
+With two columns the table gets much shorter than the three-column draft needed:
+anything list-shaped simply stays in the list column, which is where Apollo was
+already pushing it. Only genuinely detail-shaped screens are redirected.
+
+| Class | Column | Notes |
+|---|---|---|
+| `CommentsViewController` | secondary | The headline case, and the only class routed across columns today. |
+| `PostsViewController`, `LitePostsViewController` | list (in place) | Listed only so that opening a new feed **clears** a stale thread from the detail column. |
+| **everything else** | **push in place** | Default. Subreddit drill-ins, settings sub-screens, composers, media viewers, web views, and every tweak-owned VC keep today's behavior until explicitly classified. |
+
+Candidates deliberately **not** yet added, because each needs its own testing
+pass and an untested entry is worse than an unrouted one:
+`PrivateMessageViewController` / `MessagesViewController` (secondary),
+`ProfileViewController` when pushed from an author (secondary),
+`SubredditSidebarViewController` / `SubredditRulesViewController` (secondary).
+
+Note the comment *list* controllers — `AllSubredditCommentsViewController`,
+`SavedPostsCommentsViewController`, `UserCommentsViewController` — must stay in
+place despite their names. They are feeds whose rows open a real
+`CommentsViewController`, which routes to the detail column on its own.
+
+Rules:
+- Pushing a list-class VC clears the secondary column to its placeholder.
+- Pushing a detail-class VC **replaces** the secondary stack rather than
+  appending, unless it was pushed *from within* the secondary column (e.g.
+  tapping a link inside comments), in which case it appends.
+- Modal presentations are never rerouted.
+
+### Where the code lives
+
+New directory `src/ipad/`:
+
+| File | Purpose |
+|---|---|
+| `ApolloPaneLayout.{h,m}` | Feature gate, capability check, change notification, the `sPaneLayoutEnabled` state read. Single source of truth for "are panes active right now". |
+| `ApolloPaneInstall.xm` | Hooks `-[SceneDelegate scene:willConnectToSession:options:]`; builds/tears down the split controllers after `%orig`. |
+| `ApolloPaneSplitViewController.{h,m}` | `UISplitViewController` subclass + delegate: collapse/expand behavior, column widths, placeholder detail VC, safe-area column host, theming. |
+| ~~`ApolloPaneSidebarViewController.{h,m}`~~ | **Not needed.** UIKit's tab sidebar replaced the hand-drawn rail entirely. |
+| `ApolloPaneRouter.xm` | The push interception and column classification table. |
+| `ApolloPaneChrome.xm` | Per-column nav bar / immersive header / scroll-edge reconciliation (§5.3). |
+
+### Settings gate
+
+Follows the existing `IPadTabBarBottom` pattern end to end:
+
+- `UserDefaultConstants.h`: `UDKeyIPadPaneLayout` + `ApolloIPadPaneLayoutChangedNotification`
+- `ApolloState.{h,m}`: `extern BOOL sIPadPaneLayout;` default `NO`
+- `Tweak.xm`: `registerDefaults` entry + `%ctor` read
+- `settings/CustomAPIViewController.m`: an iPad-only row under General, hidden
+  entirely on iPhone (same `userInterfaceIdiom` guard as the existing row).
+
+Because installation happens at scene connect, toggling requires a relaunch.
+Present it as an explicit "Requires restart" row with a confirm-and-restart
+action rather than pretending it applies live. When panes are ON, the existing
+"Move Tab Bar to Bottom" row is hidden — it is meaningless without the floating
+pill.
+
+---
+
+## 4. Phases
+
+Each phase is independently shippable and independently revertable.
+
+### Phase 0 — Spike (throwaway code, do not merge)
+
+Purpose: falsify the riskiest assumptions before committing to architecture.
+Force panes on for the Home tab only, hardcoded, no settings, no polish.
+
+Inner loop:
+```bash
+SIM_DEVICE_TYPE="iPad Pro 13-inch (M5)" scripts/run-in-sim.sh --glass --dark
+```
+(iPad simulators are present; `run-in-sim.sh` already parameterizes the device
+type, so no script changes are needed to start.)
+
+Exit criteria — all must hold before Phase 1 begins:
+
+1. `RedditListViewController` renders and behaves in a ~320pt primary column:
+   section index titles, edit mode, swipe actions, multireddits.
+2. `PostsViewController` (an `ASTableNode`) re-measures correctly when its column
+   width changes, including a Stage Manager drag-resize, without visible cell
+   corruption.
+3. `CommentsViewController` renders in the secondary column with correct comment
+   indentation at reduced width.
+4. Collapse to compact (Slide Over) and re-expand does not lose the navigation
+   stack or crash.
+5. Frame rate during a continuous Stage Manager resize is acceptable, and memory
+   with three live columns is measured and recorded.
+
+If (2) or (5) fail, stop and reassess: ASDK re-measure cost under continuous
+resize is the assumption most likely to sink this design, and it is cheaper to
+learn now.
+
+> **Status (branch `je/ipad-pane-layout`).** Phases 1 and 2 are built. Phase 0's
+> spike was folded into Phase 1 rather than thrown away — the container work was
+> the same either way, so the exit criteria are being answered against real code.
+>
+> **Working today**, verified on an iPad Pro 13" simulator with a signed-in
+> account: the Home tab runs three columns (subreddits → feed → comments), the
+> other four run two, tapping a post opens its thread beside the feed, and a
+> sidebar toggle reaches the subreddit list in portrait. The floating tab bar is
+> still present — the destinations rail that would replace it is not built.
+>
+> Phase 0 exit criteria:
+> | # | Criterion | Status |
+> |---|---|---|
+> | 1 | Subreddit list behaves in a narrow column | **Pass** — favorites, multireddits, moderator sections, A–Z index, Edit all intact |
+> | 2 | Feed re-measures on width change | **Partially** — correct at each discrete width; the continuous drag-resize case is untested |
+> | 3 | Comments render at reduced width | **Pass** — after the column-host fix (§5.2a) |
+> | 4 | Collapse/expand keeps the stack | **Pass** — both cases, via the `compact on\|off` sim command |
+> | 5 | Resize frame rate + three-column memory measured | **Not done** |
+>
+> Criterion 4 is now testable without Slide Over: `echo "compact on" >
+> /tmp/apollofix-tap.txt` (see `ApolloSimDebugTap.xm`) forces a compact
+> horizontal size class onto every pane, which is exactly what makes a split view
+> collapse. Verified in both directions — a pane with a thread open collapses
+> onto the secondary column and comes back intact, and a pane with an empty
+> detail collapses onto the primary without dragging its placeholder along.
+>
+> Criteria 2 and 5 still need a real device or a driven window resize, which the
+> simulator inner loop cannot produce. **They remain the outstanding risk**, and
+> §5.2 is still the assumption this design hangs on.
+>
+> Also verified: iPhone is completely untouched with the layout code compiled in
+> — zero pane log lines across a full launch and a normal single-column UI.
+
+### Phase 1 — Foundation (no visible change)
+
+- Settings key, state, gate, iPad-only row, relaunch flow.
+- `ApolloPaneLayout` capability check.
+- Install/uninstall of split controllers at scene connect.
+- **The hierarchy-assumption audit (§5.1)** — the ~15 call sites, routed through
+  one shared helper.
+- Routing table present but empty: *every* push still lands in place.
+
+Ship state: with the toggle on, the app looks essentially like today (single
+wide column) but is structurally split. This isolates "did the container change
+break anything" from "did the routing break anything", which is the single most
+valuable thing this phase buys.
+
+### Phase 2 — Home tab — **done**
+
+Tab sidebar on, Home running list + detail, placeholder detail state, selection
+persistence when switching tabs. Verified on an iPad Pro 13" simulator:
+sidebar 270pt, list column 280–760, detail 760–1376, tapping a post routes
+`CommentsViewController` to the detail column, collapse/expand preserves the
+open thread and its scroll position, and portrait falls back to UIKit's floating
+tab bar with a sidebar reveal button.
+
+### Phase 3 — Remaining tabs — **structurally done, routing not extended**
+
+All five tabs are panes and all five lay out correctly; switching tabs leaves
+the sidebar untouched and replaces only the content. What is *not* done is
+extending the routing table beyond `CommentsViewController` — Inbox messages,
+author profiles and subreddit sidebars still push in place rather than opening
+in the detail column (see §3, "candidates deliberately not yet added"). Inbox
+and Modmail carry their own selector and compose flows and should be last.
+
+### Phase 4 — iPad-native polish
+
+This is what stops it feeling like a stretched iPhone app, and much of it is
+cheap because Apollo already implements the hard part:
+
+- **Keyboard.** `ApolloNavigationController` already exposes `keyCommands` for
+  `selectNextCell`, `goIntoCell`, `goBack`, `pageUp`, `scrollToTop`,
+  `goToJumpBar`, `openMedia`. With panes these become genuinely desktop-class —
+  they just need to target the focused column via the responder chain.
+- **Pointer.** Hover states on rows and the jump bar. Fixes
+  [#782](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/782), whose hover
+  handling currently drops the Liquid Glass effect and clips the title.
+- **Context menus and drag & drop.** Drag a subreddit onto the list column; drag
+  a post into a new window.
+- **Multi-window.** `UIApplicationSupportsMultipleScenes` is already true — "open
+  post in new window" is largely plumbing.
+
+### Phase 5 — Adaptivity hardening + regression sweep
+
+Slide Over, all Stage Manager sizes, both rotations, iPad multitasking splits,
+and a full iPhone regression pass to prove the dormant path is really dormant.
+
+---
+
+## 5. Known costs and risks
+
+### 5.1 Hierarchy assumptions (bounded, mechanical)
+
+Roughly 15 call sites assume `tabBarController.viewControllers[i]` is a
+`UINavigationController`. Confirmed in: `ApolloDirectChatWeb.xm` (several),
+`ApolloUserAvatars.xm`, `ApolloQuickActions.xm`, `ApolloLiquidGlass.xm`,
+`Tweak.xm`, `ApolloAutoHideTabBar.xm`, `ApolloAutoHideMetaFeeds.xm`,
+`ApolloImageUploadHost.xm`, `ApolloSwipeUpComments.xm`,
+`ApolloBadgeBookViewController.m`, `UIWindow+Apollo.m`, `ApolloPictureInPicture.xm`.
+
+Fix: add one helper to `ApolloCommon` that unwraps a tab child to its active
+navigation controller (identity today, split-view-aware when panes are on), and
+route every site through it. Mechanical, enumerable, and testable on iPhone
+where it must be a no-op.
+
+### 5.2 ASDK re-measure under column resize — **highest risk**
+
+Apollo's feed and comments are `ASTableNode`-backed; cells measure against a
+constrained width. Column resize means Texture re-measures **every node** in the
+table (`ASTableView.layoutSubviews` on constrained-width change — framework
+behavior, no incremental path). The binary confirms there is no custom resize
+handling to help or hinder: no `viewWillTransitionToSize:` or
+`traitCollectionDidChange:` on any content controller (§2). The
+`restoredViewWidth` ivars are state-restoration offset-scaling, not live-resize
+support — the app tolerating width *differences across launches* is weaker
+evidence than previously stated. What does still count in our favor: Apollo runs
+resizable on iPad today, so single-column live resize (Slide Over, Split View)
+already exercises this path in production. What's new in the pane layout is
+*three* live node graphs re-measuring on one drag — which interacts badly with
+the memory pressure recorded in the August 2026 OOM wave. Phase 0 exists to put
+a number on exactly this.
+
+One cheap mitigation if the spike shows churn: `UISplitViewController` column
+resizes step through discrete widths (display-mode changes) far more often than
+they animate continuously — continuous re-measure mainly bites during Stage
+Manager window drags, where a debounce (re-measure on drag end, letterbox during)
+is an accepted pattern.
+
+### 5.2a iPadOS 26 floats the sidebar over a FULL-WIDTH secondary — **confirmed, and it bites Texture immediately**
+
+Found while building Phase 1, from a live hierarchy dump on an iPad Pro 13":
+
+```
+secondary  _UISplitViewControllerAdaptiveColumnView  (0, 0, 1032, 1312)   ← full window
+primary    _UISplitViewControllerAdaptiveColumnView  (10, 86,  413, 1216) ← inset glass panel
+```
+
+The secondary column is laid out at the **full window width** and the sidebar
+floats over it as a Liquid Glass panel. This is the iPadOS 26 design, not a
+misconfiguration — `preferredSplitBehavior = .tile` does not change it.
+
+UIKit expects content to respect the resulting left safe-area inset. **Texture
+does not**: `ASTableView` measures its nodes against its own bounds, not its
+adjusted content inset. Every comment measured 1032pt wide, got pushed right by
+the inset, and ran off the right edge of the screen.
+
+Fix shipped: `ApolloPaneColumnHostViewController` wraps the detail column's
+navigation controller and pins it leading/trailing to the safe area (top/bottom
+still to the view, so the nav bar keeps extending under the status bar). The
+navigation controller's view is then genuinely only as wide as the uncovered
+region, and Texture measures correctly with no changes to Apollo or ASDK.
+
+**Generalize this.** Any column we add later inherits the same problem, and so
+does any tweak-drawn UI placed in the secondary column. The rule is: never let
+Texture content size itself from a view that the sidebar overlaps.
+
+**But it is configuration-dependent, not universal.** The full-width-secondary
+behavior above was measured on a **two-column** pane. On a **three-column** pane
+with the primary hidden (the portrait downgrade), the same dump shows the
+secondary properly *tiled* beside the feed:
+
+```
+supplementary  _UISplitViewControllerAdaptiveColumnView  (0.0,   0, 351.0, 1312)
+secondary      _UISplitViewControllerAdaptiveColumnView  (351.5, 0, 680.5, 1312)
+separator                                                (351.0, 0,   0.5, 1312)
+```
+
+The column host stays correct either way — when nothing overlaps, the safe area
+*is* the full bounds, so pinning to it is a no-op. Do not assume one behavior
+and design around it; read the frames.
+
+**Measure column geometry from a hierarchy dump, never from a screenshot.** An
+apparent "the feed column is only ~260pt and cramped in portrait" bug was chased
+and a whole adaptive-width mechanism written for it, before a dump showed the
+column was 351pt all along — exactly the configured
+`minimumSupplementaryColumnWidth`. The 260 came from eyeballing cell padding as
+the column edge, and from `primaryColumnWidth` (413), which reports the *hidden*
+column and is irrelevant while it is hidden. The mechanism was reverted. Use
+`echo dump > /tmp/apollofix-tap.txt` and read `_UISplitViewControllerAdaptiveColumnView`
+frames.
+
+### 5.3 Full-width chrome assumptions — **largest hidden cost**
+
+- 19 tweak modules touch `navigationBar`.
+- 33 tweak modules read `UIScreen.mainScreen`.
+
+Modules that assume a single full-width nav bar need per-column awareness:
+`ApolloImmersiveHeaderBackground`, `ApolloProgressiveBlur`,
+`ApolloScrollEdgeEffect`, `ApolloLiquidGlass` (title centering),
+`ApolloAutoHideTabBar`, `ApolloSubredditHeaders`, `ApolloSearchInPlace`.
+
+This is very likely a bigger line-count cost than the split view controller
+itself. `ApolloPaneChrome.xm` exists to hold the reconciliation, and the
+`UIScreen.mainScreen` readers should migrate to the owning view's window/traits
+regardless of this project — that migration is independently correct.
+
+### 5.4a Testing constraint: the simulator runs against a LIVE account
+
+The sim inner loop restores a real signed-in Reddit session, so **any scripted
+gesture that lands on a post or comment performs a real action on that account**.
+This was learned the hard way: a swipe issued to test column-boundary gestures
+was consumed by Apollo's swipe-to-vote and cast a genuine downvote, and the
+scripted tap bridge could not reliably reach the ASDK action button to undo it
+(taps land on `_ASDisplayView` without activating the node).
+
+Rules for the rest of this work:
+- Gesture and interaction testing on feed/comment content needs a **throwaway
+  Reddit account**, not the developer's own session.
+- The tap bridge is fine for navigation chrome (tab bar, nav bar buttons,
+  toggles) — those are idempotent. It is not safe for content rows.
+- Prefer read-only verification (screenshots, hierarchy dumps, resolved-layout
+  logs) over driving interactions whenever it answers the question.
+
+### 5.4 Gesture conflicts — partly disproved by testing
+
+**Update from measurement.** The prediction below was pessimistic. A leading-edge
+drag *inside the detail column* did **not** trigger Apollo's interactive pop —
+the gesture was consumed by Apollo's own swipe-to-vote on the comment row. So
+the "every interior boundary has an Apollo edge recognizer on each side of it"
+concern did not reproduce at the feed/detail boundary.
+
+That is one boundary, one direction, on one layout, and the test could not be
+repeated safely (§5.4a). Treat the analysis below as **unvalidated** rather than
+either confirmed or refuted, and finish it on device with a throwaway account
+before Phase 4.
+
+The original analysis:
+
+`ApolloNavigationController` installs a left screen-edge pan (interactive pop),
+a **right screen-edge pan (go forward — confirmed: it re-pushes the tail of the
+per-nav `poppedViewControllers` array)**, and a nav-bar pan for hide-on-swipe.
+In a triple-column layout every interior column boundary therefore has an Apollo
+recognizer on each side of it — the supplementary column's *right*-edge
+(go-forward) pan sits exactly on the boundary with the secondary column, whose
+*left*-edge (pop) pan sits on the same line — plus `UISplitViewController`'s own
+`presentsWithGesture` show/hide pan on the primary edge. "Screen-edge" pans are
+actually view-edge relative, so they will fire at column boundaries, not just
+screen edges. Plan: disable Apollo's edge pans on interior edges (keep pop on
+the leftmost visible column, drop go-forward inside columns — ⌘] still covers
+it), and decide `presentsWithGesture` explicitly rather than inheriting it.
+Also define the router's forward-stack policy: clear `poppedViewControllers` on
+cross-column reroutes so "go forward" never resurrects a detail VC whose list
+context is gone.
+
+### 5.5 Entry points that must keep working
+
+Deep links (`apollo://`), Siri intents, home-screen quick actions
+(`ApolloQuickActions`), the settings router, the crash prompt coordinator, and
+push notification taps all target the tab bar controller and then walk into a
+navigation controller. All are covered by §5.1's helper, but each needs an
+explicit smoke test — a deep link that lands in the wrong column is a worse bug
+than one that fails outright.
+
+### 5.6 What panes do *not* fix
+
+[#635](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/635) (search bar
+under the floating tab bar) disappears when panes are ON, because the floating
+pill is hidden. It **still affects every iPad user who leaves panes OFF**, which
+is the default. Folding it into this work means those users stay broken until
+they opt in. If that becomes unacceptable before Phase 2 lands, pull it back out
+as a standalone fix — `ApolloSearchHeaderOverlapFix.xm` already exists as the
+natural home.
+
+---
+
+## 6. Implementation best practices
+
+Rules distilled from the binary findings above plus Apple's iPad guidance
+(the tab-bar/sidebar and desktop-class articles). These bind Phases 1–4.
+
+**Split view API traps (learned the hard way)**
+
+The first three were found while the Home tab was still three-column. That
+column is gone (§3, §6a), so they no longer bite this branch — kept because they
+are real UIKit behavior and the next person to reach for a triple column will
+hit all three.
+
+- `supplementaryColumnWidth` and its preferred/min/max siblings **throw** on a
+  double-column split view: `"UISplitViewController supplementaryColumnWidth
+  properties unsupported for style = DoubleColumn"`. Reading one in shared code
+  that runs for every pane crashes the app the first time a two-column tab lays
+  out. Guard every access on the pane actually being three-column. *(Still live:
+  every pane is double-column now, so this property must never be read at all.)*
+- `oneBesideSecondary` means *one*: in a three-column layout it shows one of
+  primary/supplementary and **hides the other**. Three-column panes need
+  `twoBesideSecondary`.
+- UIKit treats `preferredDisplayMode` as a request and silently downgrades
+  `twoBesideSecondary` → `oneBesideSecondary` when the width cannot take three
+  tiles (measured: honored at 1366pt landscape, downgraded at 1032pt portrait on
+  a 13" iPad). The downgrade hides the **primary** column, so any layout relying
+  on three columns must ship a `showColumn:`/`hideColumn:` toggle or the sidebar
+  becomes unreachable. This is what killed the hand-drawn destinations rail
+  (§6a). Log the *resolved* `displayMode`/`splitBehavior` rather than trusting
+  the preference.
+- `displayModeButtonItem` renders as an empty capsule inside Apollo's Liquid
+  Glass navigation bar — present and tappable, but with no glyph. If you ever
+  need a column toggle of your own, use an explicit `UIBarButtonItem` with your
+  own symbol and accent. *(Not needed today: UIKit's tab sidebar draws its own.)*
+
+**Split view configuration**
+- `UISplitViewController(style: .doubleColumn)`, `preferredSplitBehavior = .tile`,
+  `preferredDisplayMode = .oneBesideSecondary`. Never `.overlay` for the list
+  column — content panes that float over other content re-create the
+  "blown-up iPhone app" feel this project exists to kill.
+- Set `edgesForExtendedLayout = .all` **and**
+  `extendedLayoutIncludesOpaqueBars = true` on the pane, or UIKit reserves the
+  tab bar's height and leaves a dead strip at the bottom (§3).
+- Set `presentsWithGesture` deliberately (likely `false`), because Apollo's own
+  edge pans occupy the same edges (§5.4).
+- Let the system collapse/expand do the work. Implement
+  `splitViewController(_:topColumnForCollapsingToProposedTopColumn:)` only to
+  choose the surviving top VC; do not hand-merge stacks. On expand, rebuild
+  columns from the router's classification of the collapsed stack.
+- Hide the tab bar via the tab bar controller (`hidesBottomBarWhenPushed` /
+  LG minimize APIs are irrelevant here) — the `ApolloTabBarController` object
+  itself must keep existing untouched (§3).
+
+**Routing**
+- Intercept at the ObjC shim (`pushViewController:animated:`) and reroute by
+  calling the destination nav's normal push — never splice `viewControllers`
+  arrays. Apollo's Swift push body (dedupe, `extendedLayoutIncludesOpaqueBars`,
+  `pushing` flag, nav-bar re-show loop) must run on whichever nav actually hosts
+  the VC (§2).
+- Remove a VC from its source stack *before* pushing it elsewhere, or Apollo's
+  duplicate-push guard silently eats later pushes of the same instance (§2).
+- Never reroute modals, and never reroute during an in-flight transition
+  (`pushing`/`popping` ivars are readable via `MSHookIvar` inside hooks).
+- Clear the destination column's `poppedViewControllers` on cross-column
+  reroutes (§5.4).
+
+**Presentation**
+- Tweak-drawn share sheets / alert-sheet presentations reachable from new column
+  contexts must set popover `sourceView`/`sourceRect` (iPad hard requirement).
+- Apollo's own card presentations center over the window, not the column (§2) —
+  leave as-is for v1.
+
+**Sizing & chrome**
+- New tweak UI in panes must derive geometry from the owning view's bounds /
+  window, never `UIScreen.mainScreen` — and §5.3's migration moves existing
+  modules the same way.
+- Per-column nav bars each resolve their own traits; resolve dynamic colors
+  against the column's own view (`resolvedColorWithTraitCollection:`), the same
+  rule the theme runtime already enforces for `.CGColor` uses.
+- Readable width: cap the secondary column's content at ~`UIView.
+  readableContentGuide` behavior for very wide windows rather than letting
+  comments stretch edge-to-edge on a 13" landscape iPad.
+
+**Desktop-class polish (Phase 4, iOS 16+ where available)**
+- `UIFindInteraction` for comments search (`isFindInteractionEnabled` on the
+  scroll view) instead of extending Apollo's hand-rolled search toolbar.
+- `UINavigationItem.style = .browser` on the supplementary/secondary columns'
+  nav items is worth an experiment for density; it is cosmetic and safely
+  gated on `respondsToSelector:`.
+- Keyboard focus follows the responder chain — route Apollo's existing
+  `keyCommands` (`selectNextCell`, `goIntoCell`, `goBack`, `pageUp`, …) by
+  making the focused column's nav controller first responder, not by
+  duplicating the commands.
+
+## 6a. RESOLVED: the destinations rail — UIKit's tab sidebar, option 2
+
+This section previously recorded a blocked decision: a hand-drawn destinations
+rail placed in a split view's primary column **disappears in portrait**, because
+UIKit downgrades a three-column pane to `oneBesideSecondary` at 1032pt and hides
+the primary column. With the floating tab bar retired there would have been no
+way to switch tabs at all. Three options were tabled; option 1 (hide the tab bar
+exactly when the sidebar is visible) was recommended, and the branch sat on
+option 3 (no rail) in the meantime.
+
+**Option 2 won, and the objection recorded against it was wrong.** The
+objection was that `mode = .tabSidebar` "yields four columns in landscape (tab
+sidebar + subreddits + feed + comments), which does not fit 1366pt". That is
+true, and it is not a cost of the tab sidebar — it is a cost of *also* keeping a
+subreddit column. Dropping that column is an improvement on its own terms (it
+duplicated Apollo's "Home ⌄" title menu), so the constraint dissolved rather
+than had to be paid.
+
+What UIKit's sidebar gives that a hand-drawn rail could not:
+
+- **Portrait solves itself.** UIKit collapses the sidebar into a floating tab
+  bar with a reveal button — verified on an iPad Pro 13" in portrait. No custom
+  adaptation logic, and no rotation-triggered appear/disappear to explain away,
+  which was option 1's main cost.
+- The system toggle between sidebar and tab bar, plus platform selection,
+  hover, drag-and-drop and keyboard behavior, none of it written by us.
+- One fixed sidebar for the whole app instead of a rail duplicated per tab —
+  which was the other complaint about the original design.
+
+The one genuine limit stands: **the tab sidebar is iOS 18+**. iOS 14–17 iPads
+keep the floating tab bar beside the two-column panes. That is a coherent
+layout, just a less native one, so the feature degrades rather than becoming
+unavailable. Option 1 remains the fallback if that ever needs improving.
+
+## 7. Open questions
+
+1. ~~**Sidebar destinations rail styling.**~~ **Answered:** UIKit draws it
+   (§6a). Nothing to style; it follows the platform.
+2. **Detail column empty state.** Apollo has no "no post selected" artwork.
+   Currently a themed symbol + label. The alternative is auto-selecting the
+   first post on load (Mail's behavior), which costs a network fetch on every
+   subreddit change. Unresolved, but the current state is shippable.
+3. ~~**Does the sidebar persist across tabs visually?**~~ **Answered:** there is
+   now literally one sidebar, owned by the tab bar controller, so the question
+   no longer applies. Verified: switching to Inbox leaves the sidebar untouched
+   and replaces only the content.
+4. ~~**iOS 18+ `mode = .tabSidebar`** as an alternative destinations rail.~~
+   **Answered:** it is not the alternative, it is the design (§6a).
+5. **Should the subreddit list move into the sidebar?** UIKit renders a
+   `UITabGroup`'s `children` as an expandable sidebar section, which is how
+   Music lists playlists — the native home for "your communities". It would
+   require projecting Apollo's favorites/multireddits into `UITab` objects and
+   would lose the real list's Edit mode, A–Z index and sections. Not attempted;
+   the list works well in the list column today. Revisit only if the sidebar
+   feels sparse in use.

--- a/plans/001-unify-ipad-pane-chrome.md
+++ b/plans/001-unify-ipad-pane-chrome.md
@@ -1,0 +1,431 @@
+# Plan 001: Unify the adaptive iPad pane chrome
+
+> **7 September 2026:** Incorporated with revisions into [Plan 002](002-ipad-pane-redesign.md).
+> See [implementation results](003-ipad-pane-implementation-results.md) for the
+> delivered chrome, system Find choice, geometry fixes and remaining release gates.
+> The historical fixed 54-point requirement and narrow file allowlist below are
+> superseded by Plan 002 and the user's authorization to implement the full redesign.
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report—do not improvise. When done, update this plan's status row in
+> `plans/README.md` unless a reviewer says they maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 2ada38e..HEAD -- Makefile src/ipad/ApolloPaneInstall.xm src/ipad/ApolloPaneLayout.h src/ipad/ApolloPaneSplitViewController.h src/ipad/ApolloPaneSplitViewController.m src/ipad/ApolloPaneRouter.xm src/ApolloLiquidGlass.xm src/ApolloFindInComments.xm src/ApolloSubredditHeaders.xm src/ApolloSimDebugTap.xm IPAD_PANE_PR_886_IMPLEMENTATION.md`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding. A semantic
+> mismatch is a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L (multi-day, including simulator matrix)
+- **Risk**: MED — navigation and search behavior are preserved, but the work
+  coordinates several UIKit-owned surfaces across resize/rotation transitions.
+- **Depends on**: none
+- **Category**: tech-debt / direction
+- **Planned at**: commit `2ada38e`, 2026-09-04
+
+## Why this matters
+
+PR #886 successfully re-hosts Apollo's real list and detail controllers, but it
+does not yet give their chrome a single visual policy. In the 13-inch landscape
+comments state, four independent owners produce five equal-weight islands: the
+tab controller's floating destination bar, the primary navigation row, the
+detail title capsule, Apollo's comments-search toolbar, and the detail action
+capsule. Their frames are technically valid, but the result has no clear
+information hierarchy and immersive artwork makes the primary row look like a
+separate floating banner.
+
+After this plan, pane mode has one deterministic chrome model:
+
+1. exactly one global destination surface (sidebar when wide by default,
+   otherwise the system top tab bar),
+2. exactly one aligned context row per visible content pane,
+3. search replaces the detail row's normal contents while active instead of
+   adding another row,
+4. only interactive title controls receive a title capsule, and
+5. immersive artwork begins below pane chrome instead of becoming its substrate.
+
+The behavior must remain opt-in, iPad-only, and unchanged when pane mode is off.
+
+## Target layout matrix
+
+| State | Destination surface | Primary context | Detail context | Search behavior |
+|---|---|---|---|---|
+| Wide regular (13-inch landscape / sufficiently wide Stage Manager) | Sidebar preferred on first presentation | One 54-pt row | One 54-pt row | Replaces detail context content |
+| Medium regular (11-inch landscape, 13-inch portrait) | UIKit top tab bar is allowed | One row below it | One aligned row below it | Replaces detail context content |
+| Narrow regular / compact (iPad mini portrait, narrow Stage Manager, Slide Over) | UIKit-selected tab presentation | Existing collapsed Apollo stack | No second simultaneous row | Existing one-column search behavior |
+| Empty detail | Same width policy | One row if the primary needs it | No orphan title/action capsules | Not shown |
+| Settings / Inbox / Search tabs | Same width policy | Native list title/actions | Native detail title/actions | No Home/comments-specific policy |
+
+The width decision must use the selected tab controller's actual content bounds,
+not `UIScreen.mainScreen`. Use a named constant derived from the layout
+invariant, not a device-name check: the sidebar is preferred only when its width,
+the 340-pt minimum primary, the separator, and a useful detail width all fit.
+Start the spike around 1180 points and adjust from hierarchy measurements.
+
+## Current state
+
+### Architectural intent already recorded
+
+- `docs/ipad-pane-layout-plan.md:571-584` calls full-width chrome assumptions
+  the branch's "largest hidden cost" and names a planned `ApolloPaneChrome.xm`
+  reconciliation layer. That file does not exist at commit `2ada38e`.
+- `docs/ipad-pane-layout-plan.md:737-742` already recommends replacing the
+  hand-rolled comments search toolbar with `UIFindInteraction` and spiking
+  `UINavigationItemStyleBrowser` for pane density.
+- `docs/ipad-pane-layout-plan.md:748-780` selects UIKit's tab sidebar as the
+  one persistent destination surface, while retaining UIKit's adaptive top tab
+  presentation when the sidebar is collapsed or unavailable.
+
+### The four current chrome owners
+
+1. `src/ipad/ApolloPaneInstall.xm:377-433` sets
+   `tabBarController.mode = UITabBarControllerModeTabSidebar`. UIKit still lets
+   the sidebar be minimized into `_UIFloatingTabBar`, so pane mode can show the
+   global 44-pt tab strip above both pane nav bars.
+2. `src/ipad/ApolloPaneSplitViewController.m:2067-2076` installs Apollo's
+   original navigation controller as the primary and constructs a second real
+   Apollo navigation controller for detail. This is correct and must remain;
+   the work is a policy over these controllers, not their replacement.
+3. `src/ApolloLiquidGlass.xm:1126-1162` recenters every title control and creates
+   a glass capsule for Jump Bars *and plain titles*. This turns passive labels
+   such as “21 Comments”, “Settings”, and “Apollo Reborn” into button-like
+   islands in pane mode.
+4. `Headers/ObjC/_TtC6Apollo21ASTableViewController.h:20-41` exposes Apollo's
+   search state and `upperToolbar`; `src/ApolloFindInComments.xm:3-49` preserves
+   Apollo's native comments-search pipeline. Runtime inspection on the 13-inch
+   simulator measured the comments toolbar at `(detailX, navMaxY, detailWidth,
+   45)`—a separate row below the 54-pt detail navigation bar.
+
+### Geometry is already correct
+
+Do not reopen the solved frame problem. The column host in
+`src/ipad/ApolloPaneSplitViewController.m:492-515` deliberately aligns the
+detail navigation controller to the primary's real frame without writing
+layout inputs from `viewDidLayoutSubviews`. Live hierarchy measurements at
+1376×1032 show:
+
+```text
+floating tabs: y=32, height=44       (only while sidebar is hidden)
+primary nav:   y=86, height=54
+detail nav:    y=86, height=54
+comments find: y=140, height=45      (while comments search is active)
+```
+
+With the sidebar visible, all three navigation bars (sidebar, primary, detail)
+start at y=32 and are 54 points high. Preserve these alignment invariants.
+
+### Immersive art currently owns the chrome substrate
+
+`src/ApolloSubredditHeaders.xm:1711-1772` derives an ambient background region
+from the table's complete adjusted top inset and explicitly describes that inset
+as “the full chrome above the table header.” In a pane, that makes one column's
+content art paint underneath its navigation row while the neighboring detail
+row uses a different page/media substrate. Pane mode needs a boundary at the
+navigation bar's bottom; non-pane and iPhone immersive behavior must not change.
+
+### Applicable repo conventions
+
+- Gate every new runtime path with `ApolloPaneLayoutActive()` or
+  `ApolloPaneLayoutEnabled()`; the feature is opt-in and dormant on iPhone.
+- Use `ApolloLog` for privacy-safe diagnostics.
+- Derive geometry from the owning view/window, never `UIScreen.mainScreen`.
+- Do not make layout-driving writes from `layoutSubviews`; use safe-area,
+  transition, navigation-settlement, or coalesced next-run-loop callbacks.
+- Preserve Apollo's real navigation controllers and native push/pop methods.
+- Use 4-space indentation and same-line braces.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Device build | `make package` | exit 0; a package is produced with the pinned iOS 26 SDK |
+| Simulator loop | `scripts/run-in-sim.sh --glass --dark` | exit 0; Apollo launches and pane hooks log as installed |
+| Relaunch | `scripts/run-in-sim.sh --no-build --glass --dark` | exit 0; Apollo relaunches without rebuilding |
+| Verify injection | `xcrun simctl spawn "$(cat .sim/device.txt)" log show --last 2m --predicate 'subsystem == "apollofix"'` | contains ApolloFix/pane module-load lines |
+| View hierarchy | `echo dump > /tmp/apollofix-tap.txt && xcrun simctl spawn "$(cat .sim/device.txt)" notifyutil -p apollofix.debugtap` | `/tmp/apollofix-dump.txt` is refreshed |
+
+`./.sim/backup.zip`, when present, contains live credentials. It is ignored and
+may be used by the simulator script, but must never be printed, inspected,
+copied into `plans/`, or committed.
+
+## Scope
+
+**In scope** (the only source files to modify):
+
+- `Makefile`
+- `src/ipad/ApolloPaneChrome.h` (create)
+- `src/ipad/ApolloPaneChrome.xm` (create)
+- `src/ipad/ApolloPaneInstall.xm`
+- `src/ipad/ApolloPaneLayout.h`
+- `src/ipad/ApolloPaneSplitViewController.h`
+- `src/ipad/ApolloPaneSplitViewController.m`
+- `src/ipad/ApolloPaneRouter.xm`
+- `src/ApolloLiquidGlass.xm`
+- `src/ApolloFindInComments.xm`
+- `src/ApolloSubredditHeaders.xm`
+- `src/ApolloSimDebugTap.xm`
+- `IPAD_PANE_PR_886_IMPLEMENTATION.md`
+- `plans/README.md`
+
+**Out of scope** (do not touch):
+
+- Pane routing, history, selection, collapse/expand topology, or readable-width
+  behavior except to call the chrome policy after existing settlement points.
+- Replacing either navigation controller or copying Apollo navigation items into
+  a custom toolbar.
+- Global/iPhone Liquid Glass title behavior.
+- Global removal of subreddit/profile immersive headers.
+- Theme colors, Theme Manager, settings-form geometry, feed/comment cell layout,
+  or the divider drag affordance.
+- Any new user-facing setting in the first implementation. Width/state policy
+  should be deterministic before adding preferences.
+
+## Git workflow
+
+- Work on a child branch such as `fix/886-ipad-pane-chrome` from the current PR
+  branch.
+- Use one commit per logical unit; existing commit messages use imperative form,
+  e.g. `Prevent iPad detail forms from snapping after display`.
+- Do not push or open a PR unless the operator explicitly asks.
+
+## Steps
+
+### Step 1: Add a pane-chrome policy owner and simulator diagnostics
+
+Create `ApolloPaneChrome.h/.xm`, add it to `ApolloReborn_FILES`, and make it the
+single owner of visual chrome decisions. It should accept the active pane and
+its primary/detail navigation controllers, derive these state inputs, and apply
+idempotently:
+
+- pane active vs collapsed,
+- actual pane/content width,
+- sidebar visible vs top tab bar visible,
+- primary/detail top controllers,
+- comments-search inactive vs active,
+- immersive-header active vs ordinary content.
+
+Expose narrow functions such as `ApolloPaneChromeRefresh(pane, reason)` and
+queries used by `ApolloLiquidGlass.xm` / `ApolloSubredditHeaders.xm`; do not make
+those global modules rediscover pane ownership by scanning windows.
+
+Call refresh from existing stable lifecycle points: after pane installation,
+after navigation settles in `ApolloPaneRouter.xm`, and from the pane's existing
+safe-area/transition/display-state callbacks. Coalesce duplicate refreshes onto
+the next main run-loop turn and log only when the resolved state changes.
+
+Add a simulator-only `chromedump` command that writes/logs: content width,
+collapsed state, sidebar hidden state, destination presentation, primary/detail
+nav frames, active search host/frame, and count of pane title-glass views. Do not
+log any title/search text.
+
+**Verify**: simulator build and `chromedump` succeed. Repeating `chromedump`
+without a state change reports identical values and produces no repeated policy
+mutation logs.
+
+### Step 2: Prefer the destination sidebar only when the layout is truly wide
+
+At pane installation and after width-class/size transitions, prefer
+`tabBarController.sidebar.hidden = NO` only when all of these are true:
+
+- pane mode is active and expanded,
+- the tab sidebar is available,
+- actual content width satisfies the named wide-layout invariant,
+- this scene has not recorded an explicit user collapse for the current wide
+  presentation.
+
+Observe sidebar visibility changes through the public sidebar delegate callback
+where available, without replacing another non-nil delegate. If reliable
+explicit-vs-programmatic intent cannot be distinguished on iPadOS 18–26, apply
+the preference once per scene on first wide presentation and never force it
+again. A user pressing UIKit's sidebar toggle must remain able to collapse it.
+
+Do not force a sidebar in 13-inch portrait, iPad mini portrait, narrow Stage
+Manager, or when doing so would violate the 340-pt primary minimum plus useful
+detail width. Do not use device names or screen bounds.
+
+**Verify**: cold 1376×1032 launch resolves `destination=sidebar`; manually
+collapsing it resolves `destination=top-tabs` and stays collapsed through a tab
+switch. At 1032×1376 and narrower widths, UIKit's top-tab/overlay adaptation
+remains reachable.
+
+### Step 3: Make pane navigation items read as one context row
+
+For visible primary/detail items in expanded pane mode, spike
+`UINavigationItemStyleBrowser` (iOS 16+) and retain it only if it produces these
+measured outcomes on both iPadOS 26 and 27:
+
+- titles align on the same baseline,
+- the primary Jump Bar still opens and searches correctly,
+- Back and all native trailing actions remain reachable,
+- no title/action overlap at 340-pt primary width or with Dynamic Type,
+- push/pop/interactive-pop animations remain native.
+
+Regardless of whether browser style survives the spike, change the pane-active
+Liquid Glass rule so passive plain titles do not get the custom title capsule.
+Keep capsules for genuinely interactive custom title controls such as Apollo's
+Home Jump Bar. Preserve current behavior outside active pane mode.
+
+Normal comments chrome should be one detail nav row: a low-emphasis plain
+“Comments” title (or the native title without its capsule) plus the existing
+trailing action group. Move the numeric comment count out of navigation identity
+only if this can be done without fabricating model data; otherwise keep the
+native text but remove its button-like capsule. Never rewrite unrelated screen
+titles.
+
+**Verify**: in Home, Settings, Inbox, and a comments thread, `chromedump`
+reports primary/detail bars with equal `minY` and height within 0.5 pt, and zero
+plain-title glass views. The interactive Home Jump Bar still has one title-glass
+view and remains tappable.
+
+### Step 4: Make comments search replace, not stack
+
+Keep Apollo's existing comments matching, highlight, next/previous, multi-term,
+and scroll-watchdog behavior in `ApolloFindInComments.xm`. Change only its pane
+presentation.
+
+Preferred implementation order:
+
+1. Spike a `UIFindInteraction` adapter around Apollo's existing search session.
+   Use the system find navigator only if the adapter can preserve match count,
+   current result, next/previous, comma-separated terms, keyboard Command-F,
+   and the existing cancellation/scroll watchdog.
+2. If that cannot be achieved without reimplementing Apollo's matcher, retain
+   `ApolloSearchToolbar` but re-host it inside the detail navigation row while
+   search is active. Hide/suppress the normal detail title and action group for
+   the duration, restore them atomically on dismissal, and keep the detail
+   content's top edge unchanged.
+
+On iOS 26+, a `UISearchController` with integrated/integrated-button placement
+is acceptable only if it feeds Apollo's existing matcher rather than creating a
+second search state. On iOS 18–25, use the retained toolbar takeover fallback.
+Do not leave both search systems live.
+
+The active state invariant is: one search surface, in the existing 54-pt detail
+context row, with no additional 45-pt row and no simultaneously visible comments
+title/actions. Dismissal restores the normal row without a width/height snap.
+
+**Verify**: before and during comments search, `chromedump` reports the same
+detail content `minY`; during search there is exactly one visible search host and
+no separate `ApolloSearchToolbar` below the nav bar. Query edit, comma-separated
+terms, next, previous, wrap-around, keyboard dismissal, rotation, and a user
+scroll during the watchdog all preserve current behavior.
+
+### Step 5: Bound immersive artwork below pane chrome
+
+In active expanded pane mode only, make the subreddit ambient/header artwork's
+top visible boundary start at the owning navigation bar's bottom. The navigation
+row should use one stable theme/material treatment independent of whether the
+primary shows a banner and whether the detail shows media. Preserve the banner
+inside feed content and preserve all current non-pane/iPhone immersive behavior.
+
+Do not hardcode the global tab bar height or status-bar height. Ask the pane
+chrome owner for the resolved content boundary derived from the owning nav bar
+frame. Keep the existing brightness sampling for any interactive control that
+still overlays art below that boundary.
+
+**Verify**: switching between Native/Classic/immersive header modes does not
+change nav-bar frames. In immersive Home with empty detail and with comments
+open, artwork begins below both context bars and neither bar's substrate changes
+color independently. Scrolling still collapses/reveals header content without a
+flash or gap.
+
+### Step 6: Run the complete layout matrix and update the PR tracker
+
+Exercise, at minimum:
+
+- 13-inch: portrait and landscape; sidebar shown and manually hidden; empty
+  detail, media comments, self-post comments, active comments search, Settings
+  detail, Inbox detail.
+- 11-inch: portrait and landscape; same empty/comments/search states.
+- iPad mini: portrait and landscape; confirm the system chooses overlay/collapse
+  before either pane becomes unusably narrow.
+- Stage Manager/narrow window equivalents: widths around the policy threshold
+  and at 480 points; resize across the threshold in both directions.
+- Light and dark appearance; stock and custom theme; Header Style modes; largest
+  practical Dynamic Type size.
+- Rotate/rescale while search is active, while a detail push transition is
+  settling, and after manually resizing the primary divider.
+
+For each state, capture a screenshot and `chromedump` under `.sim/`. Record the
+matrix and exact filenames in `IPAD_PANE_PR_886_IMPLEMENTATION.md`; never commit
+screenshots or the backup.
+
+**Verify**: `make package` exits 0, the simulator matrix passes all invariants,
+and `git status --short` lists only in-scope source/doc changes plus the plan
+status update.
+
+## Test plan
+
+There is no automated test suite; use the simulator and simulator-only structured
+diagnostics as the regression harness.
+
+For every matrix state, verify these machine-readable invariants:
+
+- `destination` is exactly `sidebar` or `top-tabs`, never both visible.
+- When two panes are visible, primary/detail nav `minY` and height differ by no
+  more than 0.5 point.
+- At most one context row contributes to each pane's content inset.
+- Activating comments search does not change detail content `minY`.
+- Active search has one search host; normal title/actions are absent until it
+  dismisses.
+- Plain pane titles create zero custom glass capsules; the Home Jump Bar creates
+  exactly one.
+- Compact/collapsed mode reports no simultaneous secondary chrome owner.
+
+Manual behavior checks still required: every button/menu works, keyboard focus
+lands in search, Command-F opens it, next/previous selection stays visible, Back
+and forward history work, and sidebar show/hide remains user-controlled.
+
+## Done criteria
+
+- [ ] `make package` exits 0.
+- [ ] `scripts/run-in-sim.sh --glass --dark` exits 0 and injection logs confirm
+      all pane/chrome hooks loaded.
+- [ ] The complete device/width/state matrix is recorded in
+      `IPAD_PANE_PR_886_IMPLEMENTATION.md` with `.sim/` screenshot/dump names.
+- [ ] Wide cold launch prefers the sidebar; user collapse is respected.
+- [ ] Every expanded two-pane state has one aligned context row per pane.
+- [ ] Comments search replaces detail context content and does not add vertical
+      chrome height.
+- [ ] Passive pane titles have no custom Liquid Glass capsule; interactive Home
+      Jump Bar behavior is unchanged.
+- [ ] Pane-mode immersive artwork starts below chrome; iPhone and pane-off
+      immersive behavior is unchanged.
+- [ ] No files outside the in-scope list are modified.
+- [ ] `plans/README.md` status is updated.
+
+## STOP conditions
+
+Stop and report back—do not improvise—if:
+
+- In-scope current code no longer matches the ownership/geometry described above.
+- Preserving Apollo's matcher requires replacing or synthesizing its private
+  `commentsSearch` Swift storage.
+- Search takeover cannot preserve current keyboard, next/previous, result count,
+  and dismissal semantics after two reasonable approaches.
+- Browser-style navigation loses any native action, breaks the Home Jump Bar, or
+  overlaps at the 340-pt primary minimum; reject that spike and keep navigator
+  style rather than patching UIKit's private views.
+- Detecting explicit sidebar intent would require private UIKit selectors. Fall
+  back to once-per-scene wide preference instead.
+- The immersive boundary requires changing feed/comment cell measurement or
+  Texture layout. The fix must stay at the background/chrome layer.
+- Any change would affect iPhone or pane-disabled behavior.
+- A verification failure persists after two reasonable fixes.
+
+## Maintenance notes
+
+- Reviewers should reject geometry derived from `UIScreen.mainScreen`, writes
+  from `layoutSubviews`, or window-wide view scans. The pane object already knows
+  both navigation controllers and is the correct source of state.
+- Keep structured `chromedump` output privacy-safe: frames, class names, booleans,
+  and counts only—never titles, subreddit names, search text, or account data.
+- Any future detail route must opt into the same context-row policy; do not add
+  screen-specific title/search hacks in the route module.
+- If Apple changes tab-sidebar defaults, update only the destination-placement
+  arm of `ApolloPaneChrome`; title/search/immersive rules should remain stable.

--- a/plans/002-ipad-pane-redesign.md
+++ b/plans/002-ipad-pane-redesign.md
@@ -1,0 +1,760 @@
+# Plan 002 — A coherent, responsive Apollo workspace for iPad
+
+Status: implementation delivered in the working tree; release verification remains open.
+Current results: [implementation and verification](003-ipad-pane-implementation-results.md).
+Prepared: 7 September 2026, source baseline `fa5ddcb` on `je/ipad-pane-layout`.
+Evidence: [dated source and visual audit](ipad-pane-audit-2026-09-07.md).
+Starting points: [original engineering plan](../docs/ipad-pane-layout-plan.md),
+[Plan 001](001-unify-ipad-pane-chrome.md), and
+[PR #886 tracker](../IPAD_PANE_PR_886_IMPLEMENTATION.md).
+
+## Recommendation
+
+Keep Apollo's native content controllers and navigation behavior, but make the
+surrounding interface a deliberate iPad workspace. Give each surface one job:
+destinations choose where you are, a scannable list chooses what you are reading,
+and detail gives that content room. Make search contextual and temporary. Keep
+the chrome quiet and consistent. Resize without losing the user's place, and
+make Back track the user's gesture.
+
+The largest visible improvement will come from **chrome hierarchy plus list
+density**, not adding another column. The largest engineering improvement will
+come from **explicit ownership and transition state**, not adding more delayed
+layout repairs. Smoothness is a release criterion supported by device traces.
+
+This roadmap incorporates Plan 001, including its sidebar preference, plain-title
+treatment, search integration, and artwork boundary. It supersedes that plan's
+fixed 54-point requirement, narrow file allowlist, and assumption that all existing
+geometry is settled. Implementation outcomes and validation gates are recorded
+in the results document.
+
+## 1. Product contract
+
+### 1.1 The visible hierarchy
+
+```text
+Wide workspace — one destination surface, two content panes
+┌────────────────┬────────────────────┬────────────────────────────────┐
+│ Destinations   │ Home ⌄      ⌕  ⋯   │ Comments                 ⌕  ⋯ │
+│                ├────────────────────┼────────────────────────────────┤
+│ Posts          │ Title and thumbnail│ Post / media / body            │
+│ Inbox    badge │ Selected post      │                                │
+│ Profile        │ Title and thumbnail│ Comment conversation           │
+│ Search         │ Title and thumbnail│                                │
+│ Settings       │                    │                                │
+└────────────────┴────────────────────┴────────────────────────────────┘
+
+Medium workspace — UIKit destination tabs, then list and detail
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Destination tabs                               │
+├──────────────────────────┬──────────────────────────────────────────┤
+│ Home ⌄             ⌕  ⋯ │ Comments                           ⌕  ⋯ │
+├──────────────────────────┼──────────────────────────────────────────┤
+│ Scannable post list      │ Reading content                         │
+└──────────────────────────┴──────────────────────────────────────────┘
+
+Narrow workspace — one logical browsing path
+┌──────────────────────────────┐
+│ Back     Current context  ⋯ │
+├──────────────────────────────┤
+│ List OR selected detail      │
+│                              │
+└──────────────────────────────┘
+```
+
+These are hierarchy sketches, not custom toolbar specifications. UIKit owns the
+navigation items, bars, sidebar, and their platform presentation. Screenshots and
+measured hierarchies must establish exact positions for each supported OS.
+
+Rules:
+
+1. One global destination mechanism is primary at a time. System transition
+   crossfades may temporarily contain both representations; don't count hidden
+   or noninteractive transition views as duplicate navigation.
+2. Each visible content pane has one context/action row in its normal state.
+   At normal text sizes, target aligned baselines and compatible heights. Derive
+   actual dimensions from UIKit; 54 points is historical evidence, not a constant.
+3. Passive titles are text. Interactive Home/Jump Bar titles retain a discoverable
+   disclosure/control treatment. Keep native action grouping; do not wrap every
+   label and icon in another glass island.
+4. The primary pane is a selection surface. The detail pane is the reading or
+   task surface. A long portrait image must not turn the selection surface into
+   an almost single-item feed unless the user deliberately chooses that style.
+5. Search names its scope: Reddit search, this feed, Settings, or this thread.
+   Opening one search does not unexpectedly activate or dismiss another pane's
+   search. Find-in-thread is not a second global destination.
+6. Selected row and keyboard-focused row are distinguishable. Selection survives
+   reloads by identity, not by painted coordinates. No auto-scroll of the list
+   just because detail content appears.
+7. A detail change must not resize the list or automatically toggle the sidebar.
+   User sidebar intent survives tab switches and content selection.
+8. Modal tasks belong to the originating scene; their presentation type decides
+   whether they cover the scene or anchor to a column. Dismissal restores focus.
+9. Pane-disabled and unsupported devices retain their existing behavior. Future
+   adaptive-phone eligibility is a separate rollout after iPad work passes.
+
+### 1.2 Pane contents by destination
+
+| Destination | Primary | Detail | Empty state |
+|---|---|---|---|
+| Posts | Native community index/feed with pane density | Selected post; links continue here | “Select a post to read the discussion” |
+| Inbox | Native mailbox/category index | Category list, conversation, or modern mailbox | “Choose a mailbox or conversation” |
+| Profile | Native profile index | Selected history/list/profile subpage | Contextual instruction, not “No Post Selected” |
+| Search | Search input/results in their existing navigation path | Selected result | Helpful scope guidance; no unsolicited network search |
+| Settings | Native settings index | Selected settings/task screen | “Choose a setting” |
+
+Empty detail remains spatially stable. Do not auto-select the first network item
+or expand/collapse columns on every selection/clear. Use a restrained symbol,
+brief instruction, and only a useful action when necessary. Loading, offline,
+removed, and failed detail are different states; none should masquerade as empty
+selection. Retry stays attached to the selected item and scene.
+
+### 1.3 Width and height policy
+
+Define `C` as the actual usable width available to the **two content panes**, after
+any visible destination sidebar and system margins. Define `Pmin`, `Ppreferred`,
+`Dmin`, and divider spacing `G` independently. Two panes are useful only if
+`C >= Pmin + G + Dmin`. Preferred primary width must yield when detail would be
+unusable. A global sidebar is preferred only if the resulting content width still
+satisfies that invariant.
+
+Initial design values to evaluate, not Apple requirements:
+
+- Primary minimum: retain 340 points initially; typical working width 360–420;
+  keep the existing 480 upper bound until density experiments justify a change.
+- Detail minimum: start around 420 points for standard text, and determine a
+  larger requirement for accessibility text or action-heavy screens.
+- Sidebar width: use the resolved system value. Avoid hardcoding 270/280 points.
+- Prose measure: use the current 680-point cap as the baseline, with the current
+  accessibility relaxation as a comparison. Validate nested comments and language
+  wrapping rather than assuming one measure is ideal for every screen.
+- A small hysteresis band, initially 32 points, may stabilize **our preference**
+  near a threshold. It must not fight UIKit's resolved mode or force unusable panes.
+
+With a 340-point list and approximately 420-point detail, a near-square 800-point
+content area could support two panes but not an additional persistent sidebar.
+This is a sizing example, not a prediction of foldable hardware.
+
+Use three adaptive presentations: sidebar + list/detail, tabs + list/detail, and
+one-column navigation. Honor UIKit's temporary overlay/secondary-only modes and
+always expose a public way back to the hidden list. Distinguish temporary display
+state from compact navigation topology.
+
+Height matters too. A short wide window with the keyboard open may fit two columns
+but not stacked bars, a large banner, and a composer. Keep active input and its
+actions visible; avoid orientation-based rules. Accessibility text may require a
+larger context/search surface. Prefer a deliberate accessible layout to cramming
+every control into 54 points.
+
+## 2. Architecture to build toward
+
+```mermaid
+flowchart TD
+    scene[Scene + native entry adapters] --> registry[Scene pane coordinator]
+    registry --> tab[Apollo tab controller: same identity and tab indices]
+    tab --> pane[Per-tab pane coordinator]
+    pane --> state[Navigation and topology state]
+    pane --> geometry[Resolved layout policy]
+    pane --> chrome[Chrome and search presentation]
+    pane --> selection[Semantic selection]
+    state --> primary[Real Apollo primary navigation]
+    state --> detail[Real Apollo detail navigation]
+    geometry --> host[Column host constraints]
+    chrome --> items[Native items and scoped feature adapters]
+```
+
+Suggested ownership boundaries; names may change if existing abstractions fit:
+
+| Owner | Owns | Must not own |
+|---|---|---|
+| `ApolloPaneSceneCoordinator` | Installation status, weak pane/owner registry, destination preference, user width, originating scene, lifecycle cancellation | Content matching or cell layout |
+| `ApolloPaneNavigationState` | Logical primary/detail branches, source/account generation, transaction state, pending intent and cancellation | Material colors or arbitrary view scans |
+| `ApolloPaneGeometry` | Pure layout decision inputs/outputs, resolved frame sampling, owned inset contributions | Route classification or persistent state writes during measurement |
+| `ApolloPaneChrome` | Title/action/search presentation, artwork boundary, idempotent state application | Recreating native navigation stacks |
+| `ApolloPaneSelection` | Stable item identity, native selection and accessibility synchronization | Deciding unrelated routes |
+| `ApolloPaneColumnHostViewController` | Containment and constraints around real Apollo navigation | Feed/search semantic state |
+| Runtime adapters/Swift bridge | Checked access to Apollo selectors and typed private storage | Broad reinterpretation of unknown classes or UIKit internals |
+
+Start by extracting the host, geometry, and transaction handling where ownership
+is already identifiable. Preserve controller instances and existing successful
+lineage checks. Do not replace the whole 4,457-line class in one unreviewable edit.
+
+The navigation state should express stable states (expanded, compact-primary,
+compact-detail) and transition ownership (navigation, topology, root return),
+rather than allowing arbitrary combinations of booleans. Keep generation tokens
+for stale asynchronous work, but make their owner and terminal event explicit.
+A latest-selection intent may supersede another selection; lifecycle cleanup and
+user Back must have defined semantics and must not accidentally coalesce as the
+same kind of operation.
+
+Every asynchronous callback must answer: which scene/pane/transaction owns me,
+what invalidates me, and can I still mutate this controller? Every UIKit mutation
+occurs on the main thread. An off-main helper must either assert its contract or
+enqueue the **complete operation**; re-enqueuing only a boolean “should defer”
+query can silently drop work when the main-thread result is NO.
+
+No generic event bus or new dependency is needed. Keep implementation details out
+of user-facing UI. New `.m/.xm` files go into `ApolloReborn_FILES`; Swift bridge
+changes remain small and documented. If settings UI changes, read
+`src/settings/README.md` and use its declarative form model.
+
+## 3. Implementation work packages
+
+Priority P1 means required for the redesigned iPad release; P2 follows before
+calling it fully polished; P3 is optional product expansion. Effort is relative:
+S = localized change, M = several connected paths, L = a substantial subsystem,
+XL = compatibility-sensitive work with device/OS validation. These are not timing
+promises. Each package gets a focused commit/review and recorded evidence.
+
+| ID | Work | Priority / effort | Dependencies | Audit findings |
+|---|---|---|---|---|
+| W01 | Reproducible baseline and instrumentation | P1 / M | — | All; A17 |
+| W02 | Bootstrap and scene ownership | P1 / M | W01 | A11–A12 |
+| W03 | Transition liveness and navigation-state extraction | P1 / L | W01 | A05–A06, A13–A14 |
+| W04 | Adaptive geometry and divider | P1 / L | W02–W03 | A03, A07–A09 |
+| W05 | Unified chrome and destinations | P1 / L | W04 | A01, A16 |
+| W06 | Controller-owned find and search presentation | P1 / L | W03, W05 | A01, A10 |
+| W07 | Pane list density, selection, empty/detail states | P1 / L | W04–W05 | A02, A15 |
+| W08 | Interactive Back and gesture arbitration | P1 / XL | W03–W04 | A04, A07, A17 |
+| W09 | Reading width and async content stability | P2 / L | W04, W07 | A15 |
+| W10 | Keyboard, accessibility, pointer, modal ownership | P1 / L | W02, W05–W08 | A11, A17 |
+| W11 | Performance optimization and memory lifecycle | P1 / L | Baseline first; final pass after W04–W10 | A06, A09, A16–A17 |
+| W12 | Release matrix and documentation reconciliation | P1 / L | W02–W11 | All |
+| W13 | Optional richer sidebar and window workflows | P3 / L | W12 | Product extension |
+| W14 | Adaptive-phone / foldable preparation | Separate / XL | Stable W02–W12 | Section 6 |
+
+### W01 — Establish a trustworthy baseline
+
+Build the current revision for simulator and device. Record commit, dirty state,
+base IPA identity, baked/injected dylib UUID, runtime, device, appearance, content
+style, actual view dimensions, text size, selected tab and sidebar state. Verify
+that exactly one copy of the tweak is loaded. The existing cached runtime used in
+the audit cannot substitute for this.
+
+Extend simulator diagnostics with one structured pane snapshot. Include scene-local
+opaque ID, pane/tab ID, logical and physical stack depths, display mode, usable
+width/height, nav context/search frames, chrome owners, active transaction age,
+refresh/write counts, active watchdog count, and loaded/visible controller counts.
+Avoid titles, account identifiers, queries, URLs, and raw model descriptions.
+
+Add `os_signpost` intervals for selection → detail first presentation,
+navigation/topology transitions, geometry/chrome application, and divider drag.
+Add counters at known measurement/refresh boundaries without installing a broad
+per-scroll logger. Keep instrumentation gated and measure its overhead. Reuse
+existing pane debug probes instead of making a second test language.
+
+Use stable public read-only content for visual captures; use synthetic destinations
+or a disposable account for row-swipe/gesture scenarios. Record loading and
+already-loaded content separately. Save screenshots, short screen recordings,
+structured snapshots, and device traces under ignored local artifact directories.
+
+**Done:** before-state evidence for Home text/media/empty, Settings, Inbox, search,
+compact and two-pane states; a real-device performance baseline or an explicitly
+open hardware gate. Successful compilation is not marked as visual/performance
+validation.
+
+### W02 — Make pane bootstrap and routing scene-owned
+
+Resolve required runtime classes/selectors and bridge layout contracts before
+the scene's tab children are detached. Publish required/optional capability
+results; the installer must not commit if the router could not initialize.
+Retain the existing exact rollback and fault-injection tests.
+
+Introduce per-scene installation status and weak ownership registration. Keep a
+cheap aggregate active check if useful, followed by owning-pane lookup. Disconnect
+invalidates pending work and removes that scene's registrations; another scene
+continues unaffected. Persist only scene preferences that should survive launch,
+and prune keys for discarded sessions without erasing active-session preferences.
+
+Add an originating scene/controller path to `ApolloRouteURLThroughApp` and migrate
+gallery/deleted-comment callers. Select the originating scene's real tab hierarchy
+before entering native URL logic. If Apollo's AppDelegate requires a compatibility
+ivar, save and restore the exact old value in `@try/@finally`; do not retain the
+first scene forever. Scope native-entry getter translation to the target tab
+controller rather than every tab controller reached during a global depth window.
+
+**Done:** two scenes with different tabs/details route URLs to their origin;
+failed installation in B leaves A working; cold/warm native and custom routes
+still work; required-class failure leaves stock containment.
+
+### W03 — Consolidate transition settlement and preserve state invariants
+
+First fix waiting flags and watchdog lifetime in place. Then extract one transaction
+owner. Handle accepted/rejected/late registration and duplicate completions
+idempotently. Never infer “completion won't happen” solely from NO. A coordinator
+identity or generation must prevent an old completion releasing a newer gate.
+
+Replace independent unbounded polling chains with a cancellable bounded watchdog
+only where callback coverage is insufficient. Check transaction liveness before
+rescheduling. On disconnect, superseded token, or terminal event, release retained
+closures/stacks and stop waking. On deadline, log a coarse failure and preserve the
+last valid hierarchy; don't clear UIKit's internal flags or force a concurrent pop.
+Derive a deadline from the native transition plus measured grace, accounting for
+an interactive gesture that legitimately remains active under the user's finger.
+
+Extract source/account generations and semantic navigation intent from chrome text.
+Preserve the existing typed forward-history clear. Keep `setViewControllers` for
+intentional detail-root replacement and native push/pop for branch continuation.
+
+Add focused transition/state tests because these paths can lose user navigation:
+latest selection during cancel, clear during root return, expand during compact
+restore, missing completion, duplicate completion, stale source, and scene teardown.
+Use a small testable state helper plus simulator integration, not tests that merely
+assert private flag names or duplicate implementation code.
+
+**Done:** one terminal resolution per transaction, no stale replay, no active
+watchdog after settlement/disconnect, correct Back/forward and selection across
+repeated topology cycles, and no dropped off-main operation if that API is supported.
+
+### W04 — Make geometry deterministic and dragging cheap
+
+Extract physical-edge resolution and the pure width policy. Correct RTL boundary,
+drag sign, and keyboard meaning. Track original preferred width separately from
+resolved width. Restore the original preference on cancel. Store finite clamped
+values only. Native resolved geometry never silently becomes persisted intent.
+
+Keep actual column frames as the source for host alignment. Resolve dimensions
+after UIKit settles, and coalesce safe-area/size events without stranding refreshes.
+Do not reintroduce constraint writes from `layoutSubviews`. Test continuous resize
+as distinct from a trait-only compact override.
+
+For live drag, update the visible pane only. If high input frequency causes more
+than one costly update per frame, consume the latest sample with a display-paced
+mechanism active only during drag. Stop it at end/cancel/background; don't add a
+permanent display link. Apply final width to hidden panes before their next visible
+frame, preserving lazy loading. Retain instant finger tracking; don't animate each
+sample with a separate spring. Add Reset Column Width to the divider's accessible
+actions/context menu if discoverable without extra permanent chrome.
+
+On iOS 26+, use the public secondary minimum where it produces the intended
+resolved behavior. On 18–25, choose supported show/hide/display preferences from
+the same invariant. Never force size-class overrides as a production layout policy.
+
+**Done:** no unusably narrow detail; cancelled drag restores preference; no hidden
+pane reflow per drag tick; stable thresholds in both directions; correct RTL,
+pointer hit region and no competing width writers.
+
+### W05 — Give chrome one owner
+
+Create `ApolloPaneChrome.h/.xm` and connect it to resolved pane state. Its snapshot
+includes owner/controller identity, actual usable geometry, sidebar/tab state,
+search state, content role, theme, text size, and reduced-transparency/motion traits.
+Apply only changed state at stable lifecycle boundaries. The Liquid Glass/header
+modules query this owner; they do not scan windows to rediscover it.
+
+Carry forward Plan 001 with these refinements:
+
+- Prefer the system sidebar on the first truly wide presentation, respect user
+  collapse, and never reopen it after selecting detail. Use public callbacks
+  without displacing an existing delegate. If intent cannot be distinguished,
+  make the preference once per scene, not repeatedly.
+- Remove custom capsule treatment for passive pane titles. Keep genuine title
+  controls and their hover/focus/search behavior. Evaluate browser-style native
+  navigation items only if they preserve Back, Jump Bar, and all native actions.
+- Check primary feed/Settings search as well as comments find. Inactive search
+  should not consume another permanent full-width row by default in the redesigned
+  pane presentation. Keep a clearly discoverable search action.
+- Let navigation titles identify context; counts are subordinate information.
+  Do not synthesize unavailable counts or overwrite unrelated native titles.
+- Bound immersive artwork below the resolved pane context/search boundary. Use
+  a stable shared theme/material treatment for the bars while preserving banner
+  content below them. Include profile headers in the audit, not only subreddits.
+- Expanded-pane hide-on-scroll must not independently move neighboring context
+  rows. Resolve a stable expanded policy and restore Apollo's compact behavior.
+
+Separate the **context row** from UIKit's total navigation/search container in
+diagnostics. At standard text sizes, aligned context baselines should differ by
+no more than 0.5 point. At accessibility sizes, prioritize readable/reachable
+controls and record intentional adaptation. Never change private UIKit subviews
+to satisfy a numeric snapshot.
+
+**Done:** a coherent first visual slice across Home, comments, Settings and Inbox,
+with empty/populated detail; passive titles have no custom capsule; artwork and
+search don't compete with navigation; every native action remains reachable.
+
+### W06 — Fix find ownership before changing its UI
+
+Move comments-search watchdog/node/range/generation into per-controller state.
+Bind query, next, and previous to their receiving controller. Dismiss/disappear
+cancels only that session. Protect synchronous multi-term/capture context with
+save/restore and `@try/@finally`. Retain native match order, count, highlight,
+wrap-around, and comma-term behavior. Cancel pending corrective scrolling on user
+input, query change, route replacement or scene teardown; respect Reduce Motion.
+
+For presentation, first spike the least invasive nav-row takeover of the existing
+toolbar/session. Use native search integration only where the host supports it
+without a second state model. A `UIFindInteraction` spike remains worthwhile for
+keyboard/system behavior, but its system panel can be keyboard-docked or inline;
+it does not promise to occupy the old 54-point navigation row. Arbitrary Texture
+content requires a delegate/find session, not `isFindInteractionEnabled` on a
+generic table. [Apple find interaction documentation](https://developer.apple.com/documentation/uikit/uifindinteraction).
+
+Choose **one** production presentation after measuring the spike. Prefer context
+row takeover at ordinary sizes if every action fits. A system keyboard find panel
+is acceptable with the ordinary title row retained and the redundant Apollo
+toolbar suppressed. Accessibility text may require a deliberate larger find
+surface. In every case, one query/session drives one visible set of find controls,
+with no unexplained content jump. Record any intentional inset change.
+
+Do not reimplement or synthesize Apollo's private matcher simply to meet a visual
+constraint. Separate global Reddit search, feed filtering, settings search and
+thread find; Command-F targets the focused content that supports it.
+
+**Done:** two independent scenes can search; switching tabs preserves appropriate
+session state; next/previous after returning targets the right table; touch and
+hardware keyboards, dismissal, async row changes, and user scrolling all work.
+
+### W07 — Make the list and detail feel designed together
+
+Prototype pane-local use of Apollo's native compact feed nodes at their creation
+entry point. Trace the existing factory/configuration before choosing a hook.
+Keep the user's global content-style preference intact. Existing compact thumbnail
+handling in `ApolloFeedTextPostThumbnails.xm` and filtering in
+`ApolloPostFilters.xm` are required compatibility checks.
+
+Compare two purposeful densities, not arbitrary themes: a scannable compact list
+as the proposed pane default, and a comfortable list that preserves media previews.
+Use bounded thumbnails, enough title lines to identify a post, and subordinate
+metadata. Keep media in detail appropriately sized to its aspect ratio and the
+available reading area. Preserve spoiler/NSFW treatment and all native actions.
+
+Persistent selection should be a restrained row background/accent indicator with
+the selected accessibility trait. Avoid a bright border surrounding a viewport-tall
+post. Focus and hover must remain distinct from committed selection. Do not change
+selection semantics to obtain a prettier screenshot.
+
+Standardize empty/loading/error detail states. Avoid automatic post selection,
+background fetches just to fill whitespace, fake skeleton content, or routing
+changes triggered by an empty placeholder. Expose Retry for the current failed
+route where native behavior allows it.
+
+**Done:** screenshot/interaction comparisons at 340, 400 and 480 primary widths;
+short/long titles and media types remain identifiable; scrolling and selection
+are stable; no global phone preference changes; load/error states preserve context.
+
+### W08 — Restore native-feeling Back and gesture ownership
+
+Within detail depth > 1, restore the real Apollo interactive pop behavior. The
+cross-column root return must not disable that deeper branch gesture. At detail
+root, implement a single progress-driven return to the primary, with native
+transition timing, cancellation, and source/stack reconciliation from W03.
+
+Before adopting a custom interactive root transition, spike whether a better
+supported host/compact topology can expose native Back without the extra hidden
+wrapper bar. Compare it against the existing host using the same cold-route,
+restoration, first-frame, and Texture-width tests. Adopt a simpler topology only
+if it removes special cases and preserves controller identity/containment.
+Otherwise keep the proven host and isolate the root-return transition; don't
+patch private UIKit wrappers or maintain two runtime topology fallbacks forever.
+
+Define recognizer precedence explicitly: divider drag versus content, within-detail
+Back, root Back, forward history, swipe-to-vote, and media gestures. Replace the
+blanket simultaneous-recognition rule with a justified allowlist. Keep gestures
+inside their actual column hit regions; mirror correctly for RTL. Avoid issuing
+live-account content swipes in tests.
+
+**Done:** slow drag follows the finger; reversing/cancelling restores exact state;
+nested detail swipe Back works; a new selection during interaction settles correctly;
+no duplicate nav row or disabled gesture remains after collapse/expand. Reduce
+Motion uses native reduced behavior or a short dissolve without spatial travel.
+
+### W09 — Stabilize reading width and asynchronously arriving content
+
+Preserve the first-frame Settings inset work already shipped on this branch.
+Give the readable-width owner an additive contribution rather than restoring a
+stale absolute inset snapshot. Content-ready events must classify an initially
+unknown comments header without waiting for rotation. Invalidate cached content
+role when a controller genuinely changes content.
+
+For media threads, spike text-row layout against a readable guide while the media
+header remains wide. Do not inset the entire table and letterbox every image.
+Validate nested comment indentation, long links, code blocks, inline images, and
+selection/hit testing. If Apollo/Texture does not expose a safe boundary, retain
+the proven full-width media-thread baseline and document the remaining limitation;
+do not present that phase as complete prose-width coverage.
+
+Preserve scroll anchor by item identity plus local offset across width changes,
+then remeasure once at the new constraint where needed. Do not force reloadData,
+layoutIfNeeded, or all-node invalidation on every pan sample. Framework-owned
+automatic remeasurement should be measured before augmenting it.
+
+**Done:** no full-width-to-centered snap on first visible content; stable position
+after async media/text updates; correct media aspect and readable prose; no inset
+ownership conflict on push/pop, modal dismissal, or compact transitions.
+
+### W10 — Finish input, accessibility, and presentation
+
+Track a weak focused-column intent from actual interaction/responder state, without
+stealing text-field focus on selection. Reuse Apollo's native commands for list
+selection, Enter, Back/forward, page navigation, Jump Bar, and media. Scope divider
+shortcuts so Option-arrow still edits words inside a text field. Command-F and
+Escape first resolve the focused search/modal/task, then navigation.
+
+Verify status-bar tap and `scrollsToTop` with multiple visible scroll views; make
+only the intended scroll target participate if UIKit/native behavior is ambiguous.
+Restore focus to the initiating row/control when detail, search, or a modal closes.
+
+For VoiceOver and Full Keyboard Access, give panes a useful traversal order and
+labels; don't focus hidden columns. Preserve selection announcements and avoid
+announcing every width tick. Test Switch Control divider adjustments, Reduce
+Motion, Reduce Transparency, Increase Contrast, all accessibility text sizes, RTL,
+and long localized titles. Use effective traits and canonical theme colors.
+
+Audit popovers/action sheets, composer/login, media viewers, PiP return, custom
+cards, and modern Chat/Modmail against their originating scene and control.
+Bounds and `sourceRect` conversion come from that hierarchy. Don't blanket-convert
+scene-wide modal tasks to column-only cards. Test indirect input for custom sheet
+dismissal and media pinch/scroll, using built-in recognizers where applicable.
+[Apple's iPhone Mirroring input technote](https://developer.apple.com/documentation/technotes/tn3210-optimizing-your-app-for-iphone-mirroring).
+
+**Done:** each interaction has an explicit owner and escape path; all native
+actions remain reachable with touch, keyboard, and assistive technology; two-scene
+presentation tests do not open or dismiss content in the other scene.
+
+### W11 — Optimize measured work and define memory lifetime
+
+Use the baseline and performance protocol below throughout implementation. Prioritize
+actual main-thread Texture measurement, navigation/chrome commits, image/video
+decode, and render-server/material costs in that order only as traces justify.
+Do not cache private UIKit subtree frames across arbitrary transitions or treat
+simulator wall-clock timings as device performance.
+
+Remove redundant passive-title effect views; make chrome updates state-diffed.
+Inspect title fingerprint/refresh frequency before changing its existing cache.
+Replace global navigation-item ownership scans with weak registrations. Keep the
+already allocation-free tab-minimize predicate; scope policy to the resolved
+visible workspace and avoid scanning all tabs for every offset change if traces
+show material cost. Throttle diagnostic logging, not user input.
+
+During live resize, don't broadcast width/layout to hidden tabs. For selected-post
+changes, avoid unnecessary view loads and duplicate media work; use the existing
+shareable-player lifecycle correctly. Large media in both panes can consume GPU,
+memory and battery even if the geometry code is cheap. Do not silently override
+the user's audio or autoplay preferences to make a benchmark pass.
+
+Define scene-hidden/disconnected/memory-pressure handling: cancel pane-owned work,
+stop active display links, discard transient snapshots/caches, and release obsolete
+transaction stacks. Preserve current navigation/controllers, unsent drafts, active
+media/PiP and their needed state. Only consider evicting inactive detail controllers
+after demonstrating safe semantic restoration; never set arbitrary native views to
+nil as a generic memory fix.
+
+**Done:** device targets below pass, no idle pane polling remains, live resize
+does not reflow hidden tabs, and retained object counts stabilize after repeated
+navigation, resize and scene teardown.
+
+### W12 — Release and reconcile the old documentation
+
+Run the full matrix below and record actual outcomes, limitations, build IDs, and
+artifact locations in the PR tracker. A focused simulator pass must not silently
+close its existing device/OS gates A–G. In particular, distinguish actual window
+resize from forced size-class probes and indirect-input introspection from real
+pointer use.
+
+Update the original engineering document to describe current two-content-pane
+architecture, supported OS floor, root replacement policy, search implementation,
+and measured behavior. Mark Plan 001 incorporated once its revised outcomes are
+implemented. Keep the opt-in experimental label until the required gates pass.
+
+**Done:** visual acceptance, functional matrix and device performance evidence are
+all present. No unexplained UIKit warnings, source-ownership violations, regression
+to pane-off behavior, or unsupported “buttery smooth” claims remain.
+
+### W13 — Optional expansion after the foundation is polished
+
+Evaluate a small sidebar section for pinned communities/multireddits using public
+tab/sidebar capabilities, while retaining the real RedditList for editing and
+full organization. Preserve Apollo's five stable tab indices; projecting many
+`UITab` objects must not silently alter native selection/routing assumptions.
+Don't add a fourth persistent content column or a second custom destination rail.
+
+Add explicit “Open in New Window” and post-link drag/drop only once scene routing
+and restoration pass. Opening a new window is a user action, not the default for
+ordinary post selection. Persist minimal route identity; never serialize native
+VCs, OAuth state, or content snapshots into general navigation preferences.
+
+## 4. Motion and performance acceptance
+
+### Motion contract
+
+| Interaction | Intended behavior | Reduced-motion behavior |
+|---|---|---|
+| Choose another list item | Immediate selection and stable pane bounds; evaluate a brief detail dissolve only if it improves continuity | Immediate content replacement or short opacity change |
+| Push/pop within detail | Apollo/native navigation timing; title and content settle together | Respect native reduced transition |
+| Root Back gesture | Progress follows finger; reversible until commit | Preserve gesture/action, minimize spatial animation |
+| Divider drag | Direct, frame-paced size changes; no separately sprung content | Same direct manipulation |
+| Sidebar show/hide | UIKit transition, with one accompanying content reflow | UIKit reduced behavior |
+| Search activate/dismiss | One presentation transition, stable focus and predictable inset | Immediate or short dissolve |
+| Async banner/media arrival | No delayed chrome jump; preserve content anchor | Same stable geometry |
+
+Do not select a duration as a substitute for profiling. For any new detail dissolve,
+start evaluation around 120–180 ms, with no input delay and no animation queued
+behind a newer selection. Never use a full-window snapshot to conceal repeated
+layout corruption. A transient snapshot, if measured necessary, must have bounded
+size/lifetime and cannot remain interactive or survive scene backgrounding.
+
+### Measurement protocol
+
+Use a physical 60 Hz iPad and a ProMotion iPad, including the oldest practical
+supported hardware. Compare pane-off, current baseline pane-on, and redesigned
+pane-on with matching content/cache/settings. Run at least five comparable captures
+per scenario; keep cold-launch and warm-interaction data separate. Record device,
+OS, refresh policy, Low Power Mode, thermal state, build and instrumentation mode.
+
+Capture Animation Hitches/Core Animation and Time Profiler; use Allocations/VM
+tracking for lifetime investigations. Attribute commit, render and content-loading
+cost separately. UIKit adapts to the display, but application work can still miss
+deadlines; device traces matter more than average FPS.
+[Apple performance guidance](https://developer.apple.com/documentation/xcode/improving-app-responsiveness).
+
+Required scenarios: a long text feed and thread, media-heavy feed, active comments
+find, divider drag, continuous window resize across thresholds, sidebar show/hide,
+rapid selection, cancelled Back, five-tab cycling, cold launch, and two-scene
+open/close. Run a ten-minute resize/navigation/media soak and compare retained
+objects after returning to the same idle state.
+
+Initial **project targets**, to confirm against baseline and hardware:
+
+| Measure | Acceptance target |
+|---|---|
+| Frame deadlines | Evaluate against actual refresh intervals: ~16.7 ms at 60 Hz, ~8.3 ms at 120 Hz; these are not all available to app main-thread work |
+| Hitch time ratio | Target ≤5 ms/s in representative steady scrolling/resizing; report per-scenario results and worst outliers, not only averages |
+| Severe stalls | Zero reproducible pane-induced UI stalls ≥100 ms in the interaction set; every smaller repeated hitch also investigated |
+| Pane-specific geometry/chrome work | Initial p95 target <1 ms per applied update on the target device; report full frame cost separately |
+| Interaction response | Local selection feedback by the next rendered frame; network loading reported separately from route/chrome latency |
+| Idle | No continuously running pane display link/watchdog, no continuing geometry writes in unchanged state |
+| Hidden panes | Zero hidden content remeasurements caused by each visible divider drag sample |
+| Launch/memory | Report absolute deltas and distributions; no unexplained >5% regression against equivalent baseline runs; don't invent a universal RSS cap |
+| Lifetime | No monotonic growth in pane-owned controllers, observers, transactions or snapshots across 50 repeat cycles and scene teardown |
+
+Thresholds are acceptance goals, not measurements already achieved or Apple-wide
+requirements. If content/network/native work prevents one, provide the trace and
+attribution; don't declare smoothness from a successful synthetic counter probe.
+
+## 5. Validation matrix and exit checklist
+
+| Dimension | Required coverage |
+|---|---|
+| Hardware/OS | iPad mini, 11-inch, 13-inch; supported 18.x and current 26.x; 27 prerelease recorded separately; 60 Hz and ProMotion |
+| Window | Portrait/landscape, halves/thirds/quadrants, short-wide, narrow-tall, threshold ±1/±16/±32 points, actual continuous resize, external display |
+| Destination | All five tabs, cold restored path, deep nested detail, unknown in-place route, same-tab reselection, badges/account changes |
+| Content | Empty, loading, offline/error, removed item, long text, nested comments, image, GIF/video, gallery, inline media, crosspost |
+| Search/input | Each search scope; onscreen/hardware/floating keyboard; query edit, next/previous, cancel, IME composition; focus and popover dismissal |
+| Transitions | Selection during push/pop/cancel, resize during search/Back, clear during topology change, tab switch with pending intent |
+| Accessibility | All text categories, VoiceOver, Full Keyboard Access, Switch Control, pointer, Reduce Motion/Transparency, contrast, RTL/localization |
+| Lifecycle | Two scenes, scene background/disconnect, account switch, memory pressure, restoration, launch failure/rollback |
+| Controls | iPhone/pane-off, ordinary narrow iPad, custom and stock themes, Liquid Glass and compatible non-glass appearance |
+
+Use pairwise combinations for broad coverage, then exhaustively test high-risk
+intersections: compact + nested detail + cancelled Back; resize + search + keyboard;
+two scenes + different searches/links/accounts; minimum width + accessibility text
+and RTL. Don't claim every combinatorial state was tested from a small screenshot set.
+
+Per work package, run the focused test plus the existing pane smoke checks. Run
+`make package` for the pinned device target and the simulator inner loop when
+source changes. The plan's original audit baseline predates the implementation;
+see the results document for source changes and actual validation.
+
+Release requires:
+
+- [ ] The list/detail/destination visual hierarchy is coherent across core states.
+- [ ] No duplicated search session, passive-title glass, or orphan chrome.
+- [ ] Native routing, stable tab indices, selection, Back/forward and drafts survive.
+- [ ] Compact nested swipe Back and interactive root cancellation work.
+- [ ] Scene ownership, bootstrap rollback and lifecycle cancellation pass.
+- [ ] Width constraints, RTL, cancelled drag and async readable width pass.
+- [ ] Accessibility, pointer, keyboard, modal and external-display tests are recorded.
+- [ ] Device hitch, memory, launch and soak results meet the agreed targets.
+- [ ] Original documentation and release-gate tracker match measured reality.
+
+If a private-API assumption cannot be verified, preserve the last safe behavior
+and document that specific limitation. If a visual spike fails, choose the simpler
+supported design and remove the failed implementation. Don't accumulate permanent
+fallback paths or block unrelated packages merely because one optional experiment
+did not succeed.
+
+## 6. Bonus: adaptive iPhone and a future Apple foldable
+
+### What is known
+
+The [linked checklist](https://blakecrosley.com/blog/resizable-iphone-era-checklist)
+is a useful starting prompt. Technical recommendations here are grounded in Apple
+documentation and this repository, not an assumed foldable specification.
+
+Apple's WWDC26 UIKit session explicitly describes freely resizable iPhone apps in
+iPhone Mirroring and on iPad, retaining the **phone idiom**. It recommends scene
+lifecycle, local view dimensions/size classes, scene geometry where needed, and
+removing main-screen and orientation-based layout assumptions. Device Hub provides
+a resize test environment. These are documented adaptivity requirements; they do
+not establish foldable dimensions, an idiom switch, hinge APIs, or fold lifecycle.
+[Modernize your UIKit app](https://developer.apple.com/videos/play/wwdc2026/278/),
+[Device Hub](https://developer.apple.com/videos/play/wwdc2026/260/).
+
+The existing tab-sidebar API also does not guarantee an iPad sidebar on a phone:
+its documentation says iPhone uses the regular tab bar. Therefore a wide phone
+must be able to host two content panes while retaining native destination tabs.
+[Tab-sidebar mode contract](https://developer.apple.com/documentation/uikit/uitabbarcontroller/mode-swift.enum/tabsidebar).
+
+### Feasibility
+
+**Reusing a well-finished two-pane core is feasible and worth preparing for now.**
+Shipping support for unannounced fold behavior cannot yet be promised. This is
+more than removing one iPad check, but need not be a second UI rewrite if W02–W12
+separate geometry, navigation state, and destination presentation properly.
+
+| Reusable foundation | Remaining constraint |
+|---|---|
+| Local-width geometry and two-pane routing | Current `ApolloPaneLayoutSupported()` caches a pad-idiom-only answer, and all pane hook ctors depend on it |
+| Compact/expanded logical state | Compact Back is not fully interactive today; repeated resizing must preserve deeper state, focus, search, draft and scroll anchor |
+| Native controller reuse | Apollo's precompiled binary can contain phone/portrait/main-screen assumptions that changing tweak source does not remove |
+| Scene ownership | Global find state and native URL routing must be fixed first |
+| UIKit system destinations | Tab-sidebar mode is context/platform dependent; phone tabs must remain usable without assuming sidebar availability |
+| Existing patch/build tools | Linked-SDK fields, plist capabilities and native compatibility need independent verification; an SDK-version patch is not a rebuild of Apollo |
+
+### W14 implementation sequence
+
+1. **Separate capability from geometry now.** Keep today's iPad-only rollout
+   eligibility, but have pane decisions consume a local layout environment.
+   Don't cache available width, screen, or future eligibility from first launch.
+2. **Add a development-only adaptive-phone experiment after iPad stability.**
+   Install the required hook infrastructure on eligible phone processes even
+   when they start narrow. Activation/presentation depends on local capacity;
+   a cold narrow launch must later become wide without missing ctor hooks.
+3. **Keep topology installation stable.** Avoid repeatedly replacing the window
+   root or rebuilding controllers on every threshold crossing. A supported
+   installed container should adapt between one and two panes while preserving
+   logical branches. If narrow installation cannot preserve current phone
+   behavior, resolve that architecture before enabling the experiment generally.
+4. **Test phone idiom at arbitrary sizes.** Use Device Hub and iPhone Mirroring;
+   near-square, wide-short and rapidly alternating sizes are test inputs, not
+   simulated claims about Apple's future folded/unfolded displays. Check a
+   phone that stays portrait-oriented while its window becomes wide.
+5. **Audit beyond `src/ipad/`.** Migrate reachable `UIScreen.mainScreen`, idiom
+   and orientation geometry in headers, media, search, popovers, keyboard and
+   presenters to local contexts. Check native binary paths with Hopper where a
+   behavior fails; don't globally spoof the device idiom to unlock tablet UI.
+6. **Verify distribution metadata separately.** Inspect the actual supplied IPA's
+   scene manifest, device families, full-screen/orientation flags, launch screen,
+   indirect-input declaration and linked SDK. Preserve API availability and the
+   device deployment floor. `patch.sh --liquid-glass` only changes part of that
+   compatibility story; don't assume it opts Apollo into every iOS 27 behavior.
+7. **Add real fold-specific support only when documented.** Test continuity,
+   display/safe-area changes, interruption and restoration on the actual device.
+   Use any future occlusion/posture API only if Apple publishes it and the UI
+   needs it. Don't reserve an imaginary hinge gutter or ship device-name checks.
+
+Preparedness exit test: on a supported resizable phone environment, start narrow
+on a thread, search and scroll, widen into list/detail, choose another item,
+narrow again, cancel Back, and widen once more. The visible route, list selection,
+search owner, focus and scroll anchors must remain coherent without relaunch.
+Repeat with keyboard input, a draft, media playback, and a second scene where
+supported. This is useful for documented resizable iPhone environments even if
+the rumored foldable never ships.
+
+### Scope judgment
+
+Do the ownership, geometry, continuous-resize and compact-navigation work in the
+iPad redesign. Defer enabling panes on ordinary iPhones and any hardware-specific
+claims to W14. A responsive two-pane core is a strong investment; an exact porting
+schedule would be guesswork until the adaptive-phone spike and Apple's eventual
+device contract are known.

--- a/plans/003-ipad-pane-implementation-results.md
+++ b/plans/003-ipad-pane-implementation-results.md
@@ -1,0 +1,190 @@
+# iPad pane redesign — implementation and verification
+
+Date: 7 September 2026. Branch: `je/ipad-pane-layout`, starting at `fa5ddcb`.
+Scope: all fourteen work packages in [Plan 002](002-ipad-pane-redesign.md),
+covering all seventeen [audit findings](ipad-pane-audit-2026-09-07.md) and the
+revised outcomes of [Plan 001](001-unify-ipad-pane-chrome.md).
+
+The implementation is in the working tree. This is an experimental build, not a
+claim that the release matrix or physical-device performance gates have passed.
+No improve skill was used for this implementation.
+
+## What changed
+
+The destination surface stays UIKit's native tab/sidebar controller with Apollo's
+five original tab identities. Each tab has two content columns: a compact native
+selection list and a separate native reading/navigation stack. UIKit collapses
+those columns for narrow windows. The production eligibility remains opt-in on
+iPadOS 18 and later; the device tweak still builds with an iOS 14 deployment floor.
+
+Passive titles no longer acquire custom glass capsules in expanded panes. Search
+uses the native navigation item, with a discoverable button when inactive. Thread
+Find uses one `UIFindInteraction`/`UIFindSession` adapter over Apollo's existing
+matcher, count, highlights and previous/next actions; its old extra toolbar is
+suppressed. The system may dock Find by the keyboard. This intentionally replaces
+Plan 001's fixed-height search takeover proposal.
+
+The detail host follows the actual tab content guide and context-row geometry.
+Comments media starts below that context row; immersive profile/community artwork
+is covered above its resolved content boundary. Settings insets are additive.
+Text comments/header nodes use a readable width while media keeps its full
+aspect-correct layout. Apollo/Texture remains responsible for content measurement
+and scroll anchoring; the implementation does not reload entire tables per drag.
+
+## Work-package accounting
+
+“Implemented” below describes source delivered, not every exit test in Plan 002.
+
+| Work | Implementation | Verification and limits |
+|---|---|---|
+| W01 | Structured privacy-safe snapshots, capture script with IPA hash/dylib UUID/runtime and one-copy check; opt-in signposts and counters | Simulator artifacts captured. Selection interval ends at the next display-link callback, not a measured render-server presentation. Physical baseline remains open. |
+| W02 | Required runtime-contract preflight; weak scene/nav/item registrations; public scene notifications including hidden tabs; scoped native entry translation; exact typed AppDelegate tab save/restore; gallery/recovered-link origin preserved | Native subreddit URL routing and second-window post delivery passed. Forced required-capability failure left stock containment with zero panes. Full scene/rollback matrix is tracked below. |
+| W03 | Shared bounded weak-owner settlement observer; cancellable generation-based geometry scheduling; lifecycle cancellation; native semantic PostsType identity; existing latest-intent/source validation retained | Host tests cover replacement, missing completion/deadline, cancellation and owner deallocation. Latest queued selection won the simulator gate test. |
+| W04 | Pure finite width policy; separate preferred/resolved widths; RTL edge and drag sign; cancellation restores saved intent; secondary minimum on iOS 26; visible-only display-paced divider | 146,781 geometry combinations plus RTL cases passed. Live divider produced zero layout passes/writes in all four hidden tabs. Actual continuous window resize remains separate from trait probes. |
+| W05 | Dedicated chrome policy; native search placement; plain passive titles; bounded artwork; stable expanded hide-on-scroll; first-wide sidebar preference | Home/comments and compact screenshots inspected. Native tab content guide fixed top-tab overlap. Full OS/theme/accessibility matrix remains open. |
+| W06 | Per-comments-controller query/node/range/generation and cancellation; one system Find adapter; synchronous matcher context restored in `@finally` | Real typed Find query showed highlights and “2 of 3”; next/previous/dismiss exercised. IME, hardware keyboard and independent two-scene Find require further coverage. |
+| W07 | Pane-local native compact node factory; persisted Compact/Comfortable choice without changing phone's global style; restrained selected background; contextual empty states | Compact native feed/media thread inspected at multiple primary widths. Native NSFW, filtering and action implementations retained; exhaustive content matrix remains open. |
+| W08 | Progress-driven native interactive root return, reversible cancellation; nested detail retains Apollo pop; exclusive root/divider recognizer ownership; RTL and Reduce Motion animator paths | Root commit/cancellation tested. Compact nested Back commit and cancellation both verified interactive; two queued selections settled to the newest detail root with no pending gate. |
+| W09 | Extracted column host; additive Settings readable insets; background-safe captured prose constraints and colors; media excluded from text cap | Media remains below chrome and full width. Long code/inline-image/selection/async anchor scenarios need device/content coverage. |
+| W10 | Weak focused column, single `scrollsToTop` target; Cmd-F and Cmd-Option-1/2 focus; Ctrl-Option width controls; accessibility escape, adjustable divider/reset, dynamic selection contrast; scene-scoped presentation paths; multiline self-sizing injected Settings rows | Touch/system Find exercised. Largest accessibility text at 340pt exposed and verified the Settings-row fix. Native Apollo rows still have inconsistent Dynamic Type support; complete accessibility/peripheral acceptance remains open. |
+| W11 | Weak navigation-item lookup; selected-tab minimize predicate; cached chrome actions; no hidden-tab drag broadcast; on-demand display links; cancellation on background/disconnect and conservative memory handling | Hidden tabs stayed idle during drag. A fresh 11.29-second idle comparison had unchanged layout/write/loaded counts, zero watchdogs and zero pending navigation. Device hitch/allocations/50-cycle and ten-minute soak gates remain open. |
+| W12 | Updated plan status, current architecture notes, evidence and release limitations | Documentation is reconciled. This package's release certification remains open until the required matrix is actually run. |
+| W13 | Public sidebar footer with bounded pinned communities, URL drag/drop, scene-local opening and explicit Open in New Window; all five tab indices retained | New-window integration created a second five-pane scene and opened the requested post, preserving the original scene's detail. Real RedditList remains the editor for multireddits/full organization. Drag/drop and indirect-input coverage remain open. |
+| W14 | Simulator-only real-phone eligibility flag, local bounds/effective traits, retained phone idiom and native phone tabs; actual IPA metadata inspected | Cold narrow phone launch found and fixed a UIKit wrapper routing loop. Responsive launch with five panes and zero settled watchdogs verified. No shipping foldable support claim. |
+
+## Audit finding disposition
+
+| Finding | Source resolution |
+|---|---|
+| A01 | `ApolloPaneChrome`, native navigation search and controller-owned system Find |
+| A02 | Native compact feed-node creation within the primary pane; explicit comfortable option |
+| A03 | Geometry policy, usable width excluding visible sidebar, secondary minimum |
+| A04 | Native percent-driven root Back and restored nested detail recognizers |
+| A05 | Generation/idempotence-aware `ApolloPaneGeometryScheduler` |
+| A06 | Bounded `ApolloPaneTransitionObserver` and scene lifecycle cancellation |
+| A07 | Shared physical-leading policy for LTR/RTL geometry and controls |
+| A08 | Preferred width saved independently of resolved width and restored on cancellation |
+| A09 | Display-paced updates on the visible pane; hidden panes consume preference on appearance |
+| A10 | Per-controller Find state and scoped synchronous matcher context |
+| A11 | Originating scene API and typed native AppDelegate tab exchange in `@try/@finally` |
+| A12 | Bootstrap capability contract required before atomic installation |
+| A13 | Host, geometry, observer, chrome, content, focus, sidebar and diagnostics extracted; logical navigation state remains with the owning split |
+| A14 | Native PostsType semantic identity rather than display titles |
+| A15 | Additive Settings contribution plus captured Texture text constraints; media stays wide |
+| A16 | Weak ownership lookup, cached chrome/menu work and selected-tab scroll policy |
+| A17 | Input ownership implemented and explicit validation gates retained; device smoothness remains unproven |
+
+## Important integration fixes found while implementing
+
+1. Apollo's AppDelegate tab ivar has a Swift type encoding, despite holding a
+   strong Optional UIKit object. An Objective-C `@`-encoding check rejected real
+   routes. The typed Swift bridge now exchanges/restores the exact value after
+   validating the known class/neighbor layout.
+2. UIKit's compact merge can push a navigation wrapper containing the exact
+   secondary host. Routing that structural transfer as a Settings destination
+   caused a cold-narrow launch loop. Exact host containment now bypasses the
+   application queue and is excluded from logical primary stack counts.
+3. Re-enabling Apollo's recognizer during an active root return allowed two pop
+   drivers to compete. Root tracking now owns its recognizer states until its
+   interactive transition commits or cancels.
+4. iOS 26+ floating tabs do not make the legacy `tabBar.hidden` property a reliable
+   content-boundary test. The host uses the public `contentLayoutGuide`.
+5. Comments' extended top edge let video paint behind context chrome. Expanded
+   comments now suppress that edge and restore the original policy when compact.
+6. A new compact primary selection used to push above UIKit's bridge while the
+   old detail branch remained alive. The same root-replacement policy now applies
+   in compact and expanded presentations. Synthetic nested Back races verify
+   cancellation and commit both retain the newest selection in the detail stack.
+7. Apollo did not consume a pane link from cold scene connection options, and
+   optional scene-delegate activation hooks were insufficient. A URL-only activity
+   is claimed once on UIKit's public scene activation notification. The same
+   lifecycle registration cancels work on hidden tabs without loading views.
+8. Injected root Settings rows clipped large Dynamic Type labels inside fixed
+   52-point heights. The existing root Settings owner now uses multiline native
+   self-sizing rows at accessibility categories, with normal/pane-off sizing
+   preserved. No second General-screen remapper was introduced.
+
+## Delivered build
+
+- Test IPA: `packages/Apollo-Pane-Redesign-Test.ipa` (local, unsigned for distribution).
+- Device package: `packages/com.apollo.reborn_3.6.0-18+debug_iphoneos-arm.deb`.
+- IPA SHA-256: `d5a76c198e1c7c3017ccb9ac15f97627d8b09fa10a4a73afd2eb3e6742a2dc53`.
+- Final simulator dylib UUID: `1D5BD226-DCA7-4909-8F2D-F39E282D694C`.
+- Device/simulator builds and `git diff --check` pass; host geometry/settlement tests pass.
+- IPA ZIP integrity passes; exactly one tweak entry is present under the base
+  app's existing `ApolloImprovedCustomApi.dylib` name. The injector updates that
+  alias rather than adding a second tweak load.
+- Device packaging includes the Liquid Glass patch and both Safari extensions.
+
+The phone-off control required rebooting this iOS 27 simulator to clear a retained
+development launch environment. Captures named `phone-probe-still-enabled`,
+`stock-phone-explicit-off`, and `stock-phone-direct-launch` are failed control
+attempts, not pane-off evidence. The `stock-phone-rebooted` snapshot verifies
+phone idiom, one loaded tweak, and zero pane containers.
+
+## Reproduction and evidence
+
+Run `scripts/test-ipad-pane-policy.sh` for the actual pure geometry policy and
+Foundation settlement observer. Run `make package` for the pinned device target.
+Simulator builds use the documented latest-SDK/internal-Logos path, with exactly
+one baked tweak copy; do not also set `DYLD_INSERT_LIBRARIES`.
+
+```sh
+SIM_NAME=PR886-iPad13 WORK_DIR=./.sim/pane-redesign scripts/run-in-sim.sh --glass
+python3 scripts/capture-ipad-pane-state.py \
+  --device A078A116-02A9-4EB1-B381-5FF2F29510C2 --label final
+
+SIM_NAME=Pane-Adaptive-Phone \
+  SIM_DEVICE_TYPE=com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro \
+  WORK_DIR=./.sim/pane-phone SIMCTL_CHILD_APOLLO_SIM_ADAPTIVE_PHONE=1 \
+  scripts/run-in-sim.sh --glass
+```
+
+Ignored local evidence includes:
+
+- `.sim/pane-redesign/evidence/20260907-124715-wide-media/`
+- `.sim/pane-redesign/evidence/20260907-124804-width-340/`
+- `.sim/pane-phone/evidence/20260907-130306-cold-narrow-fixed/`
+- `.sim/pane-redesign/evidence/20260907-131557-receiving-scene-verified/`
+- `.sim/pane-redesign/evidence/20260907-132211-compact-race-settled/`
+- `.sim/pane-redesign/compact-races.log` (verified native interaction and final stack)
+- `.sim/pane-redesign/idle-check.json` (fresh snapshots, no debugger attached during interval)
+- `.sim/pane-redesign/evidence/20260907-132657-settings-ax-fixed/`
+- `.sim/pane-redesign/evidence/20260907-133944-final-review/`
+- `.sim/pane-redesign/evidence/20260907-134620-final-clean/`
+- `.sim/pane-phone/evidence/20260907-133143-required-capability-failure/`
+- `.sim/pane-phone/evidence/20260907-133958-stock-phone-rebooted/`
+- `/tmp/apollo-pane-find-real.png` (typed system Find, native highlights/count)
+- `/tmp/apollo-pane-media-bounded.png` (media/context boundary)
+- `/tmp/apollo-pane-phone-sample.txt` (pre-fix cold-launch loop diagnosis)
+
+Snapshots intentionally omit account identifiers, model descriptions, titles,
+URLs, and Find queries. Screenshots can contain ordinary visible Reddit content;
+review them before sharing. Existing simulator account data was preserved; no
+credential backup was exported or checked in.
+
+The test devices were shut down, normal text/contrast/dark appearance and the
+original 480pt width preference were restored, and the prior debug command was
+restored. The iPad simulator retained three inactive test window sessions after
+destruction requests; its original session was preserved. These are simulator
+data-container state, not contents of the packaged IPA.
+The last navigation-bar screenshot tap triggered Apollo's native theme shortcut;
+`final-clean` therefore shows light mode. The native `Theme` preference was
+restored to `dark` with the simulator stopped, preserving other preferences.
+Use `final-review` for the verified dark presentation.
+
+## Release gates remain explicit
+
+The existing PR #886 A–G gates are not closed by this implementation. In particular:
+
+- Physical 60/120 Hz Time Profiler/Animation Hitches/Allocations runs and soak.
+- Supported iPadOS 18/26, mini/11/13-inch, pane-off and non-glass combinations.
+- Actual continuous window resizing/external display; a forced compact trait is
+  only a topology probe. `simctl screenConfig geometry` rejected the requested
+  custom geometry on this runtime, so that attempt is not resize evidence.
+- Complete accessibility, keyboard, pointer, IME and media/PiP/presentation matrix.
+- Multi-scene lifecycle, restoration and fault-injection combinations.
+
+Do not promote the experiment or claim “buttery smooth” until those results are
+recorded. Foldable preparation shares the pane core while keeping the phone idiom;
+Apple has not supplied a foldable device contract to certify against.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,35 @@
+# Implementation Plans
+
+Current iPad redesign implementation and validation are recorded in Plan 003.
+The historical plans remain as design and audit context; implementation status
+does not imply that physical-device release gates have passed.
+
+## Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|------|-------|----------|--------|------------|--------|
+| 001 | Unify the adaptive iPad pane chrome | P1 | L | — | INCORPORATED with revisions into 002 |
+| 002 | Complete iPad pane redesign: 14 packages / 17 findings | P1–P3 | XL | 001 incorporated | IMPLEMENTED; release validation open |
+| 003 | Implementation results and verification | — | — | 002 | Current evidence and remaining gates |
+
+Current results: [003 — implementation and verification](003-ipad-pane-implementation-results.md).
+
+## Dependency notes
+
+- Plan 001 is self-contained. Keep it as one reviewed change because the
+  destination placement, title treatment, search takeover, and immersive-header
+  boundary are four parts of one chrome state machine; landing only one can make
+  the visual hierarchy less coherent.
+
+## Findings considered and rejected
+
+- Replace Apollo's two navigation controllers with one custom pane-wide toolbar:
+  rejected because it would discard Apollo's real navigation items, back-stack
+  behavior, keyboard commands, and Liquid Glass integration—the central safety
+  premise of PR #886.
+- Remove Liquid Glass or the immersive header globally: rejected because the
+  problem is pane-specific ownership and hierarchy, not either feature by
+  itself. Preserve current iPhone and pane-disabled behavior.
+- Force the destination sidebar permanently: rejected because UIKit deliberately
+  provides a user-controlled sidebar/tab-bar toggle. Prefer the sidebar on first
+  presentation at wide widths, then respect an explicit user choice.

--- a/plans/ipad-pane-audit-2026-09-07.md
+++ b/plans/ipad-pane-audit-2026-09-07.md
@@ -1,0 +1,368 @@
+# iPad pane audit — 7 September 2026
+
+Source baseline: `fa5ddcb`, branch `je/ipad-pane-layout`.
+Implementation roadmap: [Plan 002](002-ipad-pane-redesign.md).
+
+## Assessment
+
+The branch is a credible compatibility foundation, but it is not yet a complete
+iPad product redesign. It preserves much of Apollo's behavior successfully while
+putting phone-oriented content and independently managed chrome next to each
+other. Correct containment and aligned bar origins are necessary; they do not
+establish good density, a clear hierarchy, natural gestures, or smooth resizing.
+
+Keep the real Apollo navigation controllers, the single UIKit destination
+surface, per-tab browsing state, conservative routing, and semantic selection.
+Invest in a pane-specific presentation policy and a smaller, explicit navigation
+state model. Replacing Apollo's rendering stack wholesale would discard useful
+behavior before the actual bottlenecks have been measured.
+
+## Evidence and limits
+
+This audit examined both supplied plans, the PR #886 verification tracker, all
+pane modules' responsibilities and principal navigation/layout paths, and their
+interactions with Liquid Glass, immersive subreddit headers, comments find,
+tab minimization, shared URL routing, and the Swift ivar bridge. Apple API
+behavior was checked against current documentation and the pinned iOS 26 headers.
+No production source was changed, and no new build or device performance run was
+performed for this documentation task.
+
+Evidence labels below:
+
+- **Code:** an implementation behavior or missing contract visible in this
+  revision. A described failure path is not automatically a reproduced user bug.
+- **Visual:** observed in local screenshots, with their provenance stated.
+- **Risk:** a plausible integration/performance problem requiring a focused test.
+- **Gap:** coverage or product behavior the existing work does not establish.
+
+Historical images inspected: `.sim/pr886-merged-13-landscape.png`,
+`.sim/pr886-merged-13-portrait.png`, and `.sim/pr886-merged-mini-settings.png`.
+Their filenames are not proof of orientation, point dimensions, or build revision.
+They show stacked search/navigation surfaces, passive title capsules, tall feed
+media repeated in detail, a strong full-card selection outline, and large empty
+detail regions. These are useful design evidence, not current-HEAD geometry tests.
+
+A limited live check also launched the **previously installed baked build** on
+`PR886-iPad13`, iOS 27 Simulator. Logs confirmed panes installed on all five tabs.
+Its initial pane bounds were 1032×1376 points. The captured Home hierarchy had a
+108-point primary navigation bar containing search and a 54-point empty-detail
+bar, both beginning at y=86. That shows why the old plan's universal equal-height
+54-point assertion needs a new baseline; it does not prove a regression in HEAD.
+The baked dylib's source revision was not verified.
+
+Local evidence is under `.sim/ipad-audit-2026-09-07/`: `evidence.json`,
+`baked-build-home.png`, and `baked-build-geometry.txt`. An initial launch wrongly
+added environment injection to an already baked app; its failure was excluded as
+a harness error. Normal launch succeeded. The resulting local crash prompt was
+dismissed with Not Now; no report was sent or deleted. The debug command file was
+restored and the previously shut-down iPad simulator was shut down again. No
+content gestures or account mutations were used. Screenshots remain ignored.
+
+The tracker explicitly leaves presentation, accessibility, multiwindow/device
+coverage, and the performance soak open at
+`IPAD_PANE_PR_886_IMPLEMENTATION.md:567`. Its earlier microbenchmarks and discrete
+resize checks are not measurements of live-drag hitches or sustained device load.
+
+## What is already strong
+
+- `ApolloPaneRouting.m` shares cold/warm classification, uses explicit destination
+  classes, and preserves rightward continuation. Settings/Profile index policy
+  is an intentional source-based exception to the destination allowlist.
+- `ApolloPaneInstall.xm:165` stages controller changes with identity checks,
+  rollback snapshots, and simulator fault injection.
+- `ApolloPaneLayout.m:11` distinguishes requested/enabled/active state and uses
+  weak navigation-owner registration for temporarily detached tab hierarchies.
+- `ApolloPaneSplitViewController.m:3154` coalesces cross-column intents and checks
+  source lineage before replay. Primary selection uses stable model identifiers
+  where available, not only an index path.
+- The detail host constrains Apollo's real navigation controller to usable
+  column bounds. Production `viewDidLayoutSubviews` no longer drives geometry.
+- View loading is deferred for unvisited pane tabs; width preferences are stored
+  per scene; the divider is a real accessible control.
+- Forward-history writes use a small typed Swift bridge, with more defensive
+  class/layout checks than a raw Objective-C object cast.
+
+These are regression requirements for the redesign, not tasks to implement again.
+
+## Findings
+
+### A01 — P1 — Chrome has no common presentation owner
+
+**Code + Visual.** `ApolloPaneInstall.xm:400` selects tab-sidebar mode;
+`ApolloLiquidGlass.xm:1142` independently recenters title controls and builds
+capsules for plain labels; `ApolloSubredditHeaders.xm:1711` derives artwork extent
+from the complete adjusted top inset; comments search has its own toolbar/session.
+There is still no `ApolloPaneChrome` module.
+
+The result can be individually valid components with equal visual emphasis:
+global destinations, context titles, search, actions, and artwork. The old chrome
+plan correctly identifies the problem, but needs to cover primary search as well
+as comments find and must account for the latest merged search implementation.
+
+**Outcome:** one scene destination policy and one per-pane chrome policy, with
+plain context labels, discoverable interactive controls, explicit search scope,
+and a consistent theme/material boundary above content.
+
+### A02 — P1 — Content density still treats the feed as a phone canvas
+
+**Visual + Gap.** Inspected images show a tall image consuming most of the master
+column while detail repeats the same image. Persistent native selection can draw
+a bright outline around that entire tall cell. The list is supposed to support
+rapid comparison and selection, but it offers very little scannable content.
+The current router and host reuse the existing cells without a pane density policy.
+
+**Outcome:** evaluate Apollo's existing compact feed rendering for a pane-local
+list presentation: bounded thumbnails, readable titles, small metadata, subdued
+persistent selection, and a distinct keyboard-focus indicator. Preserve an
+explicit user's comfortable/media-rich preference. Do not change the global
+phone setting to achieve a local layout. A cell factory/measurement spike is
+required before promising this can be isolated safely.
+
+### A03 — P1 — Width policy protects primary more explicitly than detail
+
+**Code + Risk.** `ApolloPaneSplitViewController.m:960` and `:2116` request a
+340–480-point primary and a 0.42 fraction, later converted to an absolute scene
+preference. There is no comparable useful-detail minimum or content/height-aware
+presentation policy. UIKit may resolve a different size from these preferences.
+The existing code correctly handles hidden/overlay primary, but does not prove
+that both visible columns are usable at every intermediate width.
+
+**Outcome:** solve for two useful content panes before preferring the global
+sidebar. Derive the decision from actual available bounds, content requirements,
+Dynamic Type, and resolved UIKit presentation. Do not use device-model or
+orientation buckets as production policy. iOS 26 provides
+`minimumSecondaryColumnWidth`; its availability must be checked for iPadOS 18–25.
+
+### A04 — P1 — Compact Back loses direct manipulation and deeper swipe Back
+
+**Code.** `ApolloPaneSplitViewController.m:3832` disables primary/detail UIKit
+interactive-pop recognizers and both Apollo left-edge recognizers while compact
+detail chrome is active. Its replacement pan is allowed only at detail depth one
+(`:4111`) and acts only when the finger lifts (`:4145`). It does not animate with
+gesture progress. At depth greater than one, these disabled Back recognizers
+remain disabled and the root-only replacement refuses the gesture. Buttons may
+still work; the ordinary swipe navigation is no longer equivalent to Apollo.
+
+**Outcome:** restore native interactive pop within detail. Give the column-root
+return one interactive transition owner with real cancellation and final-state
+reconciliation. Explicitly arbitrate forward, row swipe, media pan, and divider
+gestures. This is important for iPad narrow windows now and fold/unfold later.
+
+### A05 — P1 — Geometry refresh can latch in a waiting state
+
+**Code + failure-path risk.** The host's refresh at
+`ApolloPaneSplitViewController.m:727` and the pane's refresh at `:2793` set a
+waiting flag and clear it only inside a transition completion. They ignore the
+registration result and retain no coordinator generation/identity for recovery.
+A completion that does not arrive leaves subsequent coordinator-backed refreshes
+skipped. The navigation queue already acknowledges late/rejected registration
+at `:3061`, so the policies are inconsistent.
+
+Apple's return value reports whether animations were queued; **a completion can
+still run after NO**. Therefore a repair must be idempotent, not run an immediate
+second mutation whenever NO is returned. Recover once safe, invalidate obsolete
+coordinator callbacks, and never write geometry into an active layout pass.
+[API contract](https://developer.apple.com/documentation/uikit/uiviewcontrollertransitioncoordinator/animate(alongsidetransition:completion:)).
+
+### A06 — P1 — Transition polling has no lifecycle-bounded termination
+
+**Code + Risk.** `ApolloPaneRouter.xm:170` polls while a coordinator exists, first
+every 50 ms and later every 250 ms. It does not first ask whether its pop token
+has already settled. Compact reconciliation at
+`ApolloPaneSplitViewController.m:1788`, compact Back at `:4060`, and topology-gate
+recovery at `:4219` have additional polling loops. Several capture the pane and
+controller stacks strongly. The recursive compact Back block releases its cycle
+only on settlement.
+
+These are not proven idle CPU or leak regressions in normal navigation. However,
+a stuck native flag/coordinator or disconnected scene can retain state and keep
+waking the main queue. Reducing cadence is not a lifetime bound.
+
+**Outcome:** one cancellable observer/watchdog per actual transaction, weak
+lifetime ownership, token checks before every reschedule, scene-disconnect
+cancellation, and a measured deadline. Expiry must retain the last valid UI and
+drop unsafe work rather than force a stack mutation through UIKit's transition.
+
+### A07 — P1 — Divider assumes leading means physical left
+
+**Code.** `apollo_layoutColumnGrabber` (`:2515`) maps a leading primary directly
+to its `maxX`, and `apollo_dividerPanChanged:` (`:2638`) maps leading to positive
+x translation. In a right-to-left layout, leading is normally physical right.
+The adjacency check can hide the divider or place it at the wrong boundary;
+drag direction can reverse. Compact Back has a separate direction check, so
+there is no shared physical-edge resolution.
+
+**Outcome:** compute physical primary side from effective layout direction plus
+`primaryEdge`, and use it consistently for boundary, drag, pointer, and keyboard
+semantics. Test inherited and explicitly forced semantic directions.
+
+### A08 — P2 — Cancelled divider drag does not restore the prior preference
+
+**Code.** `:2638` stores the resolved `primaryColumnWidth` as the pan start.
+Cancellation republishes that value as the preferred width. If the saved
+preference was 480 but UIKit resolved 340 in a constrained window, beginning and
+cancelling a drag can leave the scene preference at 340. The persisted value is
+unchanged, so live state and next launch can also disagree.
+
+**Outcome:** separately capture the original preference and the resolved drag
+origin. Use the latter for smooth motion, and restore the former on cancellation.
+Ignore nonfinite input. Commit a preference only for an intentional completed
+adjustment.
+
+### A09 — P2 — Every divider sample broadcasts geometry to every tab
+
+**Code + unmeasured cost.** `apollo_publishPreferredPrimaryWidth:persist:`
+(`:2615`) iterates all pane children on every changed gesture event. Each changed
+preferred width schedules geometry on a loaded pane. Unvisited tabs stay lazy,
+which is good; previously visited but hidden tabs can still do work. The host
+then refreshes readable width and sibling geometry.
+
+**Outcome:** apply live drag width to the visible pane at most once per display
+frame when measurements justify coalescing. Publish the final preference to
+siblings at commit, or mark their version dirty and apply before next display.
+Do not redraw/reflow hidden tabs simply to keep a scalar preference synchronized.
+
+### A10 — P1 — Comments find state is process-global
+
+**Code.** `ApolloFindInComments.xm:105` has one current VC, match node/range, and
+generation. Query edits set the VC; next/previous do not bind their receiver as
+the current VC. Any comments controller's `viewDidDisappear:` cancels the global
+generation. Two scenes, or returning to an earlier search after searching in
+another tab, can cancel the wrong watchdog or pair a match from one controller
+with another controller's table. Its synchronous capture/multi-term flags also
+lack `@try/@finally` cleanup.
+
+**Outcome:** associated per-comments-controller session state, with receiver-bound
+next/previous, local cancellation, and stack-safe synchronous capture scope.
+Match-node membership must be verified against that session's table. Keep the
+native matcher; fix its ownership before adding another presentation adapter.
+
+### A11 — P1 — Shared native URL routing still pins an arbitrary scene
+
+**Code.** `ApolloCommon.m:626` populates AppDelegate's tab controller from the
+first suitable member of unordered `connectedScenes`, only when the ivar is nil.
+`ApolloRouteURLThroughApp` has no originating scene argument. Gallery and deleted
+comments call it from visible controllers (`ApolloGalleryImageViewer.m:2222`,
+`ApolloDeletedCommentsUI.xm:2631`). Opening a link in scene B can consequently
+target scene A even though newer custom settings/mailbox routes are scene-aware.
+
+**Outcome:** carry the originating scene through these callers and the native
+entry adapter. Any temporary AppDelegate compatibility binding needs an exact
+save/restore scope; prefer the scene-native entry path where verified. Do not
+retain one global scene as the permanent route destination.
+
+### A12 — P1 — Installer readiness is independent of router readiness
+
+**Code + compatibility risk.** The router ctor at `ApolloPaneRouter.xm:1078`
+refuses installation if required classes are missing. The scene installer ctor
+at `ApolloPaneInstall.xm:506` independently requires only the scene delegate and
+feature gate. There is no shared preflight asserting the routing hooks/bridge
+contracts succeeded before tab children are replaced. A missing class can leave
+structural panes without the behavior they depend on.
+
+**Outcome:** resolve required capabilities in one bootstrap before containment
+mutation. Keep optional chrome features independent. Failure in one scene must
+not deactivate a successfully installed sibling scene. A process-level Active
+flag may be a fast aggregate, but cannot be the sole owner-specific authorization.
+
+### A13 — P2 — Too many responsibilities and implicit states in one container
+
+**Code.** The split implementation is 4,457 lines, with host geometry, placeholder
+UI, selection identity, resize persistence, navigation serialization, compact
+stack repair, gestures, theming, and simulator probes. Its private ivar section
+at `:969` contains many interdependent flags, stack snapshots, generations, and
+lineage tokens. Comments retain contradictory earlier geometry approaches.
+
+Line count itself is not a performance bug. The problem is that ownership and
+valid transitions are difficult to inspect, while fixes tend to add another
+flag or delayed repair. The existing successful behavior should be captured as
+invariants before extraction.
+
+**Outcome:** a scene coordinator, a topology/navigation state owner, a geometry
+policy, a chrome owner, and a selection owner with narrow contracts. Extract by
+responsibility, not arbitrary source chunks, and do not rebuild controllers merely
+to change presentation.
+
+### A14 — P2 — Display text participates in navigation identity
+
+**Code + Risk.** `ApolloPaneSplitViewController.m:102` combines a raw byte at
+`currentPostsType + 0x20` with the displayed navigation title. The global
+`UINavigationItem.setTitle:` hook (`ApolloPaneRouter.xm:1065`) scans every live
+pane/window to find its owner before reconciling. This is event-driven, not a
+per-scroll scan, but becomes dangerous to extend as a general chrome mechanism.
+Title restyling/localization is coupled to stale-detail invalidation, and two
+semantically different destinations with the same displayed name can collide.
+
+**Outcome:** use a semantic feed/account generation from verified source entry
+points; use a typed identity where available. Keep presentation text out of the
+long-term identity contract. Replace owner discovery with weak direct registration.
+Validate all remaining private Swift storage assumptions at bootstrap; the Swift
+bridge handles ARC/representation, but cannot prove the passed pointer's type.
+
+### A15 — P2 — Readable width is conservative but not complete
+
+**Code + Risk.** `:576–721` narrows self-post comments and Settings tables using
+`additionalSafeAreaInsets`. Media threads keep full-width prose because their
+header shares the table. Async header discovery has no dedicated readiness
+event; an initially unknown self-post can remain unconstrained until a later
+geometry event. Once classified, the controller identity latches the decision.
+Restoring saved absolute insets (`:632`) could overwrite another owner's later
+left/right changes.
+
+**Outcome:** explicitly own an inset contribution, invalidate classification on
+content readiness/change, and test the first frame of async comments as well as
+forms. A later per-row readable measure can retain wide media with readable
+comment text, but requires a separate Texture measurement spike, not blanket
+table narrowing.
+
+### A16 — P2 — Broad chrome work and tab-minimize policy need profiling
+
+**Code + Risk.** The Liquid Glass title gate (`ApolloLiquidGlass.xm:1097–1218`)
+folds a capped navigation-bar subtree fingerprint before some full refreshes.
+Full refreshes allocate candidates, measure/recenter, and manage a visual effect
+view. There are already caches and deferred writes; do not report this as an
+unoptimized per-frame rebuild without traces.
+
+`ApolloAutoHideTabBar.xm:341` scans all tabs' navigation controllers to choose a
+single tab-minimize policy. Its allocation-free fast path is already implemented,
+but hidden columns can participate in a scene-wide visual decision. Pane mode
+needs an explicit scroll/chrome owner and stable bar geometry.
+
+**Outcome:** measure call counts and duration, eliminate passive-title effects,
+cache only stable owner references, and avoid unrelated pane refreshes. Profile
+Texture measurement, material rendering, and media decode separately before
+choosing a remedy.
+
+### A17 — P1 — Desktop input and release performance remain unproven
+
+**Gap.** The pane adds two Option-arrow width commands (`:2685`) but no explicit
+focused-column policy or pane-owned `scrollsToTop` arbitration. These commands
+need testing against text-field word navigation. Divider simultaneous recognition
+at `:4136` permits any other recognizer when one belongs to the divider; the
+44×64 hit area overlaps content. Pointer introspection is not a real drag test.
+
+There is no pane-level memory-warning/disconnect cleanup contract and no recorded
+device hitch trace. Native UIKit may handle some behaviors correctly; absence of
+a custom hook is not proof of failure.
+
+**Outcome:** test and specify keyboard, VoiceOver, pointer, Reduce Motion, RTL,
+modal focus, status-bar tap, scene lifecycle, memory pressure, and long sessions.
+Use standard controls where possible and add targeted code only for a failing or
+new product requirement.
+
+## Corrections to the older plans
+
+| Previous assumption | Current conclusion |
+|---|---|
+| Three Home content columns; other routes not extended | Current implementation has two content columns per tab, plus the system destination surface, and expanded routing. |
+| UIKit collapse gives stock navigation for free | The current branch needs substantial compact reconciliation; swipe behavior is not equivalent. |
+| All cross-column destinations must use native push | Current detail-root replacement intentionally uses `setViewControllers:animated:NO`; continuation uses native push. Preserve the distinction. |
+| Geometry is solved; every row is 54 points | Preserve the proven host, but rebaseline merged search/OS behavior and distinguish context row from total nav/search container. |
+| UIFindInteraction is a switch on a generic scroll view | Arbitrary Texture content needs an interaction delegate and find session; native find can be keyboard-docked or inline. |
+| iPadOS 14–17 receives a degraded pane layout | The production capability gate is now iPadOS 18+. |
+| Multiwindow is mostly plumbing because the plist permits it | Session ownership, routing, find state, and lifecycle still need verification and fixes. |
+| Passing discrete resize and a hot-predicate benchmark establishes performance | Continuous resizing, render hitches, sustained media, device memory and thermal behavior are still open. |
+
+The new roadmap absorbs Plan 001's useful visual work and expands its scope.
+Its old source-file allowlist and STOP conditions describe that earlier task;
+they do not limit this explicitly requested wider audit and plan.

--- a/scripts/capture-ipad-pane-state.py
+++ b/scripts/capture-ipad-pane-state.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Capture an existing simulator run. Does not install, alter settings, or export credentials."""
+import argparse, hashlib, json, pathlib, plistlib, shutil, subprocess, time, zipfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--device', required=True)
+parser.add_argument('--work-dir', default='.sim/pane-redesign')
+parser.add_argument('--bundle-id', default='com.christianselig.Apollo')
+parser.add_argument('--base-ipa', default='Apollo-base.ipa')
+parser.add_argument('--label', default='capture')
+args = parser.parse_args()
+root = pathlib.Path(__file__).resolve().parent.parent
+out = root / args.work_dir / 'evidence' / (time.strftime('%Y%m%d-%H%M%S-') + pathlib.Path(args.label).name)
+out.mkdir(parents=True, exist_ok=True)
+def run(*command):
+    return subprocess.check_output(command, text=True).strip()
+command_file = pathlib.Path('/tmp/apollofix-tap.txt')
+previous = command_file.read_bytes() if command_file.exists() else None
+try:
+    command_file.write_text('panesnapshot')
+    subprocess.run(['xcrun','simctl','spawn',args.device,'notifyutil','-p','apollofix.debugtap'],check=True)
+    container = pathlib.Path(run('xcrun','simctl','get_app_container',args.device,args.bundle_id,'data'))
+    snapshot = container / 'Library/Caches/ApolloPaneSnapshot.json'
+    for _ in range(40):
+        if snapshot.exists() and snapshot.stat().st_mtime >= command_file.stat().st_mtime: break
+        time.sleep(.1)
+    else: raise SystemExit('No fresh pane snapshot: verify the new tweak is running and main thread is responsive.')
+    data = json.loads(snapshot.read_text())
+    if data['loadedTweakCopies'] != 1: raise SystemExit('Expected exactly one loaded tweak.')
+    shutil.copy2(snapshot, out / 'panes.json')
+    subprocess.run(['xcrun','simctl','io',args.device,'screenshot',str(out / 'screen.png')],check=True)
+    dylib = root / args.work_dir / 'ApolloReborn.dylib'
+    metadata = {'commit':run('git','-C',str(root),'rev-parse','HEAD'),
+        'dirtyPaths':run('git','-C',str(root),'status','--short').splitlines(),
+        'dylibUUID':run('xcrun','dwarfdump','--uuid',str(dylib)),
+        'appearance':run('xcrun','simctl','ui',args.device,'appearance'),
+        'textSize':run('xcrun','simctl','ui',args.device,'content_size'),
+        'increaseContrast':run('xcrun','simctl','ui',args.device,'increase_contrast'),
+        'device':args.device, 'bundleID':args.bundle_id,
+        'validation':'Simulator evidence; no device frame-rate or foldable claim.'}
+    ipa = root / args.base_ipa
+    if ipa.exists():
+        metadata['baseIPA_SHA256'] = hashlib.file_digest(ipa.open('rb'), 'sha256').hexdigest()
+        with zipfile.ZipFile(ipa) as archive:
+            names = [n for n in archive.namelist() if n.startswith('Payload/') and n.count('/') == 2 and n.endswith('.app/Info.plist')]
+            info = plistlib.loads(archive.read(names[0]))
+            keys = ['CFBundleShortVersionString','CFBundleVersion','UIDeviceFamily','UIRequiresFullScreen',
+                'UIApplicationSceneManifest','UISupportedInterfaceOrientations','UISupportedInterfaceOrientations~ipad',
+                'UIApplicationSupportsIndirectInputEvents','UILaunchStoryboardName','MinimumOSVersion','DTSDKName']
+            metadata['baseBundleMetadata'] = {key:info[key] for key in keys if key in info}
+    (out / 'build.json').write_text(json.dumps(metadata,indent=2)+'\n')
+    print(out)
+finally:
+    if previous is not None: command_file.write_bytes(previous)
+    else: command_file.unlink(missing_ok=True)

--- a/scripts/test-ipad-pane-policy.sh
+++ b/scripts/test-ipad-pane-policy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pane_test_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-pane-tests.XXXXXX")
+trap 'rm -rf "$pane_test_dir"' EXIT
+xcrun clang -std=c11 -Wall -Wextra -Werror tests/ipad/geometry-policy.c -o "$pane_test_dir/geometry"
+"$pane_test_dir/geometry"
+xcrun clang -fobjc-arc -framework Foundation tests/ipad/transition-observer.m src/ipad/ApolloPaneTransitionObserver.m src/ipad/ApolloPaneDiagnostics.m -o "$pane_test_dir/transitions"
+"$pane_test_dir/transitions"

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -16,19 +16,25 @@
 #if APOLLO_SIM_BUILD
 
 #import "ApolloAccountCredentials.h"
+#import "ApolloAutoHideTabBar.h"
 #import "ApolloCommentVoteInsights.h"
 #import "ApolloCommon.h"
 #import "ApolloFloatingTabs.h"
+#import "ApolloGalleryImageLoader.h"
 #import "ApolloLinkPreviewFetcher.h"
 #import "ApolloTranslation.h"
-#import "ApolloGalleryImageLoader.h"
 #import "ApolloWebTextDecoding.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "UIWindow+Apollo.h"
+#import "ipad/ApolloPaneSplitViewController.h"
+#import "ipad/ApolloPaneLayout.h"
+#import "ipad/ApolloPaneSidebar.h"
+#import <mach-o/dyld.h>
 
 void ApolloSubredditIndexDebugDescribeTables(void); // ApolloSubredditIndexPolish.xm (sim-only)
 #import <objc/message.h>
+#import <objc/runtime.h>
 #import <mach/mach.h>
 
 @interface UITouch (ApolloSimDebugTap)
@@ -52,6 +58,40 @@ void ApolloSubredditIndexDebugDescribeTables(void); // ApolloSubredditIndexPolis
 @end
 
 static NSString *const kApolloSimTapFile = @"/tmp/apollofix-tap.txt";
+
+@interface ApolloPaneTransitionProbeViewController : UIViewController
+- (instancetype)initWithIdentifier:(NSString *)identifier;
+@end
+
+@implementation ApolloPaneTransitionProbeViewController {
+    NSString *_probeIdentifier;
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _probeIdentifier = [identifier copy] ?: @"unnamed";
+        self.title = [NSString stringWithFormat:@"Transition Probe %@", _probeIdentifier];
+    }
+    return self;
+}
+
+- (void)loadView {
+    UIView *view = [UIView new];
+    view.backgroundColor = UIColor.systemBackgroundColor;
+    UILabel *label = [UILabel new];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle2];
+    label.text = self.title;
+    [view addSubview:label];
+    [NSLayoutConstraint activateConstraints:@[
+        [label.centerXAnchor constraintEqualToAnchor:view.safeAreaLayoutGuide.centerXAnchor],
+        [label.centerYAnchor constraintEqualToAnchor:view.safeAreaLayoutGuide.centerYAnchor],
+    ]];
+    self.view = view;
+}
+
+@end
 
 static void ApolloSimDebugSendTouch(UITouch *touch) {
     UIApplication *app = UIApplication.sharedApplication;
@@ -367,7 +407,6 @@ static void ApolloSimDebugForceBottomInset(CGFloat bottom) {
 // ObjC++, so plain C++ linkage matches).
 const void *ApolloScrollEdgeEffectTopStampKey(void);
 const void *ApolloScrollEdgeEffectForcedHiddenStampKey(void);
-void ApolloSubredditListDiagRearm(void);
 
 static void ApolloSimDebugDumpHeaderEffectsInView(UIView *view) {
     if ([view isKindOfClass:[UIScrollView class]]) {
@@ -392,6 +431,1143 @@ static void ApolloSimDebugDumpHeaderEffects(void) {
         if (!window.hidden) ApolloSimDebugDumpHeaderEffectsInView(window);
     }
 }
+
+// Overriding the child's traits from its parent is the supported way to force a
+// size class on one subtree; passing nil restores inheritance. Matching on
+// UISplitViewController keeps this generic — no dependency on src/ipad/.
+static void ApolloSimDebugForceCompactSplitColumns(BOOL compact) {
+    UIViewController *tabBarController = ApolloMainTabBarController();
+    if (![tabBarController isKindOfClass:[UITabBarController class]]) {
+        ApolloLog(@"[SimDebugTap] compact: no tab bar controller");
+        return;
+    }
+
+    UITraitCollection *override = compact
+        ? [UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact]
+        : nil;
+
+    NSUInteger applied = 0;
+    for (UIViewController *child in [(UITabBarController *)tabBarController viewControllers]) {
+        if (![child isKindOfClass:[UISplitViewController class]]) continue;
+        [tabBarController setOverrideTraitCollection:override forChildViewController:child];
+        applied++;
+    }
+    ApolloLog(@"[SimDebugTap] compact=%d applied to %lu split controller(s)",
+              compact, (unsigned long)applied);
+}
+
+// "accessibilityescape": invoke the same action VoiceOver's two-finger scrub
+// sends to the visible pane. This validates the compact cross-column escape
+// path without relying on simulator HID support for accessibility gestures.
+static void ApolloSimDebugPerformAccessibilityEscape(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UIViewController *selected = [controller isKindOfClass:[UITabBarController class]]
+        ? ((UITabBarController *)controller).selectedViewController : nil;
+    BOOL handled = [selected accessibilityPerformEscape];
+    ApolloLog(@"[SimDebugTap] accessibility escape handled=%d selected=%@",
+              handled, NSStringFromClass(selected.class));
+}
+
+// "visibleprobe dump|alert|share|dismiss": exercise the same recursive
+// visible-controller helper used by production presentation call sites and log
+// the concrete presenter relationship. The share probe configures a popover
+// anchor so an incorrect iPad presenter fails as a hierarchy bug, not because
+// UIActivityViewController itself was incompletely configured.
+static void ApolloSimDebugVisiblePresenterProbe(NSString *operation) {
+    UIWindow *window = nil;
+    for (UIWindow *candidate in ApolloAllWindows()) {
+        if (!candidate.hidden && candidate.alpha > 0.01 && candidate.isKeyWindow) {
+            window = candidate;
+            break;
+        }
+    }
+    if (!window) {
+        for (UIWindow *candidate in ApolloAllWindows()) {
+            if (!candidate.hidden && candidate.alpha > 0.01 && candidate.windowLevel == UIWindowLevelNormal) {
+                window = candidate;
+                break;
+            }
+        }
+    }
+    UIViewController *visible = window.visibleViewController;
+    NSString *name = NSStringFromClass(visible.class) ?: @"nil";
+    ApolloLog(@"[SimDebugTap][visibleprobe] operation=%@ visible=%@ attached=%d window=%@",
+              operation, name, visible.viewIfLoaded.window != nil,
+              NSStringFromClass(window.class));
+
+    if ([operation isEqualToString:@"dump"] || !visible) return;
+    if ([operation isEqualToString:@"dismiss"]) {
+        [window.rootViewController dismissViewControllerAnimated:NO completion:^{
+            ApolloLog(@"[SimDebugTap][visibleprobe] dismissed");
+        }];
+        return;
+    }
+
+    UIViewController *probe = nil;
+    if ([operation isEqualToString:@"alert"]) {
+        UIAlertController *alert = [UIAlertController
+            alertControllerWithTitle:@"Pane Presenter Probe"
+                             message:name
+                      preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleCancel handler:nil]];
+        probe = alert;
+    } else if ([operation isEqualToString:@"share"]) {
+        UIActivityViewController *activity = [[UIActivityViewController alloc]
+            initWithActivityItems:@[ @"Apollo pane presenter probe" ] applicationActivities:nil];
+        UIPopoverPresentationController *popover = activity.popoverPresentationController;
+        popover.sourceView = visible.view;
+        popover.sourceRect = CGRectMake(CGRectGetMidX(visible.view.bounds),
+                                        CGRectGetMidY(visible.view.bounds), 1.0, 1.0);
+        popover.permittedArrowDirections = 0;
+        probe = activity;
+    }
+    if (!probe) {
+        ApolloLog(@"[SimDebugTap][visibleprobe] unknown operation %@", operation);
+        return;
+    }
+
+    [visible presentViewController:probe animated:NO completion:^{
+        UIViewController *actual = probe.presentingViewController;
+        BOOL sameBranch = actual == visible ||
+            ApolloViewControllerContains(actual, visible) ||
+            ApolloViewControllerContains(visible, actual);
+        ApolloLog(@"[SimDebugTap][visibleprobe] presented=%@ requested=%@ actual=%@ sameBranch=%d",
+                  NSStringFromClass(probe.class), NSStringFromClass(visible.class),
+                  NSStringFromClass(actual.class), sameBranch);
+    }];
+}
+
+// "navdump" command: prove which real navigation stacks the shared tab-child
+// helpers expose. This catches a subtle pane regression that a screenshot cannot:
+// UIKit owns an outer wrapper navigation controller around the secondary host,
+// while Apollo's visible detail stack is a different navigation controller
+// nested inside that host. The dump must list the latter exactly once.
+static void ApolloSimDebugDumpNavigationControllers(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    if (![controller isKindOfClass:[UITabBarController class]]) {
+        ApolloLog(@"[SimDebugTap] navdump: no tab bar controller");
+        return;
+    }
+
+    UITabBarController *tabBarController = (UITabBarController *)controller;
+    NSMutableString *out = [NSMutableString string];
+    [out appendFormat:@"selected=%lu tabs=%lu\n",
+        (unsigned long)tabBarController.selectedIndex,
+        (unsigned long)tabBarController.viewControllers.count];
+    [tabBarController.viewControllers enumerateObjectsUsingBlock:
+        ^(UIViewController *child, NSUInteger tabIndex, BOOL *stop) {
+            NSArray<UINavigationController *> *navs = ApolloAllNavigationControllersForTabChild(child);
+            UINavigationController *primary = ApolloNavigationControllerForTabChild(child);
+            [out appendFormat:@"tab=%lu child=%@ navs=%lu primary=%p\n",
+                (unsigned long)tabIndex, NSStringFromClass(child.class),
+                (unsigned long)navs.count, primary];
+            [navs enumerateObjectsUsingBlock:
+                ^(UINavigationController *nav, NSUInteger navIndex, BOOL *innerStop) {
+                    NSMutableArray<NSString *> *classes = [NSMutableArray array];
+                    for (UIViewController *stackController in nav.viewControllers) {
+                        [classes addObject:NSStringFromClass(stackController.class) ?: @"(unknown)"];
+                    }
+                    [out appendFormat:@"  nav=%lu ptr=%p primary=%d parent=%@ stack=[%@]\n",
+                        (unsigned long)navIndex, nav, nav == primary,
+                        NSStringFromClass(nav.parentViewController.class),
+                        [classes componentsJoinedByString:@", "]];
+                }];
+        }];
+    [out writeToFile:@"/tmp/apollofix-navcontrollers.txt"
+          atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[SimDebugTap] navigation-controller dump written (%lu bytes)",
+              (unsigned long)out.length);
+}
+
+// "loadstatus" command: inspect lazy pane materialization without touching any
+// unloaded view. This makes Task 15's cold-launch contract directly observable:
+// construction may wrap all tab stacks, but only a visited tab may load its
+// pane/column hierarchy.
+static void ApolloSimDebugDumpPaneLoadStatus(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    if (![controller isKindOfClass:[UITabBarController class]]) {
+        ApolloLog(@"[PaneLoadTest] no tab bar controller pass=0");
+        return;
+    }
+
+    UITabBarController *tabBarController = (UITabBarController *)controller;
+    NSMutableString *out = [NSMutableString stringWithFormat:@"selected=%lu tabs=%lu\n",
+        (unsigned long)tabBarController.selectedIndex,
+        (unsigned long)tabBarController.viewControllers.count];
+    __block NSUInteger loadedPaneCount = 0;
+    __block NSUInteger attachedPaneCount = 0;
+    __block BOOL selectedPaneLoaded = NO;
+    [tabBarController.viewControllers enumerateObjectsUsingBlock:
+        ^(UIViewController *child, NSUInteger tabIndex, BOOL *stop) {
+            if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) {
+                [out appendFormat:@"tab=%lu child=%@ pane=0\n", (unsigned long)tabIndex,
+                    NSStringFromClass(child.class)];
+                return;
+            }
+            ApolloPaneSplitViewController *pane = (ApolloPaneSplitViewController *)child;
+            UINavigationController *primary =
+                [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+            UINavigationController *detail =
+                [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+            UIViewController *host =
+                [pane viewControllerForColumn:UISplitViewControllerColumnSecondary];
+            BOOL paneLoaded = pane.isViewLoaded;
+            if (paneLoaded) loadedPaneCount++;
+            BOOL attached = pane.viewIfLoaded.window != nil;
+            if (attached) attachedPaneCount++;
+            if (tabIndex == tabBarController.selectedIndex) selectedPaneLoaded = paneLoaded;
+            [out appendFormat:
+                @"tab=%lu paneLoaded=%d primaryLoaded=%d detailLoaded=%d hostLoaded=%d "
+                 "primaryRootLoaded=%d detailRootLoaded=%d attached=%d\n",
+                (unsigned long)tabIndex, paneLoaded, primary.isViewLoaded,
+                detail.isViewLoaded, host.isViewLoaded,
+                primary.viewControllers.firstObject.isViewLoaded,
+                detail.viewControllers.firstObject.isViewLoaded,
+                attached];
+        }];
+    [out appendFormat:@"loadedPaneCount=%lu attachedPaneCount=%lu pass=%d\n",
+        (unsigned long)loadedPaneCount, (unsigned long)attachedPaneCount,
+        selectedPaneLoaded && attachedPaneCount == 1];
+    [out writeToFile:@"/tmp/apollofix-pane-load-status.txt"
+          atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneLoadTest] load status written loaded=%lu selected=%lu",
+              (unsigned long)loadedPaneCount, (unsigned long)tabBarController.selectedIndex);
+}
+
+static void ApolloSimDebugRunAutoHideScan(NSString *contents) {
+    NSArray<NSString *> *tokens = [contents componentsSeparatedByCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSUInteger iterations = tokens.count > 1 ? MAX(tokens[1].integerValue, 1) : 10000;
+    NSString *status = ApolloAutoHideTabBarSimScanStatus(iterations);
+    [status writeToFile:@"/tmp/apollofix-autohide-scan.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[AutoHideTabBarPerf] %@", status);
+}
+
+static void ApolloSimDebugSetAutoHidePolicy(NSString *contents) {
+    BOOL enabled = [contents rangeOfString:@" on"].location != NSNotFound;
+    NSString *status = ApolloAutoHideTabBarSimSetPolicy(enabled);
+    [status writeToFile:@"/tmp/apollofix-autohide-policy.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[AutoHideTabBarPerf] policy %@", status);
+}
+
+static UINavigationController *ApolloSimDebugSelectedNavigationController(NSString *columnName) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UIViewController *selected = [controller isKindOfClass:[UITabBarController class]]
+        ? ((UITabBarController *)controller).selectedViewController : nil;
+    UINavigationController *primary = ApolloNavigationControllerForTabChild(selected);
+    if (![columnName isEqualToString:@"detail"]) return primary;
+
+    for (UINavigationController *candidate in ApolloAllNavigationControllersForTabChild(selected)) {
+        if (candidate != primary) return candidate;
+    }
+    // Compact has one physical stack. Falling back to it lets the same command
+    // exercise logical-detail Back before and after an expansion.
+    return primary;
+}
+
+static ApolloPaneSplitViewController *ApolloSimDebugSelectedPane(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UIViewController *selected = [controller isKindOfClass:[UITabBarController class]]
+        ? ((UITabBarController *)controller).selectedViewController : nil;
+    return [selected isKindOfClass:[ApolloPaneSplitViewController class]]
+        ? (ApolloPaneSplitViewController *)selected : nil;
+}
+
+// Task 18 width-stability harness. Detail presentation used to hide UIKit's
+// global tab sidebar, instantly handing roughly 270pt back to the content and
+// forcing every visible Texture node through a constrained-width remeasure.
+// Production no longer owns sidebar visibility (Task 7), so sample the actual
+// resolved geometry across first and repeated detail loads and prove that the
+// old trigger stays absent. Newly appearing detail tables establish a baseline;
+// only a later width change on the same live ASTableView counts as churn.
+static NSUInteger sApolloSimReflowGeneration;
+static BOOL sApolloSimReflowActive;
+static NSUInteger sApolloSimReflowSamples;
+static BOOL sApolloSimReflowSidebarAvailable;
+static BOOL sApolloSimReflowInitialSidebarHidden;
+static BOOL sApolloSimReflowLastSidebarHidden;
+static NSUInteger sApolloSimReflowSidebarChanges;
+static CGFloat sApolloSimReflowInitialPrimaryColumnWidth;
+static CGFloat sApolloSimReflowLastPrimaryColumnWidth;
+static CGFloat sApolloSimReflowMinPrimaryColumnWidth;
+static CGFloat sApolloSimReflowMaxPrimaryColumnWidth;
+static CGFloat sApolloSimReflowInitialPrimaryNavigationWidth;
+static CGFloat sApolloSimReflowLastPrimaryNavigationWidth;
+static CGFloat sApolloSimReflowMinPrimaryNavigationWidth;
+static CGFloat sApolloSimReflowMaxPrimaryNavigationWidth;
+static NSMapTable<UIView *, NSNumber *> *sApolloSimReflowPrimaryTableWidths;
+static NSMapTable<UIView *, NSNumber *> *sApolloSimReflowDetailTableWidths;
+static NSUInteger sApolloSimReflowPrimaryTableWidthChanges;
+static NSUInteger sApolloSimReflowDetailTableWidthChanges;
+static CGFloat sApolloSimReflowLargestTextureWidthJump;
+
+static void ApolloSimDebugCollectVisibleTextureTables(UIView *view,
+                                                       NSMutableArray<UIView *> *tables) {
+    if (!view || !view.window) return;
+    Class tableClass = objc_getClass("ASTableView");
+    if (tableClass && [view isKindOfClass:tableClass] && !view.hidden && view.alpha > 0.01) {
+        [tables addObject:view];
+    }
+    for (UIView *subview in view.subviews) {
+        ApolloSimDebugCollectVisibleTextureTables(subview, tables);
+    }
+}
+
+static void ApolloSimDebugRecordTextureWidths(
+        UIView *root,
+        NSMapTable<UIView *, NSNumber *> *widths,
+        NSUInteger *changeCount) {
+    if (!root || !widths || !changeCount) return;
+    NSMutableArray<UIView *> *tables = [NSMutableArray array];
+    ApolloSimDebugCollectVisibleTextureTables(root, tables);
+    for (UIView *table in tables) {
+        CGFloat width = CGRectGetWidth(table.bounds);
+        NSNumber *previousNumber = [widths objectForKey:table];
+        if (previousNumber) {
+            CGFloat jump = fabs(width - previousNumber.doubleValue);
+            if (jump > 0.5) {
+                (*changeCount)++;
+                sApolloSimReflowLargestTextureWidthJump =
+                    MAX(sApolloSimReflowLargestTextureWidthJump, jump);
+            }
+        }
+        [widths setObject:@(width) forKey:table];
+    }
+}
+
+static NSString *ApolloSimDebugReflowStatus(void) {
+    CGFloat primaryColumnRange = sApolloSimReflowSamples > 0
+        ? sApolloSimReflowMaxPrimaryColumnWidth - sApolloSimReflowMinPrimaryColumnWidth : 0.0;
+    CGFloat primaryNavigationRange = sApolloSimReflowSamples > 0
+        ? sApolloSimReflowMaxPrimaryNavigationWidth - sApolloSimReflowMinPrimaryNavigationWidth : 0.0;
+    NSUInteger primaryTables = sApolloSimReflowPrimaryTableWidths.count;
+    NSUInteger detailTables = sApolloSimReflowDetailTableWidths.count;
+    BOOL pass = sApolloSimReflowSamples >= 10 && sApolloSimReflowSidebarAvailable &&
+        sApolloSimReflowSidebarChanges == 0 && primaryColumnRange <= 1.0 &&
+        primaryNavigationRange <= 1.0 && sApolloSimReflowPrimaryTableWidthChanges == 0 &&
+        sApolloSimReflowDetailTableWidthChanges == 0 && detailTables > 0;
+    return [NSString stringWithFormat:
+        @"active=%d samples=%lu sidebarInitialHidden=%d sidebarFinalHidden=%d sidebarChanges=%lu "
+         "primaryColumnInitial=%.1f primaryColumnFinal=%.1f primaryColumnRange=%.1f "
+         "primaryNavInitial=%.1f primaryNavFinal=%.1f primaryNavRange=%.1f "
+         "primaryTextureTables=%lu primaryTextureWidthChanges=%lu detailTextureTables=%lu "
+         "detailTextureWidthChanges=%lu largestTextureWidthJump=%.1f pass=%d",
+        sApolloSimReflowActive, (unsigned long)sApolloSimReflowSamples,
+        sApolloSimReflowInitialSidebarHidden, sApolloSimReflowLastSidebarHidden,
+        (unsigned long)sApolloSimReflowSidebarChanges,
+        sApolloSimReflowInitialPrimaryColumnWidth, sApolloSimReflowLastPrimaryColumnWidth,
+        primaryColumnRange, sApolloSimReflowInitialPrimaryNavigationWidth,
+        sApolloSimReflowLastPrimaryNavigationWidth, primaryNavigationRange,
+        (unsigned long)primaryTables, (unsigned long)sApolloSimReflowPrimaryTableWidthChanges,
+        (unsigned long)detailTables, (unsigned long)sApolloSimReflowDetailTableWidthChanges,
+        sApolloSimReflowLargestTextureWidthJump, pass];
+}
+
+static void ApolloSimDebugWriteReflowStatus(void) {
+    NSString *status = ApolloSimDebugReflowStatus();
+    [status writeToFile:@"/tmp/apollofix-reflow-status.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneReflowTest] %@", status);
+}
+
+static void ApolloSimDebugAppendReadableViews(UIView *view, NSMutableArray<NSString *> *lines,
+                                              NSUInteger depth) {
+    if (!view || depth > 12) return;
+    BOOL interesting = [view isKindOfClass:[UITableView class]] ||
+        [view isKindOfClass:[UITableViewCell class]] ||
+        [NSStringFromClass(view.class) containsString:@"CellContentView"] ||
+        [NSStringFromClass(view.class) containsString:@"ASTable"];
+    if (interesting) {
+        SEL nodeSelector = NSSelectorFromString(@"asyncdisplaykit_node");
+        id node = [view respondsToSelector:nodeSelector]
+            ? ((id (*)(id, SEL))objc_msgSend)(view, nodeSelector) : nil;
+        CGRect safe = [view convertRect:view.safeAreaLayoutGuide.layoutFrame fromView:view];
+        CGRect readable = [view convertRect:view.readableContentGuide.layoutFrame fromView:view];
+        [lines addObject:[NSString stringWithFormat:
+            @"depth=%lu class=%@ node=%@ frame=%@ bounds=%@ safe=%@ readable=%@ margins=%@",
+            (unsigned long)depth, NSStringFromClass(view.class),
+            NSStringFromClass([node class]),
+            NSStringFromCGRect(view.frame), NSStringFromCGRect(view.bounds),
+            NSStringFromCGRect(safe), NSStringFromCGRect(readable),
+            NSStringFromUIEdgeInsets(view.layoutMargins)]];
+    }
+    for (UIView *subview in view.subviews) {
+        ApolloSimDebugAppendReadableViews(subview, lines, depth + 1);
+    }
+}
+
+static void ApolloSimDebugWriteReadableStatus(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    UIViewController *top = detail.topViewController;
+    NSMutableArray<NSString *> *lines = [NSMutableArray array];
+    if (top.isViewLoaded) {
+        [lines addObject:[NSString stringWithFormat:
+            @"top=%@ bounds=%@ safeInsets=%@ safe=%@ readable=%@ additional=%@",
+            NSStringFromClass(top.class), NSStringFromCGRect(top.view.bounds),
+            NSStringFromUIEdgeInsets(top.view.safeAreaInsets),
+            NSStringFromCGRect(top.view.safeAreaLayoutGuide.layoutFrame),
+            NSStringFromCGRect(top.view.readableContentGuide.layoutFrame),
+            NSStringFromUIEdgeInsets(top.additionalSafeAreaInsets)]];
+        ApolloSimDebugAppendReadableViews(top.view, lines, 0);
+    } else {
+        [lines addObject:[NSString stringWithFormat:@"top=%@ unloaded=1",
+            NSStringFromClass(top.class)]];
+    }
+    NSString *status = [lines componentsJoinedByString:@"\n"];
+    [status writeToFile:@"/tmp/apollofix-readable-status.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneReadableTest] %@", status);
+}
+
+static void ApolloSimDebugWritePaneWidthStatus(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UITabBarController *tabs = [controller isKindOfClass:[UITabBarController class]]
+        ? (UITabBarController *)controller : nil;
+    NSMutableArray<NSString *> *lines = [NSMutableArray array];
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
+        [lines addObject:[(ApolloPaneSplitViewController *)child
+            apollo_simPreferredPrimaryColumnWidthState]];
+    }
+    NSString *status = lines.count > 0
+        ? [lines componentsJoinedByString:@"\n"] : @"no panes";
+    [status writeToFile:@"/tmp/apollofix-pane-width-status.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneWidthTest] %@", status);
+}
+
+static void ApolloSimDebugSetPaneWidth(CGFloat width) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    [pane apollo_simSetPreferredPrimaryColumnWidth:width];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloSimDebugWritePaneWidthStatus();
+    });
+}
+
+static void ApolloSimDebugAdjustPaneDivider(NSString *operation) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    BOOL adjusted = [pane apollo_simAdjustDivider:operation];
+    ApolloLog(@"[PaneWidthTest] adjust=%@ accepted=%d", operation, adjusted);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloSimDebugWritePaneWidthStatus();
+    });
+}
+
+static void ApolloSimDebugWritePaneThemeStatus(void) {
+    UIViewController *controller = ApolloMainTabBarController();
+    UITabBarController *tabs = [controller isKindOfClass:[UITabBarController class]]
+        ? (UITabBarController *)controller : nil;
+    NSMutableArray<NSString *> *lines = [NSMutableArray array];
+    for (UIViewController *child in tabs.viewControllers) {
+        if (![child isKindOfClass:[ApolloPaneSplitViewController class]]) continue;
+        [lines addObject:[(ApolloPaneSplitViewController *)child apollo_simThemeState]];
+    }
+    NSString *status = lines.count > 0
+        ? [lines componentsJoinedByString:@"\n"] : @"no panes";
+    [status writeToFile:@"/tmp/apollofix-pane-theme-status.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneThemeTest] %@", status);
+}
+
+static void ApolloSimDebugPostThemeNotification(void) {
+    [NSNotificationCenter.defaultCenter
+        postNotificationName:@"com.christianselig.ApolloSpecificThemeChanged" object:nil];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloSimDebugWritePaneThemeStatus();
+    });
+}
+
+static void ApolloSimDebugSampleReflow(NSUInteger generation) {
+    if (!sApolloSimReflowActive || generation != sApolloSimReflowGeneration) return;
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UITabBarController *tabs = [pane.tabBarController isKindOfClass:[UITabBarController class]]
+        ? pane.tabBarController : nil;
+    if (!pane || !tabs) {
+        sApolloSimReflowActive = NO;
+        ApolloSimDebugWriteReflowStatus();
+        return;
+    }
+
+    BOOL sidebarAvailable = NO;
+    BOOL sidebarHidden = NO;
+    if (@available(iOS 18.0, *)) {
+        sidebarAvailable = tabs.sidebar != nil;
+        sidebarHidden = tabs.sidebar.isHidden;
+    }
+    CGFloat primaryColumnWidth = pane.primaryColumnWidth;
+    UINavigationController *primary =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    CGFloat primaryNavigationWidth = CGRectGetWidth(primary.viewIfLoaded.bounds);
+
+    if (sApolloSimReflowSamples == 0) {
+        sApolloSimReflowSidebarAvailable = sidebarAvailable;
+        sApolloSimReflowInitialSidebarHidden = sidebarHidden;
+        sApolloSimReflowLastSidebarHidden = sidebarHidden;
+        sApolloSimReflowInitialPrimaryColumnWidth = primaryColumnWidth;
+        sApolloSimReflowMinPrimaryColumnWidth = primaryColumnWidth;
+        sApolloSimReflowMaxPrimaryColumnWidth = primaryColumnWidth;
+        sApolloSimReflowInitialPrimaryNavigationWidth = primaryNavigationWidth;
+        sApolloSimReflowMinPrimaryNavigationWidth = primaryNavigationWidth;
+        sApolloSimReflowMaxPrimaryNavigationWidth = primaryNavigationWidth;
+    } else if (sidebarAvailable && sidebarHidden != sApolloSimReflowLastSidebarHidden) {
+        sApolloSimReflowSidebarChanges++;
+    }
+
+    sApolloSimReflowLastSidebarHidden = sidebarHidden;
+    sApolloSimReflowLastPrimaryColumnWidth = primaryColumnWidth;
+    sApolloSimReflowMinPrimaryColumnWidth =
+        MIN(sApolloSimReflowMinPrimaryColumnWidth, primaryColumnWidth);
+    sApolloSimReflowMaxPrimaryColumnWidth =
+        MAX(sApolloSimReflowMaxPrimaryColumnWidth, primaryColumnWidth);
+    sApolloSimReflowLastPrimaryNavigationWidth = primaryNavigationWidth;
+    sApolloSimReflowMinPrimaryNavigationWidth =
+        MIN(sApolloSimReflowMinPrimaryNavigationWidth, primaryNavigationWidth);
+    sApolloSimReflowMaxPrimaryNavigationWidth =
+        MAX(sApolloSimReflowMaxPrimaryNavigationWidth, primaryNavigationWidth);
+    ApolloSimDebugRecordTextureWidths(primary.viewIfLoaded,
+        sApolloSimReflowPrimaryTableWidths, &sApolloSimReflowPrimaryTableWidthChanges);
+    ApolloSimDebugRecordTextureWidths(detail.viewIfLoaded,
+        sApolloSimReflowDetailTableWidths, &sApolloSimReflowDetailTableWidthChanges);
+    sApolloSimReflowSamples++;
+
+    // Twelve seconds covers clear -> first load -> clear -> repeated load with
+    // plenty of settling time, while keeping this bounded simulator-only work.
+    if (sApolloSimReflowSamples >= 240) {
+        sApolloSimReflowActive = NO;
+        ApolloSimDebugWriteReflowStatus();
+        return;
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloSimDebugSampleReflow(generation);
+    });
+}
+
+static void ApolloSimDebugStartReflowProbe(void) {
+    sApolloSimReflowGeneration++;
+    sApolloSimReflowActive = YES;
+    sApolloSimReflowSamples = 0;
+    sApolloSimReflowSidebarAvailable = NO;
+    sApolloSimReflowSidebarChanges = 0;
+    sApolloSimReflowInitialPrimaryColumnWidth = 0.0;
+    sApolloSimReflowLastPrimaryColumnWidth = 0.0;
+    sApolloSimReflowMinPrimaryColumnWidth = 0.0;
+    sApolloSimReflowMaxPrimaryColumnWidth = 0.0;
+    sApolloSimReflowInitialPrimaryNavigationWidth = 0.0;
+    sApolloSimReflowLastPrimaryNavigationWidth = 0.0;
+    sApolloSimReflowMinPrimaryNavigationWidth = 0.0;
+    sApolloSimReflowMaxPrimaryNavigationWidth = 0.0;
+    sApolloSimReflowPrimaryTableWidths = [NSMapTable weakToStrongObjectsMapTable];
+    sApolloSimReflowDetailTableWidths = [NSMapTable weakToStrongObjectsMapTable];
+    sApolloSimReflowPrimaryTableWidthChanges = 0;
+    sApolloSimReflowDetailTableWidthChanges = 0;
+    sApolloSimReflowLargestTextureWidthJump = 0.0;
+    ApolloSimDebugSampleReflow(sApolloSimReflowGeneration);
+    ApolloLog(@"[PaneReflowTest] started 12-second width-stability probe");
+}
+
+// Task 13 resolved-layout harness. Drive only the selected pane through public
+// trait/split APIs so untouched tabs retain their production lazy state.
+static void ApolloSimDebugSetPaneMode(NSString *mode) {
+    UITabBarController *tabBarController = (UITabBarController *)ApolloMainTabBarController();
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    if (![tabBarController isKindOfClass:[UITabBarController class]] || !pane) {
+        ApolloLog(@"[PaneDisplayTest] panemode unavailable");
+        return;
+    }
+    NSString *normalized = mode.lowercaseString;
+    if ([normalized isEqualToString:@"compact"]) {
+        [pane apollo_simSetResolvedLayoutMode:@"reset"];
+        UITraitCollection *compact = [UITraitCollection
+            traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact];
+        [tabBarController setOverrideTraitCollection:compact forChildViewController:pane];
+    } else {
+        UITraitCollection *regular = [UITraitCollection
+            traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassRegular];
+        [tabBarController setOverrideTraitCollection:regular forChildViewController:pane];
+        [pane apollo_simSetResolvedLayoutMode:normalized];
+        if ([normalized isEqualToString:@"reset"]) {
+            [tabBarController setOverrideTraitCollection:nil forChildViewController:pane];
+        }
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloLog(@"[PaneDisplayTest] mode=%@ %@", normalized,
+                  [pane apollo_simResolvedLayoutState]);
+    });
+}
+
+extern "C" NSDictionary *ApolloPaneSimFind(UIViewController *, NSString *);
+static void ApolloSimDebugOpenVisiblePost(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UIViewController *controller = [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary].topViewController;
+    Ivar tableIvar = class_getInstanceVariable(controller.class, "tableNode");
+    id node = tableIvar ? object_getIvar(controller, tableIvar) : nil;
+    UITableView *table = [node respondsToSelector:@selector(view)] ? (id)[node view] : nil;
+    if (![table isKindOfClass:UITableView.class]) return;
+    for (NSIndexPath *path in table.indexPathsForVisibleRows) {
+        id cell = ((id (*)(id, SEL, id))objc_msgSend)(node, NSSelectorFromString(@"nodeForRowAtIndexPath:"), path);
+        Ivar linkIvar = class_getInstanceVariable([cell class], "link");
+        id link = linkIvar ? object_getIvar(cell, linkIvar) : nil;
+        SEL selector = NSSelectorFromString(@"permalink");
+        if (![link respondsToSelector:selector]) continue;
+        id permalink = ((id (*)(id, SEL))objc_msgSend)(link, selector);
+        if ([permalink isKindOfClass:NSURL.class]) permalink = [permalink path];
+        if (![permalink isKindOfClass:NSString.class] || ![permalink hasPrefix:@"/"]) continue;
+        NSURLComponents *components = [NSURLComponents new];
+        components.scheme = @"apollo"; components.host = @"reddit.com"; components.path = permalink;
+        BOOL routed = ApolloRouteURLThroughAppInScene(components.URL, controller.viewIfLoaded.window.windowScene);
+        ApolloLog(@"[PaneReadPost] native route=%d", routed);
+        return;
+    }
+    ApolloLog(@"[PaneReadPost] no visible post model");
+}
+
+static void ApolloSimDebugWritePaneSnapshot(void) {
+    NSMutableArray *scenes = [NSMutableArray array];
+    for (UIScene *candidate in UIApplication.sharedApplication.connectedScenes) {
+        if (![candidate isKindOfClass:UIWindowScene.class]) continue;
+        UIWindowScene *scene = (id)candidate;
+        UITabBarController *tabs = (id)ApolloMainTabBarControllerForScene(scene);
+        if (![tabs isKindOfClass:UITabBarController.class] || tabs.viewIfLoaded.window.windowScene != scene) continue;
+        NSMutableArray *panes = [NSMutableArray array];
+        for (UIViewController *child in tabs.viewControllers) {
+            if ([child isKindOfClass:ApolloPaneSplitViewController.class])
+                [panes addObject:[(ApolloPaneSplitViewController *)child apollo_simStructuredSnapshot]];
+        }
+        // Session identifier is opaque system identity, never account identity.
+        [scenes addObject:@{@"scene": scene.session.persistentIdentifier, @"activation": @(scene.activationState),
+            @"bounds": NSStringFromCGRect(scene.coordinateSpace.bounds), @"selectedTab": @(tabs.selectedIndex), @"panes": panes}];
+    }
+    NSUInteger copies = 0;
+    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
+        const char *name = _dyld_get_image_name(i);
+        if (name && [@((const char *)name).lastPathComponent isEqualToString:@"ApolloReborn.dylib"]) copies++;
+    }
+    NSDictionary *snapshot = @{@"schema": @1, @"uptime": @(NSProcessInfo.processInfo.systemUptime),
+        @"runtime": UIDevice.currentDevice.systemVersion, @"idiom": @(UIDevice.currentDevice.userInterfaceIdiom),
+        @"loadedTweakCopies": @(copies), @"scenes": scenes};
+    NSData *data = [NSJSONSerialization dataWithJSONObject:snapshot options:NSJSONWritingPrettyPrinted error:nil];
+    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches/ApolloPaneSnapshot.json"];
+    [data writeToFile:path atomically:YES];
+    ApolloLog(@"[PaneSnapshot] wrote %lu scenes, tweak copies=%lu", (unsigned long)scenes.count, (unsigned long)copies);
+}
+
+static void ApolloSimDebugLogPaneStatus(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    ApolloLog(@"[PaneDisplayTest] status %@",
+              pane ? [pane apollo_simResolvedLayoutState] : @"no pane");
+}
+
+static void ApolloSimDebugLogLayoutPassState(BOOL reset) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    NSString *state = pane
+        ? [pane apollo_simLayoutPassStateReset:reset] : @"no pane pass=0";
+    [state writeToFile:@"/tmp/apollofix-layout-pass.txt"
+             atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    ApolloLog(@"[PaneLayoutPassTest] %@ %@", reset ? @"reset" : @"status", state);
+}
+
+static void ApolloSimDebugLogMasterSelectionStatus(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    ApolloLog(@"[PaneSelectionTest] %@",
+              pane ? [pane apollo_simMasterSelectionState] : @"no pane pass=0");
+}
+
+static void ApolloSimDebugClearMasterSelection(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    [pane apollo_clearDetailColumn];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloSimDebugLogMasterSelectionStatus();
+    });
+}
+
+static void ApolloSimDebugPushSelectionContinuation(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    if (!pane || pane.apollo_detailIsEmpty || !detail) {
+        ApolloLog(@"[PaneSelectionTest] continuation unavailable");
+        return;
+    }
+    UIViewController *continuation = [UIViewController new];
+    continuation.title = @"Task 14 Continuation";
+    continuation.view.backgroundColor = UIColor.systemBackgroundColor;
+    [detail pushViewController:continuation animated:NO];
+    ApolloLog(@"[PaneSelectionTest] continuation pushed depth=%lu %@",
+              (unsigned long)detail.viewControllers.count,
+              [pane apollo_simMasterSelectionState]);
+}
+
+static void ApolloSimDebugActivateShowList(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    BOOL activated = [pane apollo_simActivateShowPrimaryItem];
+    ApolloLog(@"[PaneDisplayTest] activate showlist=%d before={%@}", activated,
+              pane ? [pane apollo_simResolvedLayoutState] : @"no pane");
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloLog(@"[PaneDisplayTest] activate settled={%@}",
+                  pane ? [pane apollo_simResolvedLayoutState] : @"no pane");
+    });
+}
+
+// Deterministic serialization harness for Task 11. Holding the pane's test gate
+// emulates a live transition without relying on Xcode 27's broken HID events.
+// Multiple `transitionselect` commands exercise the real push hook and must
+// coalesce to the last identifier; `transitiongate off` releases the queue.
+static void ApolloSimDebugSetTransitionGate(NSString *operation) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    if (!pane) {
+        ApolloLog(@"[SimDebugTap][transition] gate unavailable");
+        return;
+    }
+    if ([operation isEqualToString:@"on"] || [operation isEqualToString:@"off"]) {
+        [pane apollo_simSetCrossColumnNavigationBlocked:[operation isEqualToString:@"on"]];
+    }
+    ApolloLog(@"[SimDebugTap][transition] %@", [pane apollo_simCrossColumnNavigationState]);
+}
+
+static void ApolloSimDebugSelectTransitionProbe(NSString *identifier) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UINavigationController *primary =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    if (!pane || !primary.topViewController) {
+        ApolloLog(@"[SimDebugTap][transition] selection unavailable");
+        return;
+    }
+    NSString *normalized = identifier.length > 0 ? identifier : @"unnamed";
+    ApolloPaneTransitionProbeViewController *probe =
+        [[ApolloPaneTransitionProbeViewController alloc] initWithIdentifier:normalized];
+    [primary pushViewController:probe animated:NO];
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    ApolloLog(@"[SimDebugTap][transition] selected=%@ immediatePrimary=%@ immediateDetail=%@ state={%@}",
+              normalized, primary.topViewController.title ?: @"(nil)",
+              detail.topViewController.title ?: @"(nil)",
+              [pane apollo_simCrossColumnNavigationState]);
+}
+
+static void ApolloSimDebugDumpTransitionState(void) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UINavigationController *primary =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnPrimary];
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    ApolloLog(@"[SimDebugTap][transition] primary=%@ depth=%lu detail=%@ depth=%lu state={%@}",
+              primary.topViewController.title ?: NSStringFromClass(primary.topViewController.class),
+              (unsigned long)primary.viewControllers.count,
+              detail.topViewController.title ?: NSStringFromClass(detail.topViewController.class),
+              (unsigned long)detail.viewControllers.count,
+              pane ? [pane apollo_simCrossColumnNavigationState] : @"no pane");
+}
+
+static UIGestureRecognizer *ApolloSimDebugNavigationGesture(UINavigationController *navigationController,
+                                                            const char *ivarName) {
+    if (!navigationController || !ivarName) return nil;
+    @try {
+        Ivar ivar = class_getInstanceVariable(navigationController.class, ivarName);
+        id value = ivar ? object_getIvar(navigationController, ivar) : nil;
+        return [value isKindOfClass:[UIGestureRecognizer class]] ? value : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+// Drive Apollo's real detail edge recognizer while two newer primary selections
+// arrive. This is intentionally slower than an ordinary swipe so both pushes
+// deterministically land after the recognizer begins and before it terminates.
+static BOOL sApolloSimTransitionRaceRunning = NO;
+
+static void ApolloSimDebugRunInteractiveTransitionRace(BOOL shouldCommit) {
+    ApolloPaneSplitViewController *pane = ApolloSimDebugSelectedPane();
+    UINavigationController *detail =
+        [pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary];
+    if (!pane || !detail.viewIfLoaded.window ||
+        detail.transitionCoordinator || sApolloSimTransitionRaceRunning) {
+        ApolloLog(@"[SimDebugTap][transitionrace] detail unavailable");
+        return;
+    }
+    // Always isolate the gesture from real Reddit content. The synthetic Back
+    // pops only this inert probe even when the live detail stack was already deep.
+    ApolloPaneTransitionProbeViewController *child =
+        [[ApolloPaneTransitionProbeViewController alloc] initWithIdentifier:@"Gesture Child"];
+    [detail pushViewController:child animated:NO];
+    if (detail.viewControllers.count < 2) {
+        ApolloLog(@"[SimDebugTap][transitionrace] could not prepare detail child");
+        return;
+    }
+
+    // The nonanimated fixture push still delivers appearance/gesture policy on
+    // the next run-loop turn. Begin the touch after that real settlement, as a
+    // user does after a completed push; a touch begun on a disabled recognizer
+    // cannot be recovered by enabling it midway through the same sequence.
+    sApolloSimTransitionRaceRunning = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIGestureRecognizer *apolloEdge =
+            ApolloSimDebugNavigationGesture(detail, "leftScreenEdgePanGestureRecognizer");
+        if (!apolloEdge) {
+            ApolloLog(@"[SimDebugTap][transitionrace] ERROR Apollo edge recognizer unavailable");
+            sApolloSimTransitionRaceRunning = NO;
+            return;
+        }
+
+        UIWindow *window = detail.view.window;
+        // Stay clear of the divider's intentional 44-point hit region at mid-height.
+        CGPoint localStart = CGPointMake(8.0, CGRectGetHeight(detail.view.bounds) * 0.25);
+        CGPoint localEnd = CGPointMake(shouldCommit ? detail.view.bounds.size.width * 0.72 : 42.0,
+                                       localStart.y);
+        CGPoint start = [detail.view convertPoint:localStart toView:window];
+        CGPoint end = [detail.view convertPoint:localEnd toView:window];
+        UIView *hitView = [window hitTest:start withEvent:nil];
+        if (!hitView || ![hitView isDescendantOfView:detail.view]) {
+            ApolloLog(@"[SimDebugTap][transitionrace] invalid edge hit view=%@", hitView);
+            sApolloSimTransitionRaceRunning = NO;
+            return;
+        }
+
+        UITouch *touch = [UITouch new];
+        [touch setWindow:window];
+        [touch setView:hitView];
+        [touch setTapCount:1];
+        if ([touch respondsToSelector:@selector(_setIsFirstTouchForView:)]) {
+            [touch _setIsFirstTouchForView:YES];
+        }
+        [touch _setLocationInWindow:start resetPrevious:YES];
+        [touch setPhase:UITouchPhaseBegan];
+        sApolloSimTransitionRaceRunning = YES;
+        ApolloSimDebugSendTouch(touch);
+
+        const int steps = 24;
+        __block BOOL raceVerified = NO;
+        for (int index = 1; index <= steps; index++) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                (int64_t)(index * 0.022 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    CGFloat progress;
+                    if (!shouldCommit && index <= 4) {
+                        // Cross pan-recognition hysteresis promptly, then crawl to
+                        // the cancellation endpoint so terminal velocity stays low.
+                        progress = (28.0 - localStart.x) * ((CGFloat)index / 4.0) /
+                            (localEnd.x - localStart.x);
+                    } else if (!shouldCommit) {
+                        CGFloat tail = (CGFloat)(index - 4) / (CGFloat)(steps - 4);
+                        progress = ((28.0 - localStart.x) +
+                            (localEnd.x - 28.0) * tail) / (localEnd.x - localStart.x);
+                    } else {
+                        progress = (CGFloat)index / (CGFloat)steps;
+                    }
+                    CGPoint point = CGPointMake(start.x + (end.x - start.x) * progress,
+                                                start.y + (end.y - start.y) * progress);
+                    [touch _setLocationInWindow:point resetPrevious:NO];
+                    [touch setPhase:UITouchPhaseMoved];
+                    ApolloSimDebugSendTouch(touch);
+                });
+        }
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.10 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            id<UIViewControllerTransitionCoordinator> coordinator = detail.transitionCoordinator;
+            UIGestureRecognizerState state = apolloEdge.state;
+            raceVerified = (state == UIGestureRecognizerStateBegan ||
+                            state == UIGestureRecognizerStateChanged) && coordinator.isInteractive;
+            ApolloLog(@"[SimDebugTap][transitionrace] verified=%d edgeState=%ld interactive=%d",
+                      raceVerified, (long)state, coordinator.isInteractive);
+            if (!raceVerified) {
+                ApolloLog(@"[SimDebugTap][transitionrace] ERROR interactive transition did not begin");
+            }
+        });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.14 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            if (raceVerified) ApolloSimDebugSelectTransitionProbe(@"Race A");
+        });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.24 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            if (raceVerified) ApolloSimDebugSelectTransitionProbe(@"Race B");
+        });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.56 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            [touch _setLocationInWindow:end resetPrevious:NO];
+            [touch setPhase:shouldCommit ? UITouchPhaseEnded : UITouchPhaseCancelled];
+            ApolloSimDebugSendTouch(touch);
+            ApolloLog(@"[SimDebugTap][transitionrace] gesture ended commit=%d verified=%d start=(%.0f,%.0f) end=(%.0f,%.0f)",
+                      shouldCommit, raceVerified, start.x, start.y, end.x, end.y);
+        });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.2 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            ApolloSimDebugDumpTransitionState();
+            sApolloSimTransitionRaceRunning = NO;
+        });
+    });
+}
+
+static NSString *ApolloSimDebugNavigationItemSummary(UINavigationItem *item) {
+    NSMutableArray<NSString *> *leftItems = [NSMutableArray array];
+    for (UIBarButtonItem *barItem in item.leftBarButtonItems ?: @[]) {
+        [leftItems addObject:barItem.title ?: barItem.accessibilityIdentifier ?: @"(untitled)"];
+    }
+    return [NSString stringWithFormat:@"hides=%d supplements=%d left=[%@] back=%@",
+        item.hidesBackButton, item.leftItemsSupplementBackButton,
+        [leftItems componentsJoinedByString:@", "],
+        item.backBarButtonItem.title ?: item.backButtonTitle ?: @"(nil)"];
+}
+
+// "navitemdump [primary|detail]" records the top controller's complete leading-
+// item policy so real Apollo destinations can be compared before and after a
+// pane route without relying on pixels alone.
+static void ApolloSimDebugDumpNavigationItem(NSString *columnName) {
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(columnName);
+    UIViewController *top = navigationController.topViewController;
+    ApolloLog(@"[SimDebugTap] navitem column=%@ top=%@ depth=%lu %@",
+              columnName ?: @"primary", NSStringFromClass(top.class),
+              (unsigned long)navigationController.viewControllers.count,
+              ApolloSimDebugNavigationItemSummary(top.navigationItem));
+}
+
+// "navitemprobe [primary|detail]" pushes an intentionally unknown controller
+// whose native policy hides Back and owns a leading item. The pane router must
+// leave every property and object identity untouched, then the original stack
+// is restored without creating Forward history.
+static void ApolloSimDebugProbeUnknownNavigationItem(NSString *columnName) {
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(columnName);
+    if (!navigationController) {
+        ApolloLog(@"[SimDebugTap] navitemprobe unavailable column=%@", columnName);
+        return;
+    }
+    NSArray<UIViewController *> *originalStack = navigationController.viewControllers;
+    UIViewController *probe = [UIViewController new];
+    probe.title = @"Unknown Navigation Item Probe";
+    UIBarButtonItem *nativeItem = [[UIBarButtonItem alloc]
+        initWithTitle:@"Native" style:UIBarButtonItemStylePlain target:nil action:nil];
+    probe.navigationItem.leftBarButtonItems = @[ nativeItem ];
+    probe.navigationItem.hidesBackButton = YES;
+    probe.navigationItem.leftItemsSupplementBackButton = NO;
+
+    [navigationController pushViewController:probe animated:NO];
+    BOOL retained = navigationController.topViewController == probe &&
+        probe.navigationItem.hidesBackButton &&
+        !probe.navigationItem.leftItemsSupplementBackButton &&
+        probe.navigationItem.leftBarButtonItems.count == 1 &&
+        probe.navigationItem.leftBarButtonItems.firstObject == nativeItem;
+    ApolloLog(@"[SimDebugTap] navitemprobe column=%@ retained=%d %@",
+              columnName ?: @"primary", retained,
+              ApolloSimDebugNavigationItemSummary(probe.navigationItem));
+    [navigationController setViewControllers:originalStack animated:NO];
+}
+
+// "navitemmutate [primary|detail]" simulates a destination changing its own
+// leading items and Back policy while compact. Expansion must remove only the
+// pane-owned item and preserve these native changes.
+static void ApolloSimDebugMutateNavigationItem(NSString *columnName) {
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(columnName);
+    UIViewController *top = navigationController.topViewController;
+    if (!top) {
+        ApolloLog(@"[SimDebugTap] navitemmutate unavailable column=%@", columnName);
+        return;
+    }
+    UIBarButtonItem *dynamicItem = [[UIBarButtonItem alloc]
+        initWithTitle:@"Dynamic" style:UIBarButtonItemStylePlain target:nil action:nil];
+    dynamicItem.accessibilityIdentifier = @"ApolloPaneTask10Dynamic";
+    NSArray<UIBarButtonItem *> *existing = top.navigationItem.leftBarButtonItems ?: @[];
+    top.navigationItem.leftBarButtonItems = [existing arrayByAddingObject:dynamicItem];
+    top.navigationItem.leftItemsSupplementBackButton = YES;
+    top.navigationItem.hidesBackButton = YES;
+    ApolloLog(@"[SimDebugTap] navitemmutate column=%@ top=%@ %@",
+              columnName ?: @"detail", NSStringFromClass(top.class),
+              ApolloSimDebugNavigationItemSummary(top.navigationItem));
+}
+
+// "navback [primary|detail]" command: perform the navigation-controller pop that UIKit's Back
+// button would request. Xcode 27 currently drops idb HID events, so this keeps
+// compact ownership tests deterministic while still exercising the real stack
+// mutation and navigation-controller delegate callbacks.
+static void ApolloSimDebugPerformNavigationBack(NSString *columnName) {
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(columnName);
+    if (navigationController.viewControllers.count <= 1) {
+        ApolloLog(@"[SimDebugTap] navback unavailable column=%@ depth=%lu",
+                  columnName ?: @"primary",
+                  (unsigned long)navigationController.viewControllers.count);
+        return;
+    }
+
+    UIViewController *popped = [navigationController popViewControllerAnimated:NO];
+    ApolloLog(@"[SimDebugTap] navback column=%@ popped=%@ remaining=%@ depth=%lu",
+              columnName ?: @"primary",
+              NSStringFromClass(popped.class),
+              NSStringFromClass(navigationController.topViewController.class),
+              (unsigned long)navigationController.viewControllers.count);
+}
+
+// "navforward [primary|detail]" pairs with navback and invokes ApolloNavigationController's
+// real forward-history action. Re-pushing through that path also passes through
+// the pane router, which is the behavior the compact ownership test needs to
+// verify before expansion.
+static void ApolloSimDebugPerformNavigationForward(NSString *columnName) {
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(columnName);
+    SEL forward = NSSelectorFromString(@"goForward");
+    if (![navigationController respondsToSelector:forward]) {
+        ApolloLog(@"[SimDebugTap] navforward unavailable column=%@ nav=%@",
+                  columnName ?: @"primary", NSStringFromClass(navigationController.class));
+        return;
+    }
+
+    NSUInteger beforeDepth = navigationController.viewControllers.count;
+    NSString *beforeTop = NSStringFromClass(navigationController.topViewController.class);
+    ((void (*)(id, SEL))objc_msgSend)(navigationController, forward);
+    ApolloLog(@"[SimDebugTap] navforward column=%@ nav=%@ depth=%lu->%lu top=%@->%@",
+              columnName ?: @"primary",
+              NSStringFromClass(navigationController.class),
+              (unsigned long)beforeDepth,
+              (unsigned long)navigationController.viewControllers.count,
+              beforeTop, NSStringFromClass(navigationController.topViewController.class));
+}
+
+// "navset primary same|root": deterministically exercise Apollo's
+// setViewControllers: entry point. `same` proves a no-op replacement retains a
+// valid detail branch; `root` proves removing its owner clears detail and
+// forward history. Simulator-only because production never needs a synthetic
+// stack mutation.
+static void ApolloSimDebugSetNavigationStack(NSString *arguments) {
+    NSArray<NSString *> *parts = [arguments componentsSeparatedByCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    for (NSString *part in parts) {
+        if (part.length > 0) [tokens addObject:part];
+    }
+    NSString *column = tokens.count > 0 ? tokens[0] : @"primary";
+    NSString *operation = tokens.count > 1 ? tokens[1] : @"same";
+    UINavigationController *navigationController =
+        ApolloSimDebugSelectedNavigationController(column);
+    NSArray<UIViewController *> *before = navigationController.viewControllers;
+    NSArray<UIViewController *> *replacement = before;
+    if ([operation isEqualToString:@"root"] && before.firstObject) {
+        replacement = @[ before.firstObject ];
+    }
+    [navigationController setViewControllers:replacement animated:NO];
+    ApolloLog(@"[SimDebugTap] navset column=%@ operation=%@ depth=%lu->%lu",
+              column, operation, (unsigned long)before.count,
+              (unsigned long)navigationController.viewControllers.count);
+}
+
+// Exercise the same unambiguous active-account notification that production
+// observes, without changing or exposing any saved credentials.
+static void ApolloSimDebugPostAccountContextChange(void) {
+    [NSNotificationCenter.defaultCenter
+        postNotificationName:@"com.christianselig.RedditCurrentAccountChanged"
+                      object:nil];
+    ApolloLog(@"[SimDebugTap] posted active-account context change");
+}
+
+// "tab N" command: select a tab through UITabBarController's public API. This
+// avoids Xcode 27's broken HID path while still exercising Apollo's ordinary
+// tab-child attachment and pane lifecycle for the smoke loop.
+static void ApolloSimDebugSelectTab(NSInteger index) {
+    UIViewController *controller = ApolloMainTabBarController();
+    if (![controller isKindOfClass:[UITabBarController class]]) {
+        ApolloLog(@"[SimDebugTap] tab selection unavailable");
+        return;
+    }
+    UITabBarController *tabBarController = (UITabBarController *)controller;
+    if (index < 0 || index >= (NSInteger)tabBarController.viewControllers.count) {
+        ApolloLog(@"[SimDebugTap] tab selection out of range: %ld", (long)index);
+        return;
+    }
+    tabBarController.selectedIndex = index;
+    ApolloLog(@"[SimDebugTap] selected tab %ld child=%@", (long)index,
+              NSStringFromClass(tabBarController.selectedViewController.class));
+}
+
+// "routeurl <url>": invoke Apollo's real AppDelegate URL entry point. The
+// simulator's URL-scheme dispatcher is unreliable for this re-signed app on
+// Xcode 27, so this provides deterministic warm-entry coverage without
+// replacing any production routing logic.
+static void ApolloSimDebugRouteURL(NSString *rawURL) {
+    NSURL *url = [NSURL URLWithString:rawURL];
+    BOOL routed = url && ApolloRouteURLThroughApp(url);
+    ApolloLog(@"[SimDebugTap] routeurl routed=%d scheme=%@",
+              routed, url.scheme.lowercaseString ?: @"invalid");
+}
+
+// "useractivity <url>": invoke Apollo's real SceneDelegate Handoff/universal-
+// link entry point with a browsing-web activity.
+static void ApolloSimDebugContinueUserActivity(NSString *rawURL) {
+    NSURL *url = [NSURL URLWithString:rawURL];
+    NSString *scheme = url.scheme.lowercaseString;
+    if (!([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"])) {
+        ApolloLog(@"[SimDebugTap] useractivity rejected non-web scheme=%@",
+                  scheme ?: @"invalid");
+        return;
+    }
+    NSUserActivity *activity = [[NSUserActivity alloc]
+        initWithActivityType:NSUserActivityTypeBrowsingWeb];
+    @try {
+        activity.webpageURL = url;
+    } @catch (NSException *exception) {
+        ApolloLog(@"[SimDebugTap] useractivity could not set webpage URL: %@", exception);
+        return;
+    }
+
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        id delegate = scene.delegate;
+        SEL selector = @selector(scene:continueUserActivity:);
+        if (![delegate respondsToSelector:selector]) continue;
+        ((void (*)(id, SEL, id, id))objc_msgSend)(delegate, selector, scene, activity);
+        ApolloLog(@"[SimDebugTap] useractivity delivered=%d scheme=%@",
+                  url != nil, url.scheme.lowercaseString ?: @"invalid");
+        return;
+    }
+    ApolloLog(@"[SimDebugTap] useractivity: no scene delegate accepted the activity");
+}
+
+// "shortcut Search" and "shortcut FavoriteSubreddit <name>": drive the two
+// exact UIApplicationShortcutItem types Apollo 1.15.11 accepts through the
+// real SceneDelegate callback. Search is especially useful here because the
+// native implementation indexes viewControllers[3] and casts it to a nav.
+static void ApolloSimDebugPerformShortcut(NSString *arguments) {
+    NSArray<NSString *> *parts = [arguments componentsSeparatedByCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    for (NSString *part in parts) if (part.length > 0) [tokens addObject:part];
+    NSString *type = tokens.firstObject;
+    if (!([type isEqualToString:@"Search"] || [type isEqualToString:@"FavoriteSubreddit"])) {
+        ApolloLog(@"[SimDebugTap] shortcut rejected unknown type=%@", type ?: @"missing");
+        return;
+    }
+
+    NSDictionary *userInfo = nil;
+    if ([type isEqualToString:@"FavoriteSubreddit"]) {
+        if (tokens.count < 2) {
+            ApolloLog(@"[SimDebugTap] FavoriteSubreddit shortcut requires a subreddit");
+            return;
+        }
+        userInfo = @{ @"subreddit": tokens[1] };
+    }
+    UIApplicationShortcutItem *item = [[UIApplicationShortcutItem alloc]
+        initWithType:type localizedTitle:type localizedSubtitle:nil icon:nil userInfo:userInfo];
+
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        id delegate = scene.delegate;
+        SEL selector = @selector(windowScene:performActionForShortcutItem:completionHandler:);
+        if (![delegate respondsToSelector:selector]) continue;
+        void (^completion)(BOOL) = ^(BOOL succeeded) {
+            ApolloLog(@"[SimDebugTap] shortcut type=%@ completed=%d", type, succeeded);
+        };
+        ((void (*)(id, SEL, id, id, id))objc_msgSend)(delegate, selector, scene, item, completion);
+        return;
+    }
+    ApolloLog(@"[SimDebugTap] shortcut: no scene delegate accepted the item");
+}
+
+void ApolloSubredditListDiagRearm(void);
 
 #pragma mark - gifmem probe (issue #1000)
 
@@ -632,17 +1808,358 @@ static void ApolloSimInstallLowPowerModeOverride(void) {
     ApolloLog(@"[SimDebugTap] lpm override installed on %@", NSStringFromClass(cls));
 }
 
+static BOOL ApolloSimDebugHandleIntegratedMainCommand(NSString *contents) {
+    if ([contents hasPrefix:@"listdiag"]) {
+        ApolloSubredditListDiagRearm();
+        return YES;
+    }
+    if ([contents hasPrefix:@"gifmode "]) {
+        NSInteger mode = [[contents substringFromIndex:8] integerValue];
+        [NSUserDefaults.standardUserDefaults setInteger:mode forKey:UDKeyAutoplayInlineGIFs];
+        ApolloLog(@"[SimDebugTap] gifmode -> %ld", (long)mode);
+        return YES;
+    }
+    if ([contents hasPrefix:@"scrollto "]) {
+        ApolloSimDebugScrollTo([[contents substringFromIndex:9] doubleValue]);
+        return YES;
+    }
+    if ([contents hasPrefix:@"lpm "]) {
+        NSString *payload = [[contents substringFromIndex:4]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        sApolloSimForceLowPowerMode = [payload isEqualToString:@"on"];
+        [NSNotificationCenter.defaultCenter
+            postNotificationName:NSProcessInfoPowerStateDidChangeNotification
+                          object:NSProcessInfo.processInfo];
+        ApolloLog(@"[SimDebugTap] lpm -> %d (isLowPowerModeEnabled=%d)",
+                  sApolloSimForceLowPowerMode, NSProcessInfo.processInfo.isLowPowerModeEnabled);
+        return YES;
+    }
+    if ([contents hasPrefix:@"devvitjs "]) {
+        extern void ApolloDevvitDebugEvaluateJS(NSString *js);
+        ApolloDevvitDebugEvaluateJS([contents substringFromIndex:9]);
+        return YES;
+    }
+    if ([contents hasPrefix:@"devvitsweep"]) {
+        extern void ApolloDevvitDebugSweep(void);
+        ApolloDevvitDebugSweep();
+        return YES;
+    }
+    if ([contents hasPrefix:@"rotate "]) {
+        NSString *direction = [[contents substringFromIndex:7]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        if (@available(iOS 16.0, *)) {
+            UIInterfaceOrientationMask mask = [direction isEqualToString:@"landscape"]
+                ? UIInterfaceOrientationMaskLandscapeRight
+                : UIInterfaceOrientationMaskPortrait;
+            UIWindowScene *scene = ApolloAllWindows().firstObject.windowScene;
+            if (!scene) {
+                ApolloLog(@"[SimDebugTap] rotate: no window scene");
+                return YES;
+            }
+            UIWindowSceneGeometryPreferencesIOS *preferences =
+                [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
+            [scene requestGeometryUpdateWithPreferences:preferences errorHandler:^(NSError *error) {
+                ApolloLog(@"[SimDebugTap] rotate error: %@", error.localizedDescription);
+            }];
+            ApolloLog(@"[SimDebugTap] rotate -> %@", direction);
+        } else {
+            ApolloLog(@"[SimDebugTap] rotate: needs iOS 16+");
+        }
+        return YES;
+    }
+    if ([contents hasPrefix:@"gifmem "]) {
+        NSString *argument = [[contents substringFromIndex:7]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        ApolloSimDebugMeasureGIFMemory(argument);
+        return YES;
+    }
+    if ([contents hasPrefix:@"linkpreview "]) {
+        NSString *urlString = [[contents substringFromIndex:12]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        NSURL *previewURL = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
+        if (!previewURL) {
+            ApolloLog(@"[SimDebugTap] malformed linkpreview url: %@", urlString);
+            return YES;
+        }
+        [ApolloLinkPreviewFetcher requestPreviewForURL:previewURL
+                                            completion:^(ApolloLinkPreview *preview) {
+            ApolloLog(@"[SimDebugTap] linkpreview %@\n  site=%@\n  title=%@\n  desc=%@\n  image=%@",
+                      urlString, preview.siteName ?: @"(nil)", preview.title ?: @"(nil)",
+                      preview.desc ?: @"(nil)", preview.imageURL.absoluteString ?: @"(nil)");
+        }];
+        return YES;
+    }
+    if ([contents hasPrefix:@"translate "]) {
+        NSString *spec = [[contents substringFromIndex:10]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        ApolloTranslationDebugProbe(spec);
+        return YES;
+    }
+    if ([contents hasPrefix:@"floattab "]) {
+        NSString *payload = [[contents substringFromIndex:9]
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        ApolloFloatingTabsDebugCommand(payload);
+        return YES;
+    }
+    return NO;
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+    // Capture at notification receipt, before queueing main-thread delivery.
+    // Reading the shared command file later can execute a newer swipe twice.
+    NSString *contents = [NSString stringWithContentsOfFile:kApolloSimTapFile
+                                                   encoding:NSUTF8StringEncoding error:nil];
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSString *contents = [NSString stringWithContentsOfFile:kApolloSimTapFile
-                                                       encoding:NSUTF8StringEncoding error:nil];
+        if (ApolloSimDebugHandleIntegratedMainCommand(contents)) return;
         if ([contents hasPrefix:@"insetbottom "]) {
             ApolloSimDebugForceBottomInset([[contents substringFromIndex:12] doubleValue]);
             return;
         }
         if ([contents hasPrefix:@"dump"]) {
             ApolloSimDebugDumpHierarchy();
+            return;
+        }
+        // "compact on|off": force every split view controller under the tab bar
+        // to a compact horizontal size class, which is what makes a
+        // UISplitViewController collapse. Slide Over and small Stage Manager
+        // windows are the real-world trigger and neither can be driven from a
+        // script, so this is the only way to exercise the iPad pane layout's
+        // collapse/expand path in the simulator loop.
+        if ([contents hasPrefix:@"compact "]) {
+            BOOL on = [[contents substringFromIndex:8] hasPrefix:@"on"];
+            ApolloSimDebugForceCompactSplitColumns(on);
+            return;
+        }
+        if ([contents isEqualToString:@"panereadpost"]) { ApolloSimDebugOpenVisiblePost(); return; }
+        if ([contents isEqualToString:@"panenewwindow"]) { ApolloPaneOpenDetailInNewWindow(ApolloSimDebugSelectedPane()); return; }
+        if ([contents hasPrefix:@"panefind "]) {
+            UIViewController *detail = [ApolloSimDebugSelectedPane() apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController;
+            ApolloLog(@"[PaneFindTest] %@", ApolloPaneSimFind(detail, [contents substringFromIndex:9])); return;
+        }
+        if ([contents hasPrefix:@"sidebar "]) {
+            if (@available(iOS 18.0, *)) ApolloSimDebugSelectedPane().tabBarController.sidebar.hidden = [[contents substringFromIndex:8] isEqualToString:@"hide"];
+            return;
+        }
+        if ([contents isEqualToString:@"panesnapshot"]) { ApolloSimDebugWritePaneSnapshot(); return; }
+        if ([contents hasPrefix:@"panemode "]) {
+            NSString *mode = [[contents substringFromIndex:9]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugSetPaneMode(mode);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"panestatus"]) {
+            ApolloSimDebugLogPaneStatus();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"layoutreset"]) {
+            ApolloSimDebugLogLayoutPassState(YES);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"layoutstatus"]) {
+            ApolloSimDebugLogLayoutPassState(NO);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"reflowreset"]) {
+            ApolloSimDebugStartReflowProbe();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"reflowstatus"]) {
+            ApolloSimDebugWriteReflowStatus();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"readablestatus"]) {
+            ApolloSimDebugWriteReadableStatus();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"widthstatus"]) {
+            ApolloSimDebugWritePaneWidthStatus();
+            return;
+        }
+        if ([contents hasPrefix:@"widthset "]) {
+            ApolloSimDebugSetPaneWidth([[contents substringFromIndex:9] doubleValue]);
+            return;
+        }
+        if ([contents hasPrefix:@"widthadjust "]) {
+            NSString *operation = [[contents substringFromIndex:12]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugAdjustPaneDivider(operation);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"themestatus"]) {
+            ApolloSimDebugWritePaneThemeStatus();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"themenotify"]) {
+            ApolloSimDebugPostThemeNotification();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"selectionstatus"]) {
+            ApolloSimDebugLogMasterSelectionStatus();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"selectionclear"]) {
+            ApolloSimDebugClearMasterSelection();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"selectioncontinue"]) {
+            ApolloSimDebugPushSelectionContinuation();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"paneactivate showlist"]) {
+            ApolloSimDebugActivateShowList();
+            return;
+        }
+        if ([contents hasPrefix:@"navdump"]) {
+            ApolloSimDebugDumpNavigationControllers();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"loadstatus"]) {
+            ApolloSimDebugDumpPaneLoadStatus();
+            return;
+        }
+        if ([contents hasPrefix:@"autohidescan"]) {
+            ApolloSimDebugRunAutoHideScan(contents);
+            return;
+        }
+        if ([contents hasPrefix:@"autohidepolicy "]) {
+            ApolloSimDebugSetAutoHidePolicy(contents);
+            return;
+        }
+        if ([contents hasPrefix:@"transitiongate "]) {
+            NSString *operation = [[contents substringFromIndex:@"transitiongate ".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugSetTransitionGate(operation);
+            return;
+        }
+        if ([contents hasPrefix:@"transitionselect "]) {
+            NSString *identifier = [[contents substringFromIndex:@"transitionselect ".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugSelectTransitionProbe(identifier);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"transitionstatus"]) {
+            ApolloSimDebugDumpTransitionState();
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"transitionstale"]) {
+            [ApolloPaneSplitViewController apollo_simRunDeallocatedSourceProbe];
+            return;
+        }
+        if ([contents hasPrefix:@"transitionrace "]) {
+            NSString *outcome = [[contents substringFromIndex:@"transitionrace ".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            if (![@[ @"commit", @"cancel" ] containsObject:outcome]) {
+                ApolloLog(@"[SimDebugTap][transitionrace] expected commit|cancel, got %@", outcome);
+                return;
+            }
+            ApolloSimDebugRunInteractiveTransitionRace([outcome isEqualToString:@"commit"]);
+            return;
+        }
+        if ([contents hasPrefix:@"navitemdump"]) {
+            NSString *columnName = [[contents substringFromIndex:@"navitemdump".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugDumpNavigationItem(columnName.length ? columnName : @"primary");
+            return;
+        }
+        if ([contents hasPrefix:@"navitemprobe"]) {
+            NSString *columnName = [[contents substringFromIndex:@"navitemprobe".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugProbeUnknownNavigationItem(columnName.length ? columnName : @"detail");
+            return;
+        }
+        if ([contents hasPrefix:@"navitemmutate"]) {
+            NSString *columnName = [[contents substringFromIndex:@"navitemmutate".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugMutateNavigationItem(columnName.length ? columnName : @"detail");
+            return;
+        }
+        if ([contents hasPrefix:@"navback"]) {
+            NSString *columnName = [[contents substringFromIndex:@"navback".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugPerformNavigationBack(columnName.length ? columnName : @"primary");
+            return;
+        }
+        if ([contents hasPrefix:@"navforward"]) {
+            NSString *columnName = [[contents substringFromIndex:@"navforward".length]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugPerformNavigationForward(columnName.length ? columnName : @"primary");
+            return;
+        }
+        if ([contents hasPrefix:@"navset "]) {
+            NSString *arguments = [[contents substringFromIndex:7]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugSetNavigationStack(arguments);
+            return;
+        }
+        if ([[contents stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                isEqualToString:@"accountchange"]) {
+            ApolloSimDebugPostAccountContextChange();
+            return;
+        }
+        if ([contents hasPrefix:@"tab "]) {
+            ApolloSimDebugSelectTab([[contents substringFromIndex:4] integerValue]);
+            return;
+        }
+        if ([contents hasPrefix:@"routeurl "]) {
+            NSString *rawURL = [[contents substringFromIndex:9]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugRouteURL(rawURL);
+            return;
+        }
+        if ([contents hasPrefix:@"useractivity "]) {
+            NSString *rawURL = [[contents substringFromIndex:13]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugContinueUserActivity(rawURL);
+            return;
+        }
+        if ([contents hasPrefix:@"shortcut "]) {
+            NSString *arguments = [[contents substringFromIndex:9]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugPerformShortcut(arguments);
+            return;
+        }
+        if ([contents hasPrefix:@"accessibilityescape"]) {
+            ApolloSimDebugPerformAccessibilityEscape();
+            return;
+        }
+        if ([contents hasPrefix:@"visibleprobe "]) {
+            NSString *operation = [[contents substringFromIndex:13]
+                stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            ApolloSimDebugVisiblePresenterProbe(operation);
             return;
         }
         // "headerdump" command: log every visible scroll view's topEdgeEffect
@@ -677,29 +2194,6 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
             [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyScrollEdgeEffectStyle];
             [[NSNotificationCenter defaultCenter] postNotificationName:ApolloScrollEdgeEffectStyleChangedNotification object:nil];
             ApolloLog(@"[SimDebugTap] headerstyle -> %ld", (long)mode);
-            return;
-        }
-        // "gifmode N" command: set Autoplay Inline GIFs (1 Never, 2 WiFi Only,
-        // 3 Always, 4 Tap to Play) through the same defaults write the settings
-        // picker makes, so the KVO reload + live refresh of on-screen GIFs run.
-        if ([contents hasPrefix:@"gifmode "]) {
-            NSInteger mode = [[contents substringFromIndex:8] integerValue];
-            [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyAutoplayInlineGIFs];
-            ApolloLog(@"[SimDebugTap] gifmode -> %ld", (long)mode);
-            return;
-        }
-        if ([contents hasPrefix:@"scrollto "]) {
-            ApolloSimDebugScrollTo([[contents substringFromIndex:9] doubleValue]);
-            return;
-        }
-        if ([contents hasPrefix:@"lpm "]) {
-            NSString *payload = [[contents substringFromIndex:4] stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            sApolloSimForceLowPowerMode = [payload isEqualToString:@"on"];
-            [[NSNotificationCenter defaultCenter] postNotificationName:NSProcessInfoPowerStateDidChangeNotification
-                                                                object:NSProcessInfo.processInfo];
-            ApolloLog(@"[SimDebugTap] lpm -> %d (isLowPowerModeEnabled=%d)",
-                      sApolloSimForceLowPowerMode, NSProcessInfo.processInfo.isLowPowerModeEnabled);
             return;
         }
         if ([contents hasPrefix:@"crash "]) {
@@ -764,57 +2258,10 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
                 });
             return;
         }
-        // "linkpreview <url>" command: run the real link-preview fetch against
-        // an arbitrary page and log what came back. Exercising the fetcher
-        // needs no Reddit account, so metadata extraction — charset handling
-        // above all (issue #945) — can be verified against live foreign-language
-        // pages on a signed-out simulator.
-        // "gifmem <path-or-url>" command: measure what the gallery viewer's
-        // animated-GIF path actually costs in resident memory. Decodes with the
-        // shipping loader entry point, hangs the result on a real on-screen
-        // UIImageView, and samples phys_footprint across the first animation
-        // loops — the point where issue #1000's jetsam happened.
-        if ([contents hasPrefix:@"gifmem "]) {
-            NSString *arg = [[contents substringFromIndex:7] stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            ApolloSimDebugMeasureGIFMemory(arg);
-            return;
-        }
-        if ([contents hasPrefix:@"linkpreview "]) {
-            NSString *urlString = [[contents substringFromIndex:12] stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            NSURL *previewURL = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
-            if (!previewURL) { ApolloLog(@"[SimDebugTap] malformed linkpreview url: %@", urlString); return; }
-            [ApolloLinkPreviewFetcher requestPreviewForURL:previewURL completion:^(ApolloLinkPreview *preview) {
-                ApolloLog(@"[SimDebugTap] linkpreview %@\n  site=%@\n  title=%@\n  desc=%@\n  image=%@",
-                          urlString, preview.siteName ?: @"(nil)", preview.title ?: @"(nil)",
-                          preview.desc ?: @"(nil)", preview.imageURL.absoluteString ?: @"(nil)");
-            }];
-            return;
-        }
-        // "translate <google|libre|auto> <text>" command: run text through the
-        // real translation provider pipeline and log the result. Needs no
-        // Reddit session — isolates provider/network failures (issue #995).
-        if ([contents hasPrefix:@"translate "]) {
-            NSString *spec = [[contents substringFromIndex:10] stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            ApolloTranslationDebugProbe(spec);
-            return;
-        }
         if ([contents hasPrefix:@"text "]) {
             NSString *payload = [[contents substringFromIndex:5] stringByTrimmingCharactersInSet:
                 NSCharacterSet.newlineCharacterSet];
             ApolloSimDebugTypeText(payload);
-            return;
-        }
-        // "floattab <keep|state|tap N|close N|release N cx cy vx vy>": drive
-        // the Floating Post Tabs feature headlessly (create a tab from the
-        // topmost comments view, tap/close bubbles, run the real end-of-drag
-        // pipeline for magnet/tuck/dock testing, dump tab state to the log).
-        if ([contents hasPrefix:@"floattab "]) {
-            NSString *payload = [[contents substringFromIndex:9] stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            ApolloFloatingTabsDebugCommand(payload);
             return;
         }
         BOOL isSwipe = [contents hasPrefix:@"swipe "];

--- a/tests/ipad/geometry-policy.c
+++ b/tests/ipad/geometry-policy.c
@@ -1,0 +1,25 @@
+#include "../../src/ipad/ApolloPaneGeometryPolicy.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    assert(ApolloPanePreferredWidth(NAN) == 420);
+    assert(ApolloPanePreferredWidth(INFINITY) == 420);
+    assert(ApolloPanePreferredWidth(-1) == 340);
+    assert(ApolloPanePreferredWidth(1000) == 480);
+    for (double preferred = 340; preferred <= 480; preferred += 1) {
+        for (double available = 760; available <= 1800; available += 1) {
+            double resolved = ApolloPaneResolvedWidth(preferred, available);
+            assert(isfinite(resolved) && resolved >= 340 && resolved <= preferred);
+            assert(available - resolved >= 420);
+            assert(ApolloPaneResolvedWidth(resolved, available) == resolved);
+            // Narrowing and widening must never overwrite the user's intent.
+            assert(ApolloPaneResolvedWidth(preferred, 1800) == preferred);
+        }
+    }
+    assert(ApolloPanePrimaryIsPhysicallyLeft(true, false));
+    assert(!ApolloPanePrimaryIsPhysicallyLeft(true, true));
+    assert(!ApolloPanePrimaryIsPhysicallyLeft(false, false));
+    assert(ApolloPanePrimaryIsPhysicallyLeft(false, true));
+    puts("Pane geometry: 146,781 width/capacity combinations and RTL cases passed");
+}

--- a/tests/ipad/transition-observer.m
+++ b/tests/ipad/transition-observer.m
@@ -1,0 +1,40 @@
+#import "../../src/ipad/ApolloPaneTransitionObserver.h"
+#import <assert.h>
+static void pump(NSTimeInterval seconds) {
+    NSDate *end = [NSDate dateWithTimeIntervalSinceNow:seconds];
+    while (end.timeIntervalSinceNow > 0)
+        [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+}
+int main(void) { @autoreleasepool {
+    NSObject *owner = [NSObject new];
+    __block NSUInteger calls = 0;
+    __block BOOL ready = NO;
+    [ApolloPaneTransitionObserver observeOwner:owner key:@"route" timeout:1
+        ready:^BOOL(id object) { return ready; }
+        completion:^(id object, BOOL expired) { assert(!expired); calls++; }];
+    pump(.07); assert(calls == 0);
+    ready = YES; pump(.12); assert(calls == 1);
+    assert([ApolloPaneTransitionObserver activeCountForOwner:owner] == 0);
+    pump(.12); assert(calls == 1); // no duplicate settlement
+    [ApolloPaneTransitionObserver observeOwner:owner key:@"route" timeout:1
+        ready:^BOOL(id object) { return YES; }
+        completion:^(id object, BOOL expired) { assert(false); }];
+    [ApolloPaneTransitionObserver observeOwner:owner key:@"route" timeout:.1
+        ready:^BOOL(id object) { return NO; }
+        completion:^(id object, BOOL expired) { assert(expired); calls++; }];
+    pump(.2); assert(calls == 2); // only newest route reaches its deadline
+    [ApolloPaneTransitionObserver observeOwner:owner key:@"cancel" timeout:.1
+        ready:^BOOL(id object) { return NO; }
+        completion:^(id object, BOOL expired) { assert(false); }];
+    [ApolloPaneTransitionObserver cancelOwner:owner];
+    pump(.2); assert([ApolloPaneTransitionObserver activeCountForOwner:owner] == 0);
+    __weak NSObject *weakOwner;
+    @autoreleasepool {
+        NSObject *temporary = [NSObject new]; weakOwner = temporary;
+        [ApolloPaneTransitionObserver observeOwner:temporary key:@"lifetime" timeout:.1
+            ready:^BOOL(id object) { return NO; }
+            completion:^(id object, BOOL expired) { assert(false); }];
+    }
+    assert(!weakOwner); pump(.2);
+    puts("Pane settlement: readiness, replacement, deadline, cancellation, deallocation passed");
+} }


### PR DESCRIPTION
Separate simulator-only probes, repeatable policy tests, and the existing engineering/audit records from shipping UI review. This completes the lossless split of #886.

Stacked on `je/ipad-05-workspace`; review this PR against that base.

Validation: The complete Git tree at this tip is byte-for-byte identical to #886 at b6305b4559c16aa59dbe90506fccef17aadada14. Geometry policy (146,781 cases) and transition-observer lifecycle tests pass; simulator build passes.

Part of the replacement stack for #886. The complete runtime stack remains experimental and opt-in. These draft slices are for review in order; do not ship an intermediate navigation implementation. Foldable/resizable-phone support is a separate follow-up. Existing device-only and performance validation gaps remain recorded in the validation PR.

Review order: #1053 → #1054 → #1055 → #1056 → #1057 → #1058; resizable iPhone support: #1059.
