### PR TITLE
Resizable iPhone: opt-in list/detail panes on expanded iOS 27 windows

### DIFF
--- a/docs/resizable-iphone-panes.md
+++ b/docs/resizable-iphone-panes.md
@@ -1,0 +1,67 @@
+# Resizable iPhone panes (experimental)
+
+Settings → Apollo Reborn → Interface → **Multi-Column Layout (Experimental)**.
+The setting defaults to OFF and applies after quitting and reopening Apollo.
+It is available on iPadOS 18+ and iOS 27 phones. Turning it off restores Apollo's
+ordinary navigation hierarchy on the next launch.
+
+With the setting on, UIKit adapts the same split controllers using the inherited
+size classes and actual available space. Narrow windows collapse to one browsing
+path; expanded windows show the list and detail side by side. No phone model,
+fold posture, orientation, screen dimensions, or idiom spoofing chooses columns.
+The device/OS check is only a capability gate for installing the experiment.
+The phone simulator override has been removed; tests use the persisted setting.
+
+## Prepare and run
+
+Apollo is a closed-source legacy executable. Compiling the injected tweak with a
+new SDK does not change the main app's linked SDK. iOS 27's resizing opt-in must
+also be present on that main executable. The following explicit options patch
+its linked-SDK declaration to at least 27.0, preserve its deployment target and
+platform, retain its existing scene/launch-screen configuration, declare all four
+orientations and indirect input, and remove full-screen requirements. This is a
+compatibility patch, not a recompilation of Apollo or a hardware-support guarantee.
+The options include the existing Liquid Glass preparation; normal release variants
+keep their current behavior.
+
+```sh
+WORK_DIR=./.sim/pane-redesign SIM_NAME=Resizable-iPhone \
+    scripts/run-in-sim.sh --resizable
+# Then enable Multi-Column Layout in Interface and quit/reopen Apollo.
+# Enter resize mode using Device Hub's toolbar.
+
+./patch.sh ./Apollo-base.ipa --resizable --fix-safari-extension \
+    -o /tmp/Apollo-resizable-base.ipa
+# Inject the freshly built tweak using build-ipa.sh before signing/sideloading.
+```
+
+Run `--resizable` on subsequent simulator invocations too. Omitting it prepares
+an ordinary shell again. Do not hold a `devicectl appResize start` session while
+trying to enter resize mode from Device Hub: the external session owns that mode.
+Wait for Apollo to finish launching before starting resize mode.
+
+## Verification
+
+- The iPad review stack through #1058 has exactly the same Git tree as #886 at
+  `b6305b4559c16aa59dbe90506fccef17aadada14`. #1053 is simulator tooling;
+  #1054–#1057 are runtime slices; #1058 contains probes, tests, and audit records.
+- Each runtime slice compiles and links for the simulator. The final pure geometry
+  policy and transition-observer lifecycle tests pass.
+- On an iOS 27 iPhone 17 Pro simulator (phone idiom throughout), setting OFF
+  installed zero panes; setting ON installed five; narrow launch collapsed.
+- Actual resize-session transitions through 402×874, 820×900, 600×800, 1161×680,
+  402×874, and 1161×680 collapsed/expanded the selected Settings pane correctly.
+  The list/detail stack depths returned to 1/1 on expansion and 2/1 on collapse,
+  preserving the open detail. Every settled sample had zero pending navigation
+  and zero transition watchdogs. Screenshots confirmed adjacent panes at 1161×680.
+- App-shell tests verify platform/deployment-target/code preservation, repeatable
+  patching, no SDK downgrades, and rejection of malformed binaries before writes.
+
+These are simulator navigation/resize checks, not frame-rate measurements or
+foldable hardware validation. Signed-in feed/media behavior, real-device iPhone
+Mirroring, and actual foldable hardware still need validation. Existing iPad
+release gates are recorded in `plans/003-ipad-pane-implementation-results.md`.
+
+Apple documents resizable iPhone apps that retain their phone idiom and recommends
+size classes and surrounding view dimensions for layout:
+[Modernize your UIKit app (WWDC26)](https://developer.apple.com/videos/play/wwdc2026/278/).

--- a/docs/resizable-iphone-panes.md
+++ b/docs/resizable-iphone-panes.md
@@ -5,11 +5,14 @@ The setting defaults to OFF and applies after quitting and reopening Apollo.
 It is available on iPadOS 18+ and iOS 27 phones. Turning it off restores Apollo's
 ordinary navigation hierarchy on the next launch.
 
-With the setting on, UIKit adapts the same split controllers using the inherited
-size classes and actual available space. Narrow windows collapse to one browsing
-path; expanded windows show the list and detail side by side. No phone model,
-fold posture, orientation, screen dimensions, or idiom spoofing chooses columns.
-The device/OS check is only a capability gate for installing the experiment.
+With the setting on, UIKit adapts the same split controllers to the available
+space. On iOS 27 phones, the pane container sets its own horizontal size class
+from its view dimensions: at least 760 × 500 points allows list and detail side
+by side; smaller windows collapse to one browsing path. This avoids a stale
+compact trait when Device Hub starts resizing from a narrow window and keeps
+ordinary landscape phones collapsed. iPad retains its existing size-class policy.
+No phone model, fold posture, orientation, screen dimensions, or global idiom
+spoofing chooses columns. The device/OS check gates the supported platforms.
 The phone simulator override has been removed; tests use the persisted setting.
 
 ## Prepare and run
@@ -49,11 +52,17 @@ Wait for Apollo to finish launching before starting resize mode.
   policy and transition-observer lifecycle tests pass.
 - On an iOS 27 iPhone 17 Pro simulator (phone idiom throughout), setting OFF
   installed zero panes; setting ON installed five; narrow launch collapsed.
-- Actual resize-session transitions through 402×874, 820×900, 600×800, 1161×680,
-  402×874, and 1161×680 collapsed/expanded the selected Settings pane correctly.
-  The list/detail stack depths returned to 1/1 on expansion and 2/1 on collapse,
-  preserving the open detail. Every settled sample had zero pending navigation
-  and zero transition watchdogs. Screenshots confirmed adjacent panes at 1161×680.
+- Starting resize mode with Device Hub's toolbar while narrow, then widening to
+  1161×680, shows adjacent Settings index/detail panes. The phone-specific size
+  policy also passes narrow 402×874, landscape 874×402, and the 760×500 boundary.
+  Repeated shrinking/expansion preserves the open Interface page; settled stack
+  depths are 2/1 when collapsed and 1/1 when expanded, with no pending navigation
+  or transition watchdogs. The beta can constrain requested portrait geometry:
+  requests for 759×900 and 820×900 yielded actual app bounds of 675×900 in this
+  Device Hub session. Assertions use the app's actual bounds, not requested size.
+- A compact Settings deep link now reveals a replacement detail after popping
+  the primary root. The actual Multi-Column Layout switch presents its restart
+  prompt and pending-state subtitle correctly.
 - App-shell tests verify platform/deployment-target/code preservation, repeatable
   patching, no SDK downgrades, and rejection of malformed binaries before writes.
 

--- a/patch.sh
+++ b/patch.sh
@@ -40,6 +40,7 @@ INPUT_IPA=""
 OUTPUT_IPA="Apollo-Patched.ipa"
 REMOVE_CODE_SIGNATURE="false"
 LIQUID_GLASS="false"
+RESIZABLE_APP="false"
 LIQUID_GLASS_ICONS_ONLY="false"
 URL_SCHEMES=""
 OUTPUT_IPA_PATH=""
@@ -53,6 +54,7 @@ print_usage() {
     echo "  -o, --output <file>           Output IPA filename (default: Apollo-Patched.ipa)"
     echo "  --remove-code-signature       Remove code signature from the binary"
     echo "  --liquid-glass                Apply Liquid Glass patch for iOS 26"
+    echo "  --resizable                  Experimental iOS 27 resizing (includes Liquid Glass)"
     echo "  --fix-safari-extension        Install the manual + legacy Safari extensions"
     echo "  --fix-openin-extension        Repair the bundled 'Open in Apollo' share-sheet action"
     echo "                                (needs the openin-extension dylib; run 'make package' first)"
@@ -78,6 +80,11 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         --remove-code-signature)
             REMOVE_CODE_SIGNATURE="true"
+            shift
+            ;;
+        --resizable)
+            RESIZABLE_APP="true"
+            LIQUID_GLASS="true"
             shift
             ;;
         --liquid-glass)
@@ -188,6 +195,12 @@ if [ "${LIQUID_GLASS}" == "true" ]; then
     fi
     patch_liquid_glass_binary_in_app "$APP_BUNDLE"
     patch_liquid_glass_assets_in_app "$APP_BUNDLE"
+fi
+
+# Opt into the iOS 27 app-shell contract after the existing Glass preparation.
+# This is explicit: ordinary release variants keep their existing linked SDK.
+if [ "$RESIZABLE_APP" == "true" ]; then
+    python3 "$SCRIPT_DIR/scripts/prepare-resizable-app.py" "$APP_BUNDLE"
 fi
 
 # 2a-icons. Liquid Glass icons-only (assets only, no SDK bump)

--- a/scripts/capture-ipad-pane-state.py
+++ b/scripts/capture-ipad-pane-state.py
@@ -8,6 +8,7 @@ parser.add_argument('--work-dir', default='.sim/pane-redesign')
 parser.add_argument('--bundle-id', default='com.christianselig.Apollo')
 parser.add_argument('--base-ipa', default='Apollo-base.ipa')
 parser.add_argument('--label', default='capture')
+parser.add_argument('--display', help='simctl display name or ID (e.g. resizable for iOS 27 resize sessions)')
 args = parser.parse_args()
 root = pathlib.Path(__file__).resolve().parent.parent
 out = root / args.work_dir / 'evidence' / (time.strftime('%Y%m%d-%H%M%S-') + pathlib.Path(args.label).name)
@@ -28,7 +29,8 @@ try:
     data = json.loads(snapshot.read_text())
     if data['loadedTweakCopies'] != 1: raise SystemExit('Expected exactly one loaded tweak.')
     shutil.copy2(snapshot, out / 'panes.json')
-    subprocess.run(['xcrun','simctl','io',args.device,'screenshot',str(out / 'screen.png')],check=True)
+    display = ['--display=' + args.display] if args.display else []
+    subprocess.run(['xcrun','simctl','io',args.device,'screenshot',*display,str(out / 'screen.png')],check=True)
     dylib = root / args.work_dir / 'ApolloReborn.dylib'
     metadata = {'commit':run('git','-C',str(root),'rev-parse','HEAD'),
         'dirtyPaths':run('git','-C',str(root),'status','--short').splitlines(),

--- a/scripts/prepare-resizable-app.py
+++ b/scripts/prepare-resizable-app.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Opt the legacy Apollo shell into iOS 27 resizing before re-signing it.
+
+This changes the main executable's linked-SDK declaration, not its deployment
+target or machine code. It is an experimental compatibility patch, not a rebuild
+of Apollo against SDK 27. The tweak still checks runtime API availability.
+"""
+import argparse
+import pathlib
+import plistlib
+import struct
+
+
+def prepare(app):
+    plist = app / 'Info.plist'
+    info = plistlib.loads(plist.read_bytes())
+    executable = info['CFBundleExecutable']
+    if pathlib.Path(executable).name != executable:
+        raise ValueError('Expected a bundle-local executable name')
+    if not info.get('UIApplicationSceneManifest'):
+        raise ValueError('Resizable Apollo requires its existing scene manifest')
+    if not (info.get('UILaunchStoryboardName') or 'UILaunchScreen' in info):
+        raise ValueError('Resizable Apollo requires a launch-screen configuration')
+    binary = app / executable
+    data = bytearray(binary.read_bytes())
+    if len(data) < 32 or struct.unpack_from('<I', data)[0] != 0xFEEDFACF:
+        raise ValueError('Expected Apollo’s thin 64-bit Mach-O executable')
+    count, size = struct.unpack_from('<II', data, 16)
+    end = 32 + size
+    if end > len(data):
+        raise ValueError('Truncated load commands')
+    offset, build = 32, None
+    for _ in range(count):
+        if offset + 8 > end:
+            raise ValueError('Truncated load command')
+        command, length = struct.unpack_from('<II', data, offset)
+        if length < 8 or offset + length > end:
+            raise ValueError('Invalid load command length')
+        if command == 0x32:  # LC_BUILD_VERSION
+            if length < 24 or build is not None:
+                raise ValueError('Invalid or duplicate build-version command')
+            platform, minimum, sdk = struct.unpack_from('<III', data, offset + 8)
+            if platform not in (2, 7):  # iOS / iOS Simulator
+                raise ValueError('Expected an iOS or iOS Simulator executable')
+            struct.pack_into('<I', data, offset + 16, max(sdk, 27 << 16))
+            build = (platform, minimum)
+        offset += length
+    if build is None or offset != end:
+        raise ValueError('Missing build version or inconsistent load-command size')
+    orientations = ['UIInterfaceOrientationPortrait', 'UIInterfaceOrientationPortraitUpsideDown',
+                    'UIInterfaceOrientationLandscapeLeft', 'UIInterfaceOrientationLandscapeRight']
+    info['UISupportedInterfaceOrientations'] = orientations
+    info['UISupportedInterfaceOrientations~ipad'] = orientations
+    info.pop('UIRequiresFullScreen', None)
+    info.pop('UIRequiresFullScreen~ipad', None)
+    info['UIApplicationSupportsIndirectInputEvents'] = True
+    # Validate everything before either write. Signing is the caller's final step.
+    encoded = plistlib.dumps(info)
+    binary.write_bytes(data)
+    plist.write_bytes(encoded)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('app', type=pathlib.Path)
+    prepare(parser.parse_args().app)

--- a/scripts/run-in-sim.sh
+++ b/scripts/run-in-sim.sh
@@ -38,6 +38,9 @@
 #     Contents/SharedFrameworks/. Xcode.app's bundle can't be patched (write-protected),
 #     so for now drive taps manually in Device Hub until idb_companion ships a fix.
 #
+# --resizable: opt the cached Apollo shell into iOS 27 continuous resizing.
+# Enable Multi-Column Layout in Settings separately; this flag never sets it.
+#
 # Env overrides:
 #   BASE_IPA (./apollo-base.ipa)  BUNDLE_ID (com.christianselig.Apollo)
 #   SIM_NAME (Apollo-Sim)  SIM_DEVICE_TYPE (iPhone 16 Pro)  SIM_RUNTIME (newest iOS)
@@ -60,6 +63,7 @@ APP_GROUP_SUITE="group.com.christianselig.apollo"   # tweak hardcodes this regar
 BACKUP_ZIP="${BACKUP_ZIP:-}"
 APPEARANCE="${APPEARANCE:-}"
 GLASS="${GLASS:-0}"
+RESIZABLE_APP=0
 
 DO_BUILD=1; FRESH_APP=0; DO_LOGS=0; DO_DRIVE=0
 while [[ $# -gt 0 ]]; do
@@ -70,6 +74,7 @@ while [[ $# -gt 0 ]]; do
         --drive)      DO_DRIVE=1 ;;
         --dark)       APPEARANCE=dark ;;
         --light)      APPEARANCE=light ;;
+        --resizable)  RESIZABLE_APP=1 ;;
         --glass)      GLASS=1 ;;
         --no-glass)   GLASS=0 ;;
         --backup)     BACKUP_ZIP="${2:-}"; shift ;;
@@ -79,6 +84,8 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+# SDK 27 also opts into modern chrome; use the canonical Glass preparation.
+if [[ "$RESIZABLE_APP" == 1 ]]; then GLASS=1; fi
 # Convention: if no backup was named, auto-load ./.sim/backup.zip when present, so
 # agents/devs can drop a settings backup there once and have it preloaded on every
 # run. (./.sim/ is gitignored; a backup zip carries live credentials — never commit
@@ -174,6 +181,9 @@ fi
 # >= 19.0 (iOS 26) means glass is on.
 if [[ -f "$APP_DIR/Apollo" ]]; then
     CACHED_SDK_MAJOR="$(vtool -show-build "$APP_DIR/Apollo" 2>/dev/null | awk '/sdk/{split($2,v,"."); print v[1]}')"
+    CACHED_RESIZABLE=0
+    [[ -n "$CACHED_SDK_MAJOR" && "$CACHED_SDK_MAJOR" -ge 27 ]] && CACHED_RESIZABLE=1
+    if [[ "$CACHED_RESIZABLE" != "$RESIZABLE_APP" ]]; then FRESH_APP=1; fi
     CACHED_GLASS=0; [[ -n "$CACHED_SDK_MAJOR" && "$CACHED_SDK_MAJOR" -ge 19 ]] && CACHED_GLASS=1
     if [[ "$CACHED_GLASS" != "$GLASS" ]]; then
         log "Requested glass=$GLASS differs from prepared glass=$CACHED_GLASS — re-preparing app"
@@ -258,6 +268,11 @@ if [[ "$FRESH_APP" == 1 || ! -d "$APP_DIR" ]]; then
             [[ -e "$ext" ]] && codesign -f -s - "$ext" >/dev/null 2>&1
         done
     fi
+    codesign -f -s - "$APP_DIR" >/dev/null 2>&1
+fi
+
+if [[ "$RESIZABLE_APP" == 1 ]]; then
+    python3 scripts/prepare-resizable-app.py "$APP_DIR"
     codesign -f -s - "$APP_DIR" >/dev/null 2>&1
 fi
 

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -1052,7 +1052,11 @@ static void ApolloSimDebugWritePaneSnapshot(void) {
     }
     NSDictionary *snapshot = @{@"schema": @1, @"uptime": @(NSProcessInfo.processInfo.systemUptime),
         @"runtime": UIDevice.currentDevice.systemVersion, @"idiom": @(UIDevice.currentDevice.userInterfaceIdiom),
-        @"loadedTweakCopies": @(copies), @"scenes": scenes};
+        @"loadedTweakCopies": @(copies), @"scenes": scenes,
+        @"paneSupported": @(ApolloPaneLayoutSupported()),
+        @"paneEnabled": @(ApolloPaneLayoutEnabled()),
+        @"paneActive": @(ApolloPaneLayoutActive()),
+        @"paneDesired": @([NSUserDefaults.standardUserDefaults boolForKey:UDKeyIPadPaneLayout])};
     NSData *data = [NSJSONSerialization dataWithJSONObject:snapshot options:NSJSONWritingPrettyPrinted error:nil];
     NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches/ApolloPaneSnapshot.json"];
     [data writeToFile:path atomically:YES];
@@ -1942,6 +1946,13 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
             return;
         }
         if ([contents isEqualToString:@"panesnapshot"]) { ApolloSimDebugWritePaneSnapshot(); return; }
+        // Persist the same preference as the UI, without changing this process's
+        // install decision. Tests must relaunch, exactly as users do.
+        if ([contents isEqualToString:@"panesetting on"] || [contents isEqualToString:@"panesetting off"]) {
+            [NSUserDefaults.standardUserDefaults setBool:[contents hasSuffix:@" on"] forKey:UDKeyIPadPaneLayout];
+            ApolloSimDebugWritePaneSnapshot();
+            return;
+        }
         if ([contents hasPrefix:@"panemode "]) {
             NSString *mode = [[contents substringFromIndex:9]
                 stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];

--- a/src/ipad/ApolloPaneGeometryPolicy.h
+++ b/src/ipad/ApolloPaneGeometryPolicy.h
@@ -17,3 +17,9 @@ static inline double ApolloPaneResolvedWidth(double preferred, double available)
 static inline bool ApolloPanePrimaryIsPhysicallyLeft(bool leading, bool rightToLeft) {
     return leading != rightToLeft;
 }
+
+// Two useful columns need 340pt for the list and 420pt for detail. The height
+// floor keeps a conventional landscape phone in its single browsing path.
+static inline bool ApolloPanePhoneHasRoomForColumns(double width, double height) {
+    return isfinite(width) && isfinite(height) && width >= 760.0 && height >= 500.0;
+}

--- a/src/ipad/ApolloPaneInstall.xm
+++ b/src/ipad/ApolloPaneInstall.xm
@@ -397,7 +397,7 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
     // Had this required `tabs`, the alternative would have been rebuilding
     // Apollo's tab model by hand, which is a far larger and more fragile change.
     //
-    // ApolloPaneLayoutSupported() gates production installation to iPadOS 18+
+    // ApolloPaneLayoutSupported() gates installation to iPadOS 18+ / iOS 27 phones
     // so the experiment always gets this navigation model. Keep the fallback
     // for defensive safety if this function is ever invoked directly.
     if (@available(iOS 18.0, *)) {
@@ -511,12 +511,11 @@ static BOOL ApolloPaneInstallIntoTabBarController(UITabBarController *tabBarCont
 %end
 
 %ctor {
-    // iPhone never loads any of this: the idiom check comes first, so the hook
-    // is not even installed on a device that can never run the pane layout.
+    // Install only on supported OS/device combinations and explicit opt-in.
     if (!ApolloPaneLayoutSupported()) return;
 
     if (!ApolloPaneLayoutEnabled()) {
-        ApolloLog(@"[PaneInstall] iPad detected, pane layout off (UDKeyIPadPaneLayout); hook not installed");
+        ApolloLog(@"[PaneInstall] supported device, pane layout off (UDKeyIPadPaneLayout); hook not installed");
         return;
     }
 

--- a/src/ipad/ApolloPaneLayout.h
+++ b/src/ipad/ApolloPaneLayout.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, ApolloPaneColumn) {
 //
 // Three distinct questions, deliberately not collapsed into one:
 //
-//   Supported  — could this device ever run the pane layout? (iPad, immutable)
+//   Supported  — could this OS/device run panes? (iPadOS 18+ / iOS 27 phone)
 //   Enabled    — did the user ask for it for THIS process? (read at %ctor)
 //   Active     — did installation actually succeed and is it live right now?
 //
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, ApolloPaneColumn) {
 // the default would make every consumer disagree with reality for the rest of
 // the session.
 
-// iPad idiom. Cached — the idiom cannot change for the life of the process.
+// OS/device capability, cached. Never use this to decide the number of columns.
 BOOL ApolloPaneLayoutSupported(void);
 
 // Supported AND the user default was on when %ctor read it. This is the
@@ -76,7 +76,7 @@ UISplitViewController *_Nullable ApolloPanePrimarySplitForNavigationItem(UINavig
 // MARK: - Hierarchy
 
 // The pane split controller enclosing `viewController`, or nil when it is not
-// inside one (always nil on iPhone, and whenever the layout is off). Walks up
+// inside one (nil whenever the layout is off). Walks up
 // through parents, so it works from a deeply nested child.
 UISplitViewController *_Nullable ApolloPaneSplitControllerFor(UIViewController *_Nullable viewController);
 

--- a/src/ipad/ApolloPaneLayout.m
+++ b/src/ipad/ApolloPaneLayout.m
@@ -45,29 +45,20 @@ BOOL ApolloPaneLayoutSupported(void) {
     static BOOL supported = NO;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        // The experiment's navigation model depends on UIKit's system tab
-        // sidebar. Earlier iPadOS releases can render the split columns, but
-        // retain Apollo's tab bar alongside them, which does not match the UI
-        // promised by the setting and has not received the same test coverage.
-        // Keep the production opt-in honest and conservative: iPadOS 18 is the
-        // first supported release, while Apollo's normal layout remains
-        // untouched everywhere else.
-        if (@available(iOS 18.0, *)) {
-            supported = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad);
-#if APOLLO_SIM_BUILD
-            // Development only: exercise an actual phone idiom at cold narrow
-            // launch and through resizing. Never spoof UIDevice or global traits.
-            supported |= [NSProcessInfo.processInfo.environment[@"APOLLO_SIM_ADAPTIVE_PHONE"] boolValue];
-#endif
+        // Capability is fixed for this process; layout is not. iOS 27 supports
+        // resizable phone scenes without changing their phone idiom. UIKit's
+        // inherited size classes drive the split's collapse/expand lifecycle.
+        if (@available(iOS 27.0, *)) {
+            UIUserInterfaceIdiom idiom = UIDevice.currentDevice.userInterfaceIdiom;
+            supported = idiom == UIUserInterfaceIdiomPad || idiom == UIUserInterfaceIdiomPhone;
+        } else if (@available(iOS 18.0, *)) {
+            supported = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad;
         }
     });
     return supported;
 }
 
 BOOL ApolloPaneLayoutEnabled(void) {
-#if APOLLO_SIM_BUILD
-    if ([NSProcessInfo.processInfo.environment[@"APOLLO_SIM_ADAPTIVE_PHONE"] boolValue]) return ApolloPaneLayoutSupported();
-#endif
     return ApolloPaneLayoutSupported() && sIPadPaneLayout;
 }
 

--- a/src/ipad/ApolloPaneSidebar.m
+++ b/src/ipad/ApolloPaneSidebar.m
@@ -151,7 +151,8 @@ API_AVAILABLE(ios(18.0))
             identifier:nil handler:^(__unused UIAction *action) { ApolloPaneOpenCommunity(weakTabs, name, YES); }];
         UIAction *remove = [UIAction actionWithTitle:@"Unpin community" image:[UIImage systemImageNamed:@"pin.slash"]
             identifier:nil handler:^(__unused UIAction *action) { ApolloPaneChangePin(weakTabs, name, YES); }];
-        button.menu = [UIMenu menuWithTitle:@"" children:@[window, remove]];
+        button.menu = [UIMenu menuWithTitle:@"" children:UIApplication.sharedApplication.supportsMultipleScenes
+            ? @[window, remove] : @[remove]];
         [button addInteraction:[[UIDragInteraction alloc] initWithDelegate:self]];
         [self.stack addArrangedSubview:button];
     }];
@@ -239,7 +240,7 @@ void ApolloPaneSidebarFirstAppearance(UITabBarController *tabs) {
         // A single initial preference, never a resize/selection enforcement.
         // UIKit owns subsequent visibility and the user's collapse choice.
         if (CGRectGetWidth(tabs.view.bounds) >= 1100.0 &&
-            tabs.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) tabs.sidebar.hidden = NO;
+            tabs.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) tabs.sidebar.hidden = NO;
     }
 }
 
@@ -262,7 +263,8 @@ static NSURL *ApolloPanePostURL(UIViewController *controller) {
 }
 BOOL ApolloPaneCanOpenDetailInNewWindow(UISplitViewController *split) {
     ApolloPaneSplitViewController *pane = (id)split;
-    return ApolloPanePostURL([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController) != nil;
+    return UIApplication.sharedApplication.supportsMultipleScenes &&
+        ApolloPanePostURL([pane apollo_navigationControllerForColumn:ApolloPaneColumnSecondary].topViewController) != nil;
 }
 void ApolloPaneOpenDetailInNewWindow(UISplitViewController *split) {
     ApolloPaneSplitViewController *pane = (id)split;

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -2348,8 +2348,36 @@ apply:
     [self apollo_scheduleResolvedGeometryRefresh];
 }
 
+- (void)apollo_updateResizablePhoneColumnsForSize:(CGSize)size {
+    if (@available(iOS 27.0, *)) {
+        // The legacy tab host can keep a compact inherited trait when Device
+        // Hub starts resizing from a phone-sized window. Derive the split's
+        // local presentation from its own space, never UIScreen.main bounds or
+        // orientation. This changes only our container's trait; UIDevice and
+        // the scene retain their real idiom and platform traits.
+        if (UIDevice.currentDevice.userInterfaceIdiom != UIUserInterfaceIdiomPhone ||
+            size.width <= 0.0 || size.height <= 0.0) return;
+        UIUserInterfaceSizeClass sizeClass = ApolloPanePhoneHasRoomForColumns(size.width, size.height)
+            ? UIUserInterfaceSizeClassRegular : UIUserInterfaceSizeClassCompact;
+        // Reading a trait override that has not been set raises an assertion.
+        if ([self.traitOverrides containsTrait:UITraitHorizontalSizeClass.class] &&
+            self.traitOverrides.horizontalSizeClass == sizeClass) return;
+        self.traitOverrides.horizontalSizeClass = sizeClass;
+        ApolloLog(@"[PanePhone] tab %ld size=%.0fx%.0f columns=%d",
+                  (long)self.apollo_tabIndex, size.width, size.height,
+                  sizeClass == UIUserInterfaceSizeClassRegular ? 2 : 1);
+    }
+}
+
+- (void)viewIsAppearing:(BOOL)animated {
+    [super viewIsAppearing:animated];
+    // Offscreen tabs are updated when attached; their views stay lazy.
+    [self apollo_updateResizablePhoneColumnsForSize:self.view.bounds.size];
+}
+
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [self apollo_updateResizablePhoneColumnsForSize:size];
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     __weak ApolloPaneSplitViewController *weakSelf = self;
     [coordinator animateAlongsideTransition:nil

--- a/src/ipad/ApolloPaneSplitViewController.m
+++ b/src/ipad/ApolloPaneSplitViewController.m
@@ -2039,8 +2039,15 @@ static NSArray<UIBarButtonItem *> *ApolloPaneBarItemsByRemovingIdentity(
 }
 
 - (void)apollo_revealDetailAfterPrimarySelectionIfNeeded {
-    if (self.isCollapsed ||
-        self.displayMode != UISplitViewControllerDisplayModeOneOverSecondary) return;
+    if (self.isCollapsed) {
+        // A deep link can pop the primary to its root before replacing an
+        // existing detail branch. Updating that branch does not re-present
+        // UIKit's compact column bridge. Explicitly reveal the destination,
+        // including when the old detail still owns its compact chrome state.
+        if (!self.apollo_detailIsEmpty) [self showColumn:UISplitViewControllerColumnSecondary];
+        return;
+    }
+    if (self.displayMode != UISplitViewControllerDisplayModeOneOverSecondary) return;
     ApolloLog(@"[PaneDisplay] tab %ld dismissing primary overlay after detail selection",
               (long)self.apollo_tabIndex);
     [self hideColumn:UISplitViewControllerColumnPrimary];

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -92,7 +92,7 @@ static NSString *ApolloIPadPaneLayoutSettingDetail(void) {
             ? @"Will turn on after Apollo quits and reopens. The current single-column layout remains active until then."
             : @"Will turn off after Apollo quits and reopens. The current multi-column layout remains active until then.";
     }
-    return @"Experimental on iPadOS 18 or newer. Puts your tabs in a sidebar and opens comments beside the post list instead of on top of it. Apollo restarts to apply changes.";
+    return @"Experimental on iPadOS 18+ and iOS 27. Opens detail beside the list when space allows, and returns to one column in narrow windows. Apollo restarts to apply changes.";
 }
 
 @interface ApolloFeedShortcutsPreviewState : NSObject
@@ -1874,11 +1874,8 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf lgTitleGapCenteringSwitchToggled:sender]; }];
     titleGapCentering.visible = ^BOOL { return IsLiquidGlass(); };
 
-    // Experimental multi-column iPad layout. Hidden outright on iPhone rather
-    // than shown-disabled: it is a whole-app restructure with nothing to
-    // preview or explain on a device that will never run it.
-    // Installation happens at scene connect, so the handler confirms and
-    // restarts instead of pretending the change is live.
+    // Keep the opt-in visible even in a narrow supported phone window. The
+    // saved choice is read on launch; resizing then adapts the same hierarchy.
     ApolloSettingsRow *iPadPaneLayout =
         [ApolloSettingsRow customRowWithID:@"gen.iPadPaneLayout"
                                       cell:^UITableViewCell *(__unused UITableView *tableView, __unused ApolloSettingsRow *row) {

--- a/tests/ipad/geometry-policy.c
+++ b/tests/ipad/geometry-policy.c
@@ -3,6 +3,15 @@
 #include <stdio.h>
 
 int main(void) {
+    assert(!ApolloPanePhoneHasRoomForColumns(402, 874));
+    assert(!ApolloPanePhoneHasRoomForColumns(874, 402));
+    assert(!ApolloPanePhoneHasRoomForColumns(759, 900));
+    assert(!ApolloPanePhoneHasRoomForColumns(900, 499));
+    assert(ApolloPanePhoneHasRoomForColumns(760, 500));
+    assert(ApolloPanePhoneHasRoomForColumns(820, 900));
+    assert(ApolloPanePhoneHasRoomForColumns(1161, 680));
+    assert(!ApolloPanePhoneHasRoomForColumns(NAN, 900));
+    assert(!ApolloPanePhoneHasRoomForColumns(900, INFINITY));
     assert(ApolloPanePreferredWidth(NAN) == 420);
     assert(ApolloPanePreferredWidth(INFINITY) == 420);
     assert(ApolloPanePreferredWidth(-1) == 340);

--- a/tests/ipad/resizable-shell.py
+++ b/tests/ipad/resizable-shell.py
@@ -1,0 +1,67 @@
+"""Verify the compatibility patch preserves binary layout and rejects bad input."""
+import importlib.util
+import pathlib
+import plistlib
+import struct
+import tempfile
+import unittest
+import sys
+
+sys.dont_write_bytecode = True
+
+root = pathlib.Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('prepare', root / 'scripts/prepare-resizable-app.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class ResizableShellTests(unittest.TestCase):
+    def fixture(self, directory, platform=7, sdk=19):
+        app = pathlib.Path(directory)
+        data = struct.pack('<8I', 0xFEEDFACF, 0x100000C, 0, 2, 1, 24, 0, 0)
+        data += struct.pack('<6I', 0x32, 24, platform, 15 << 16, sdk << 16, 0)
+        data += b'unchanged machine code'
+        (app / 'Apollo').write_bytes(data)
+        (app / 'Info.plist').write_bytes(plistlib.dumps({
+            'CFBundleExecutable': 'Apollo', 'UIApplicationSceneManifest': {'UISceneConfigurations': {}},
+            'UILaunchStoryboardName': 'LaunchScreen', 'MinimumOSVersion': '14.0',
+            'UIRequiresFullScreen': True, 'UIRequiresFullScreen~ipad': True,
+        }))
+        return app, data
+
+    def test_device_and_simulator_preserve_platform_minimum_and_code(self):
+        for platform in (2, 7):
+            with self.subTest(platform=platform), tempfile.TemporaryDirectory() as directory:
+                app, before = self.fixture(directory, platform)
+                module.prepare(app)
+                after = (app / 'Apollo').read_bytes()
+                self.assertEqual(after[:48], before[:48])
+                self.assertEqual(after[52:], before[52:])
+                self.assertEqual(struct.unpack_from('<I', after, 48)[0], 27 << 16)
+                info = plistlib.loads((app / 'Info.plist').read_bytes())
+                self.assertEqual(info['MinimumOSVersion'], '14.0')
+                self.assertNotIn('UIRequiresFullScreen', info)
+                self.assertNotIn('UIRequiresFullScreen~ipad', info)
+                self.assertEqual(len(info['UISupportedInterfaceOrientations']), 4)
+                module.prepare(app)
+                self.assertEqual((app / 'Apollo').read_bytes(), after)
+
+    def test_never_downgrades_a_newer_sdk(self):
+        with tempfile.TemporaryDirectory() as directory:
+            app, before = self.fixture(directory, sdk=28)
+            module.prepare(app)
+            self.assertEqual((app / 'Apollo').read_bytes(), before)
+
+    def test_invalid_binary_does_not_change_plist(self):
+        with tempfile.TemporaryDirectory() as directory:
+            app, _ = self.fixture(directory)
+            before = (app / 'Info.plist').read_bytes()
+            (app / 'Apollo').write_bytes(b'invalid')
+            with self.assertRaises(ValueError):
+                module.prepare(app)
+            self.assertEqual((app / 'Info.plist').read_bytes(), before)
+            self.assertEqual((app / 'Apollo').read_bytes(), b'invalid')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
An iOS 27 phone window can resize to tablet dimensions while retaining the phone idiom. Allow the existing opt-in pane hierarchy on iOS 27 phones, so UIKit collapses it at narrow sizes and expands the list/detail panes when space allows.

Stacked on #1058. **Multi-Column Layout (Experimental)** remains OFF by default in Settings → Apollo Reborn → Interface. Changing it requires quit/reopen; resizing afterward reuses the same pane hierarchy. Remove the simulator-only override so tests use the persisted setting. Sidebar initialization follows width/size class, and new-window actions require actual multi-scene support.

Derive the iOS 27 phone pane container’s horizontal size class from its own available dimensions (760 × 500 points for two columns). This handles Device Hub starting resize mode from a narrow window while the legacy parent retains a compact trait. Ordinary landscape phones stay collapsed; iPad retains its existing policy. Only the pane container receives the override; the real device idiom is unchanged.

Fix compact deep links that replace a hidden detail branch after popping the primary root: explicitly reveal the secondary column. Verified by opening Interface from a compact Settings route and activating its real Multi-Column Layout switch; the restart prompt and pending-state subtitle appeared correctly.

Add explicit `--resizable` simulator/test-IPA preparation. Apollo's main executable must declare SDK 27 as well as the injected tweak; the compatibility patch preserves the deployment target, platform, and executable code, retains the scene/launch-screen configuration, and prepares continuous resizing. It includes the existing Liquid Glass preparation. Normal release variants retain their current SDK behavior.

Validation:
- Simulator build and pinned iOS 26 device build/package (iOS 14 deployment floor) passed. The parallel package build stalled in a submake; serial packaging completed.
- Phone setting OFF → zero panes; ON after relaunch → five panes and narrow collapse; OFF after testing → zero panes again.
- Device Hub toolbar resize starting narrow: verified repeated compact/expanded transitions at actual app sizes 402×874, 874×402, 760×500, 675×900, and 1161×680. Settings detail remained open, with zero pending navigation/watchdogs after every settled sample. This beta constrained portrait requests for 759×900 and 820×900 to actual app bounds of 675×900; assertions use actual bounds.
- Screenshot confirmed adjacent Settings index/detail at 1161×680 while the idiom remained phone.
- Geometry policy (146,781 cases), transition lifecycle, and binary-preservation patch tests passed.

This is resizable-phone support and foldable preparation, not a claim of testing unreleased hardware. Real-device iPhone Mirroring, signed-in feed/media behavior, and foldable hardware remain validation work. Setup, evidence summary, and Apple documentation links: `docs/resizable-iphone-panes.md`.
