### PR TITLE
Floating Tabs: crest faces for match threads, letter faces for same-subreddit text posts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloVideoHoldSpeed.xm \
     $(SRC_DIR)/ApolloPictureInPicture.xm \
     $(SRC_DIR)/ApolloFloatingTabs.xm \
+    $(SRC_DIR)/ApolloFloatingTabsCrests.m \
     $(SRC_DIR)/ApolloMediaPreviewErrorFix.xm \
     $(SRC_DIR)/ApolloFeedShortcutsAppearance.m \
     $(SRC_DIR)/ApolloSubredditIndexPolish.xm \

--- a/src/ApolloFloatingTabs.xm
+++ b/src/ApolloFloatingTabs.xm
@@ -165,7 +165,7 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
 @property (nonatomic, strong) UILabel *badgeLabel;
 @property (nonatomic, assign) BOOL badgeConfigured;
 - (void)applyMainImage:(UIImage *)image;                          // nil → subreddit monogram
-- (void)applyBadgeImage:(UIImage *)image initial:(NSString *)initial; // both nil → hidden
+- (void)applyBadgeImage:(UIImage *)image initial:(NSString *)initial; // shows initial's first character; both nil → hidden
 - (void)applyMonogramColors;
 - (void)updateTuckAppearance;
 - (void)refreshAccessibility;
@@ -280,7 +280,10 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
         self.badgeLabel.hidden = YES;
         self.badgeContainer.backgroundColor = [UIColor clearColor];
     } else if (initial.length > 0) {
-        self.badgeLabel.text = [initial substringToIndex:1].uppercaseString;
+        // First composed character only (surrogate-safe), so a longer string
+        // can never widen the badge.
+        NSRange first = [initial rangeOfComposedCharacterSequenceAtIndex:0];
+        self.badgeLabel.text = [initial substringWithRange:first].uppercaseString;
         self.badgeLabel.hidden = NO;
         self.badgeImageView.hidden = YES;
         [self refreshBadgeColors];
@@ -736,9 +739,91 @@ static ApolloFloatingTabsController *sFTController = nil;
 //      subreddit, and the badge keeps the community identity visible.
 //   2. No thumbnail (text/NSFW/spoiler post): subreddit icon (or monogram) as
 //      the face. If ANOTHER badge-less tab shares the subreddit, each gets a
-//      post-title-initial badge so same-sub text posts still tell apart.
+//      post-title-initial badge so same-sub text posts still tell apart. The
+//      initial skips the words the colliding titles share ("Match Thread:",
+//      "[Serious]", "Daily Discussion"), so two r/soccer match threads badge
+//      by team (R / B) instead of both wearing an M — see
+//      ApolloFTBadgeLettersForTitles.
 // Recomputed wholesale on every add/close/restore and image arrival —
 // identity is derived state, never patched incrementally.
+
+// First alphanumeric character of `word` (taken as a composed sequence, so an
+// accented or non-BMP letter survives), uppercased; nil when the word has
+// none ("|", "—", an emoji).
+static NSString *ApolloFTWordInitial(NSString *word) {
+    NSCharacterSet *alphanumerics = [NSCharacterSet alphanumericCharacterSet];
+    NSUInteger index = 0;
+    while (index < word.length) {
+        NSRange range = [word rangeOfComposedCharacterSequenceAtIndex:index];
+        NSString *character = [word substringWithRange:range];
+        if ([character rangeOfCharacterFromSet:alphanumerics].location != NSNotFound) {
+            return character.uppercaseString;
+        }
+        index = NSMaxRange(range);
+    }
+    return nil;
+}
+
+// One badge letter per member of a same-subreddit collision group. Titles are
+// compared word by word: members that share an initial at `depth` are refined
+// one word deeper until they split, so each badge is the first word that tells
+// its tab apart from the others, never a prefix they all share:
+//   "Match Thread: Real Madrid vs Inter" / "Match Thread: Bayern vs Chelsea"
+//     → R / B   (not M / M)
+//   "Match Thread: Real Madrid …" / "Post Match Thread: Real Madrid …"
+//     → M / P   (a match thread and its post-match thread stay distinct)
+//   "Match Thread: Real Madrid …" / "Match Thread: Real Sociedad …"
+//     → M / S
+// A title that runs out of words while the others continue keeps its first
+// initial ("•" when it has none), so it still differs from the rest.
+static void ApolloFTAssignBadgeLetters(NSArray<NSArray<NSString *> *> *initials,
+                                       NSIndexSet *members, NSUInteger depth,
+                                       NSMutableArray<NSString *> *letters) {
+    // Partition members by their initial at `depth`; @"" = title exhausted.
+    NSMutableDictionary<NSString *, NSMutableIndexSet *> *buckets = [NSMutableDictionary dictionary];
+    NSMutableArray<NSString *> *bucketOrder = [NSMutableArray array];
+    [members enumerateIndexesUsingBlock:^(NSUInteger member, BOOL *stop) {
+        NSArray<NSString *> *words = initials[member];
+        NSString *key = depth < words.count ? words[depth] : @"";
+        if (!buckets[key]) {
+            buckets[key] = [NSMutableIndexSet indexSet];
+            [bucketOrder addObject:key];
+        }
+        [buckets[key] addIndex:member];
+    }];
+    for (NSString *key in bucketOrder) {
+        NSIndexSet *bucket = buckets[key];
+        if (key.length > 0 && bucket.count > 1) {
+            // Still tied on this word — split on the next one.
+            ApolloFTAssignBadgeLetters(initials, bucket, depth + 1, letters);
+            continue;
+        }
+        [bucket enumerateIndexesUsingBlock:^(NSUInteger member, BOOL *stop) {
+            NSString *letter = key.length > 0 ? key : initials[member].firstObject;
+            letters[member] = letter ?: @"•";
+        }];
+    }
+}
+
+static NSArray<NSString *> *ApolloFTBadgeLettersForTitles(NSArray<NSString *> *titles) {
+    NSMutableArray<NSArray<NSString *> *> *initials = [NSMutableArray arrayWithCapacity:titles.count];
+    NSMutableArray<NSString *> *letters = [NSMutableArray arrayWithCapacity:titles.count];
+    NSCharacterSet *separators = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    for (NSString *title in titles) {
+        NSMutableArray<NSString *> *words = [NSMutableArray array];
+        for (NSString *word in [title componentsSeparatedByCharactersInSet:separators]) {
+            NSString *initial = ApolloFTWordInitial(word);
+            if (initial) [words addObject:initial];
+        }
+        [initials addObject:words];
+        [letters addObject:@"•"];
+    }
+    if (titles.count > 0) {
+        NSIndexSet *all = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, titles.count)];
+        ApolloFTAssignBadgeLetters(initials, all, 0, letters);
+    }
+    return letters;
+}
 
 - (void)refreshIdentityForTab:(ApolloFloatingTab *)tab {
     ApolloFloatingBubbleView *bubble = [self bubbleForTab:tab];
@@ -755,27 +840,24 @@ static ApolloFloatingTabsController *sFTController = nil;
     }
 
     [bubble applyMainImage:subIcon]; // nil → monogram
-    // Collision = another tab that will ALSO wear this subreddit's face
+    // Collision group = every tab that will wear this subreddit's face
     // (judged by stored thumbnail URL, not fetch state, so badges don't
-    // flicker while a thumbnail is still downloading).
-    BOOL collision = NO;
+    // flicker while a thumbnail is still downloading). Alone → no badge;
+    // otherwise the group's titles are lettered together, so each badge is
+    // the first word that tells its tab apart (ApolloFTBadgeLettersForTitles).
+    NSMutableArray<ApolloFloatingTab *> *group = [NSMutableArray array];
     for (ApolloFloatingTab *other in self.tabs) {
-        if (other != tab && other.thumbnailURL.length == 0
+        if (other.thumbnailURL.length == 0
             && [other.subreddit.lowercaseString isEqualToString:subKey]) {
-            collision = YES;
-            break;
+            [group addObject:other];
         }
     }
+    if (![group containsObject:tab]) [group addObject:tab]; // refreshed before joining the roster
     NSString *titleInitial = nil;
-    if (collision) {
-        for (NSUInteger i = 0; i < tab.title.length; i++) {
-            unichar c = [tab.title characterAtIndex:i];
-            if ([[NSCharacterSet alphanumericCharacterSet] characterIsMember:c]) {
-                titleInitial = [tab.title substringWithRange:NSMakeRange(i, 1)];
-                break;
-            }
-        }
-        if (!titleInitial) titleInitial = @"•";
+    if (group.count > 1) {
+        NSMutableArray<NSString *> *titles = [NSMutableArray arrayWithCapacity:group.count];
+        for (ApolloFloatingTab *member in group) [titles addObject:member.title ?: @""];
+        titleInitial = ApolloFTBadgeLettersForTitles(titles)[[group indexOfObject:tab]];
     }
     [bubble applyBadgeImage:nil initial:titleInitial];
 }
@@ -2168,11 +2250,14 @@ void ApolloFloatingTabsDebugCommand(NSString *payload) {
         NSInteger i = 0;
         for (ApolloFloatingTab *tab in controller.tabs) {
             ApolloFloatingBubbleView *bubble = [controller bubbleForTab:tab];
-            ApolloLog(@"[FloatingTabs][debug]   [%ld] %@ r/%@ side=%ld yFrac=%.3f tucked=%d stack=%@/%ld vc=%d snap=%d center=(%.0f,%.0f)",
+            ApolloLog(@"[FloatingTabs][debug]   [%ld] %@ r/%@ side=%ld yFrac=%.3f tucked=%d stack=%@/%ld vc=%d snap=%d center=(%.0f,%.0f) face=%@ badge=%@",
                       (long)i, tab.linkKey, tab.subreddit, (long)tab.side, tab.yFrac, tab.tucked,
                       tab.stackID ?: @"-", (long)tab.stackOrder,
                       tab.commentsVC != nil, tab.snapshot != nil,
-                      bubble.center.x, bubble.center.y);
+                      bubble.center.x, bubble.center.y,
+                      bubble.iconView.hidden ? @"monogram" : @"image",
+                      bubble.badgeContainer.hidden ? @"-"
+                          : (bubble.badgeLabel.hidden ? @"image" : bubble.badgeLabel.text));
             i++;
         }
         return;

--- a/src/ApolloFloatingTabs.xm
+++ b/src/ApolloFloatingTabs.xm
@@ -287,6 +287,9 @@ typedef NS_ENUM(NSInteger, ApolloFTCrestState) {
     if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previous]) {
         [self applyMonogramColors];
         [self refreshBadgeColors];
+        // A crest face carries light + dark renders; pick ours explicitly.
+        UIImageAsset *asset = self.iconView.image.imageAsset;
+        if (asset) self.iconView.image = [asset imageWithTraitCollection:self.traitCollection];
     }
 }
 
@@ -563,6 +566,27 @@ static ApolloFloatingTabsController *sFTController = nil;
     self.rootViewController = rootVC;
     window.hidden = NO;
     ApolloLog(@"[FloatingTabs] Overlay window created (scene=%@)", scene ? @"yes" : @"no");
+    for (UIWindow *candidate in ApolloAllWindows()) {
+        if ([self syncOverlayAppearanceWithWindow:candidate]) break;
+    }
+}
+
+// The overlay is its own UIWindow, so it follows the SYSTEM appearance while
+// Apollo's window may be forced dark or light (Theme Manager › Light/Dark Mode
+// set to manual, or a schedule). Everything on a bubble resolves against the
+// bubble's traits — accent monogram, badge, the crest disc — so the overlay
+// mirrors Apollo's window override, here at creation and from the
+// setOverrideUserInterfaceStyle: hook below whenever Apollo changes it.
+// Returns NO when `candidate` isn't Apollo's app window.
+- (BOOL)syncOverlayAppearanceWithWindow:(UIWindow *)candidate {
+    if (!self.window || candidate == self.window) return NO;
+    if (!candidate.rootViewController || candidate.windowLevel != UIWindowLevelNormal) return NO;
+    UIUserInterfaceStyle style = candidate.overrideUserInterfaceStyle;
+    if (self.window.overrideUserInterfaceStyle != style) {
+        self.window.overrideUserInterfaceStyle = style;
+        ApolloLog(@"[FloatingTabs] Overlay appearance mirrors app window override=%ld", (long)style);
+    }
+    return YES;
 }
 
 - (void)tearDownWindowIfEmpty {
@@ -867,10 +891,10 @@ static CGRect ApolloFTAspectFitRect(CGSize imageSize, CGRect box) {
                       fitted.width, fitted.height);
 }
 
-// Half-and-half crest face: home crest on the left, away on the right, on a
-// light disc with a hairline divider. Rendered once per pair at bubble size
-// and cached; the bubble's own circular clip trims the edges.
-static UIImage *ApolloFTComposeCrestPair(UIImage *home, UIImage *away) {
+// One half-and-half render: home crest on the left, away on the right, on a
+// disc with a hairline divider. Light appearance = near-white disc; dark =
+// charcoal, so the face sits with the rest of a dark theme instead of glowing.
+static UIImage *ApolloFTRenderCrestPair(UIImage *home, UIImage *away, BOOL dark) {
     const CGFloat size = kFTBubbleSize;
     const CGFloat crest = 26.0;
     UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
@@ -878,15 +902,28 @@ static UIImage *ApolloFTComposeCrestPair(UIImage *home, UIImage *away) {
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(size, size)
                                                                                format:format];
     return [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *ctx) {
-        [[UIColor colorWithWhite:0.96 alpha:1.0] setFill];
+        [[UIColor colorWithWhite:(dark ? 0.17 : 0.96) alpha:1.0] setFill];
         [[UIBezierPath bezierPathWithOvalInRect:CGRectMake(0, 0, size, size)] fill];
         CGRect leftBox = CGRectMake(size / 4.0 - crest / 2.0, (size - crest) / 2.0, crest, crest);
         CGRect rightBox = CGRectMake(size * 3.0 / 4.0 - crest / 2.0, (size - crest) / 2.0, crest, crest);
         [home drawInRect:ApolloFTAspectFitRect(home.size, leftBox)];
         [away drawInRect:ApolloFTAspectFitRect(away.size, rightBox)];
-        [[UIColor colorWithWhite:0.80 alpha:1.0] setFill];
+        [[UIColor colorWithWhite:(dark ? 0.36 : 0.80) alpha:1.0] setFill];
         UIRectFill(CGRectMake(size / 2.0 - 0.5, 9.0, 1.0, size - 18.0));
     }];
+}
+
+// The crest face as a dynamic image: both appearances rendered once per pair
+// and registered in a UIImageAsset, so UIImageView swaps them on a trait
+// change (system dark mode, or Apollo flipping its window style for a dark
+// theme) exactly like the monogram and badge colours already follow it.
+static UIImage *ApolloFTComposeCrestPair(UIImage *home, UIImage *away) {
+    UIImageAsset *asset = [UIImageAsset new];
+    [asset registerImage:ApolloFTRenderCrestPair(home, away, NO)
+     withTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
+    [asset registerImage:ApolloFTRenderCrestPair(home, away, YES)
+     withTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
+    return [asset imageWithTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
 }
 
 - (UIImage *)crestFaceForTab:(ApolloFloatingTab *)tab {
@@ -2336,6 +2373,28 @@ static void ApolloFTMenuPerform(id actionController) {
     else if (link) ApolloFTKeepOrToggleForLink(link);
 }
 
+// Apollo forces its window's style for manual/scheduled Light/Dark Mode; the
+// overlay window must follow or its bubbles resolve to the system appearance.
+// Cheap and rare: a real style change, or the theme runtime's one-turn flip.
+%hook UIWindow
+- (void)setOverrideUserInterfaceStyle:(UIUserInterfaceStyle)style {
+    %orig;
+    ApolloFloatingTabsController *controller = [ApolloFloatingTabsController sharedIfExists];
+    if (!controller.window || self == controller.window) return;
+    // Deferred one runloop turn on purpose: ApolloThemeRuntime's repaint flips
+    // EVERY window's override (ours included) and restores each from a
+    // snapshot on the next turn. Mirroring synchronously inside that loop
+    // would be captured as the overlay's snapshot and restored as if it were
+    // real, leaving the overlay dark on a light app. After the turn, the app
+    // window holds its true value again and the mirror reads that.
+    __weak UIWindow *weakWindow = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIWindow *window = weakWindow;
+        if (window) [[ApolloFloatingTabsController sharedIfExists] syncOverlayAppearanceWithWindow:window];
+    });
+}
+%end
+
 %hook _TtC6Apollo22CommentsViewController
 
 - (void)moreOptionsBarButtonItemTappedWithSender:(id)sender {
@@ -2463,8 +2522,15 @@ void ApolloFloatingTabsDebugCommand(NSString *payload) {
     }
 
     if ([command isEqualToString:@"state"]) {
-        ApolloLog(@"[FloatingTabs][debug] state: %lu tab(s), magnet=%d",
-                  (unsigned long)controller.tabs.count, sFloatingPostTabsMagnet ? 1 : 0);
+        UIWindow *appWindow = nil;
+        for (UIWindow *w in ApolloAllWindows()) {
+            if (w != controller.window && w.rootViewController) { appWindow = w; break; }
+        }
+        ApolloLog(@"[FloatingTabs][debug] state: %lu tab(s), magnet=%d overlayStyle=%ld appWindowOverride=%ld appWindowStyle=%ld",
+                  (unsigned long)controller.tabs.count, sFloatingPostTabsMagnet ? 1 : 0,
+                  (long)controller.window.traitCollection.userInterfaceStyle,
+                  (long)appWindow.overrideUserInterfaceStyle,
+                  (long)appWindow.traitCollection.userInterfaceStyle);
         NSInteger i = 0;
         for (ApolloFloatingTab *tab in controller.tabs) {
             ApolloFloatingBubbleView *bubble = [controller bubbleForTab:tab];
@@ -2474,7 +2540,8 @@ void ApolloFloatingTabsDebugCommand(NSString *payload) {
                       tab.commentsVC != nil, tab.snapshot != nil,
                       bubble.center.x, bubble.center.y,
                       bubble.iconView.hidden ? @"monogram"
-                          : ([controller crestFaceForTab:tab] && bubble.iconView.image == [controller crestFaceForTab:tab]
+                          : ([controller crestFaceForTab:tab]
+                             && bubble.iconView.image.imageAsset == [controller crestFaceForTab:tab].imageAsset
                              ? @"crests" : @"image"),
                       bubble.badgeContainer.hidden ? @"-"
                           : (bubble.badgeLabel.hidden ? @"image" : bubble.badgeLabel.text));

--- a/src/ApolloFloatingTabs.xm
+++ b/src/ApolloFloatingTabs.xm
@@ -64,6 +64,8 @@
 #import <objc/message.h>
 
 #import "ApolloFloatingTabs.h"
+#import "ApolloUserFlair.h"
+#import "ApolloFloatingTabsCrests.h"
 #import "ApolloActionMenu.h"
 #import "ApolloCommon.h"
 #import "ApolloState.h"
@@ -86,6 +88,7 @@ static const CGFloat kFTCloseHitRadius = 64.0;      // drop-to-close capture dis
 static const CGFloat kFTFlingVelocityThreshold = 250.0;  // below this a release stays put (same as PiP)
 static const CGFloat kFTTuckVelocityThreshold = 300.0;   // outward fling speed that tucks (same as PiP)
 static const NSInteger kFTMaxTabs = 5;
+static const NSInteger kFTCrestMaxAttempts = 3;    // catalogue + image fetch attempts per tab (per launch)
 // After a fan-out (magnet on), how long members linger spread out before
 // springing back into the pile. Long enough to tap one open or start dragging
 // one away, short enough that the pile feels like it never really left.
@@ -128,6 +131,13 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
 // MARK: - Model
 // =============================================================================
 
+typedef NS_ENUM(NSInteger, ApolloFTCrestState) {
+    ApolloFTCrestStateUnresolved = 0, // not looked at yet, or a catalogue fetch failed (worth retrying)
+    ApolloFTCrestStatePending,        // catalogue lookup in flight
+    ApolloFTCrestStateNone,           // final: not a match thread, or a side has no crest
+    ApolloFTCrestStateMatched,        // crestURLs/crestKey set; face cached, or fetchable again after eviction
+};
+
 @interface ApolloFloatingTab : NSObject
 @property (nonatomic, copy) NSString *linkKey;        // t3_xxx, lowercased (identity)
 @property (nonatomic, copy) NSString *permalink;      // "/r/sub/comments/..." (cold-reopen fallback; may be empty)
@@ -136,6 +146,12 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
 @property (nonatomic, copy) NSString *thumbnailURL;   // post thumbnail (bubble face when present; empty for text/NSFW/spoiler posts)
 @property (nonatomic, strong) UIViewController *commentsVC; // the LIVE screen; nil for cold tabs
 @property (nonatomic, strong) UIImage *snapshot;      // last-seen preview; nil for cold tabs / after memory warning
+// Match-thread crest face, derived from title + subreddit (never persisted;
+// re-resolved after a relaunch). See ApolloFloatingTabsCrests.h.
+@property (nonatomic, assign) NSInteger crestState;          // ApolloFTCrestState
+@property (nonatomic, assign) NSInteger crestAttempts;       // network attempts, capped at kFTCrestMaxAttempts
+@property (nonatomic, copy) NSArray<NSString *> *crestURLs;  // [home, away] crest PNG URLs once matched
+@property (nonatomic, copy) NSString *crestKey;              // composed-face cache key ("home|away")
 // Dock state
 @property (nonatomic, assign) NSInteger side;         // -1 left edge, +1 right edge
 @property (nonatomic, assign) CGFloat yFrac;          // resting center Y as a fraction of window height
@@ -164,6 +180,10 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
 @property (nonatomic, strong) UIImageView *badgeImageView;
 @property (nonatomic, strong) UILabel *badgeLabel;
 @property (nonatomic, assign) BOOL badgeConfigured;
+// When set, the monogram face shows this instead of the subreddit's first
+// letter (same-sub collision: the post's distinguishing letter becomes the
+// face and the subreddit moves to the rim badge).
+@property (nonatomic, copy) NSString *monogramOverride;
 - (void)applyMainImage:(UIImage *)image;                          // nil → subreddit monogram
 - (void)applyBadgeImage:(UIImage *)image initial:(NSString *)initial; // shows initial's first character; both nil → hidden
 - (void)applyMonogramColors;
@@ -253,6 +273,10 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
     self.iconContainer.backgroundColor = resolved;
     self.monogramLabel.textColor = ApolloColorIsLight(resolved) ? [UIColor blackColor] : [UIColor whiteColor];
 
+    if (self.monogramOverride.length > 0) {
+        self.monogramLabel.text = self.monogramOverride.uppercaseString;
+        return;
+    }
     NSString *name = self.tab.subreddit ?: @"";
     if ([name.lowercaseString hasPrefix:@"u_"] && name.length > 2) name = [name substringFromIndex:2];
     self.monogramLabel.text = name.length > 0 ? [[name substringToIndex:1] uppercaseString] : @"r";
@@ -426,6 +450,8 @@ static void ApolloFTHapticImpact(UIImpactFeedbackStyle style) {
 @property (nonatomic, strong) NSCache<NSString *, UIImage *> *iconCache;         // lowercased subreddit -> image
 @property (nonatomic, strong) NSMutableSet<NSString *> *iconFetchesInFlight;
 @property (nonatomic, strong) NSCache<NSString *, UIImage *> *thumbCache;        // thumbnail URL -> image
+@property (nonatomic, strong) NSCache<NSString *, UIImage *> *crestCache;        // crestKey -> composed crest-pair face
+@property (nonatomic, strong) NSMutableSet<NSString *> *crestFetchesInFlight;   // crestKey
 @property (nonatomic, strong) NSMutableSet<NSString *> *thumbFetchesInFlight;
 @property (nonatomic, assign) BOOL didAttemptRestore;
 
@@ -477,6 +503,9 @@ static ApolloFloatingTabsController *sFTController = nil;
     _iconFetchesInFlight = [NSMutableSet set];
     _thumbCache = [[NSCache alloc] init];
     _thumbFetchesInFlight = [NSMutableSet set];
+    _crestCache = [[NSCache alloc] init];
+    _crestCache.countLimit = kFTMaxTabs * 2;
+    _crestFetchesInFlight = [NSMutableSet set];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleMemoryWarning)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification
@@ -737,12 +766,17 @@ static ApolloFloatingTabsController *sFTController = nil;
 //   1. Post thumbnail as the face + subreddit icon (or its letter) as the rim
 //      badge — every tab reads distinctly even when several come from one
 //      subreddit, and the badge keeps the community identity visible.
-//   2. No thumbnail (text/NSFW/spoiler post): subreddit icon (or monogram) as
-//      the face. If ANOTHER badge-less tab shares the subreddit, each gets a
-//      post-title-initial badge so same-sub text posts still tell apart. The
-//      initial skips the words the colliding titles share ("Match Thread:",
-//      "[Serious]", "Daily Discussion"), so two r/soccer match threads badge
-//      by team (R / B) instead of both wearing an M — see
+//   2. Match thread without a thumbnail: the two teams' crests, half and half,
+//      as the face + the subreddit on the rim — the crests come from the
+//      subreddit's own flair emoji catalogue (ApolloFloatingTabsCrests.h), so
+//      no outside service is involved. Resolved asynchronously; until (unless)
+//      they land the tab is treated like any other text post below.
+//   3. No thumbnail (text/NSFW/spoiler post): subreddit icon (or monogram) as
+//      the face. If ANOTHER such tab shares the subreddit, each becomes a big
+//      accent monogram of its post title's distinguishing letter with the
+//      subreddit on the rim. The letter skips the words the colliding titles
+//      share ("Match Thread:", "[Serious]", "Daily Discussion"), so two
+//      r/soccer match threads read R / B instead of both wearing an M — see
 //      ApolloFTBadgeLettersForTitles.
 // Recomputed wholesale on every add/close/restore and image arrival —
 // identity is derived state, never patched incrementally.
@@ -825,6 +859,46 @@ static NSArray<NSString *> *ApolloFTBadgeLettersForTitles(NSArray<NSString *> *t
     return letters;
 }
 
+static CGRect ApolloFTAspectFitRect(CGSize imageSize, CGRect box) {
+    if (imageSize.width <= 0 || imageSize.height <= 0) return box;
+    CGFloat scale = MIN(box.size.width / imageSize.width, box.size.height / imageSize.height);
+    CGSize fitted = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
+    return CGRectMake(CGRectGetMidX(box) - fitted.width / 2.0, CGRectGetMidY(box) - fitted.height / 2.0,
+                      fitted.width, fitted.height);
+}
+
+// Half-and-half crest face: home crest on the left, away on the right, on a
+// light disc with a hairline divider. Rendered once per pair at bubble size
+// and cached; the bubble's own circular clip trims the edges.
+static UIImage *ApolloFTComposeCrestPair(UIImage *home, UIImage *away) {
+    const CGFloat size = kFTBubbleSize;
+    const CGFloat crest = 26.0;
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.opaque = NO;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(size, size)
+                                                                               format:format];
+    return [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *ctx) {
+        [[UIColor colorWithWhite:0.96 alpha:1.0] setFill];
+        [[UIBezierPath bezierPathWithOvalInRect:CGRectMake(0, 0, size, size)] fill];
+        CGRect leftBox = CGRectMake(size / 4.0 - crest / 2.0, (size - crest) / 2.0, crest, crest);
+        CGRect rightBox = CGRectMake(size * 3.0 / 4.0 - crest / 2.0, (size - crest) / 2.0, crest, crest);
+        [home drawInRect:ApolloFTAspectFitRect(home.size, leftBox)];
+        [away drawInRect:ApolloFTAspectFitRect(away.size, rightBox)];
+        [[UIColor colorWithWhite:0.80 alpha:1.0] setFill];
+        UIRectFill(CGRectMake(size / 2.0 - 0.5, 9.0, 1.0, size - 18.0));
+    }];
+}
+
+- (UIImage *)crestFaceForTab:(ApolloFloatingTab *)tab {
+    return tab.crestKey.length > 0 ? [self.crestCache objectForKey:tab.crestKey] : nil;
+}
+
+// A tab that shows its SUBREDDIT as the face: no thumbnail and no crest pair
+// (yet). Judged by stored URL / cached face, so nothing flickers mid-download.
+- (BOOL)tabWearsSubredditFace:(ApolloFloatingTab *)tab {
+    return tab.thumbnailURL.length == 0 && ![self crestFaceForTab:tab];
+}
+
 - (void)refreshIdentityForTab:(ApolloFloatingTab *)tab {
     ApolloFloatingBubbleView *bubble = [self bubbleForTab:tab];
     if (!bubble) return;
@@ -839,31 +913,156 @@ static NSArray<NSString *> *ApolloFTBadgeLettersForTitles(NSArray<NSString *> *t
         return;
     }
 
-    [bubble applyMainImage:subIcon]; // nil → monogram
-    // Collision group = every tab that will wear this subreddit's face
-    // (judged by stored thumbnail URL, not fetch state, so badges don't
-    // flicker while a thumbnail is still downloading). Alone → no badge;
-    // otherwise the group's titles are lettered together, so each badge is
-    // the first word that tells its tab apart (ApolloFTBadgeLettersForTitles).
+    UIImage *crests = [self crestFaceForTab:tab];
+    if (crests) {
+        bubble.monogramOverride = nil;
+        [bubble applyMonogramColors];
+        [bubble applyMainImage:crests];
+        NSString *subInitial = subKey.length > 0 ? [subKey substringToIndex:1] : @"r";
+        [bubble applyBadgeImage:subIcon initial:(subIcon ? nil : subInitial)];
+        return;
+    }
+    [self resolveCrestsForTab:tab]; // no-op unless unresolved (or the face was evicted)
+
+    // Collision group = every tab that wears this subreddit's face.
     NSMutableArray<ApolloFloatingTab *> *group = [NSMutableArray array];
     for (ApolloFloatingTab *other in self.tabs) {
-        if (other.thumbnailURL.length == 0
+        if ([self tabWearsSubredditFace:other]
             && [other.subreddit.lowercaseString isEqualToString:subKey]) {
             [group addObject:other];
         }
     }
     if (![group containsObject:tab]) [group addObject:tab]; // refreshed before joining the roster
-    NSString *titleInitial = nil;
-    if (group.count > 1) {
-        NSMutableArray<NSString *> *titles = [NSMutableArray arrayWithCapacity:group.count];
-        for (ApolloFloatingTab *member in group) [titles addObject:member.title ?: @""];
-        titleInitial = ApolloFTBadgeLettersForTitles(titles)[[group indexOfObject:tab]];
+    if (group.count == 1) {
+        // Alone: the subreddit icon (or monogram) IS the identity.
+        bubble.monogramOverride = nil;
+        [bubble applyMonogramColors];
+        [bubble applyMainImage:subIcon]; // nil → monogram
+        [bubble applyBadgeImage:nil initial:nil];
+        return;
     }
-    [bubble applyBadgeImage:nil initial:titleInitial];
+    // Several same-sub text posts: the group's titles are lettered together
+    // (ApolloFTBadgeLettersForTitles) and each tab's distinguishing letter
+    // becomes its FACE — a big accent monogram — while the subreddit moves
+    // to the rim badge, exactly the thumbnail layout (unique face, community
+    // on the rim). A tiny badge letter on identical icons read as twins.
+    NSMutableArray<NSString *> *titles = [NSMutableArray arrayWithCapacity:group.count];
+    for (ApolloFloatingTab *member in group) [titles addObject:member.title ?: @""];
+    bubble.monogramOverride = ApolloFTBadgeLettersForTitles(titles)[[group indexOfObject:tab]];
+    [bubble applyMonogramColors];
+    [bubble applyMainImage:nil]; // monogram face
+    NSString *subInitial = subKey.length > 0 ? [subKey substringToIndex:1] : @"r";
+    [bubble applyBadgeImage:subIcon initial:(subIcon ? nil : subInitial)];
 }
 
 - (void)refreshAllIdentities {
     for (ApolloFloatingTab *tab in self.tabs) [self refreshIdentityForTab:tab];
+}
+
+// Match-thread crests: title → two sides → the subreddit's flair emoji
+// catalogue → two crest PNGs → one composed face. Every step is a no-op once
+// it has a verdict; a network failure leaves the tab retryable (next identity
+// refresh, within kFTCrestMaxAttempts) rather than caching "no crests".
+- (void)resolveCrestsForTab:(ApolloFloatingTab *)tab {
+    if (tab.thumbnailURL.length > 0) return; // a real thumbnail always wins
+    if (tab.crestState == ApolloFTCrestStateMatched) {
+        [self fetchCrestPairForTab:tab]; // face evicted under memory pressure — fetch the pair again
+        return;
+    }
+    if (tab.crestState != ApolloFTCrestStateUnresolved || tab.crestAttempts >= kFTCrestMaxAttempts) return;
+    NSString *home = nil, *away = nil;
+    if (!ApolloFTCrestTeamsFromTitle(tab.title, &home, &away)) {
+        tab.crestState = ApolloFTCrestStateNone; // not a match thread — final, and free to decide
+        return;
+    }
+    tab.crestState = ApolloFTCrestStatePending;
+    tab.crestAttempts++;
+    NSString *subreddit = tab.subreddit ?: @"";
+    // Weak on both sides: a closed tab (or a torn-down controller) must not be
+    // kept alive by a slow catalogue fetch, and a verdict for a gone tab is moot.
+    __weak __typeof(self) weakSelf = self;
+    __weak ApolloFloatingTab *weakTab = tab;
+    ApolloUserFlairEnsureEmojisForSubreddit(subreddit, ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __typeof(self) strongSelf = weakSelf;
+            ApolloFloatingTab *tab = weakTab;
+            if (!strongSelf || !tab) return;
+            NSArray<NSDictionary<NSString *, NSString *> *> *catalogue = ApolloUserFlairCachedEmojisForSubreddit(subreddit);
+            if (catalogue.count == 0) {
+                // No catalogue (offline, or the fetch failed): not a verdict.
+                tab.crestState = ApolloFTCrestStateUnresolved;
+                ApolloLog(@"[FloatingTabs] Crests: no flair emoji catalogue for r/%@ (attempt %ld)",
+                          subreddit, (long)tab.crestAttempts);
+                return;
+            }
+            NSString *homeName = nil, *awayName = nil;
+            NSString *homeURL = ApolloFTCrestURLForTeam(home, subreddit, catalogue, &homeName);
+            NSString *awayURL = ApolloFTCrestURLForTeam(away, subreddit, catalogue, &awayName);
+            if (homeURL.length == 0 || awayURL.length == 0) {
+                tab.crestState = ApolloFTCrestStateNone;
+                ApolloLog(@"[FloatingTabs] Crests: r/%@ \"%@\" → %@, \"%@\" → %@ — letter fallback",
+                          subreddit, home, homeName ?: @"no crest", away, awayName ?: @"no crest");
+                return;
+            }
+            tab.crestURLs = @[homeURL, awayURL];
+            tab.crestKey = [NSString stringWithFormat:@"%@|%@", homeURL, awayURL];
+            tab.crestState = ApolloFTCrestStateMatched;
+            ApolloLog(@"[FloatingTabs] Crests: r/%@ %@ / %@", subreddit, homeName, awayName);
+            if ([strongSelf.crestCache objectForKey:tab.crestKey]) {
+                [strongSelf refreshAllIdentities]; // same fixture as another tab — face already composed
+                return;
+            }
+            [strongSelf fetchCrestPairForTab:tab];
+        });
+    });
+}
+
+- (void)fetchCrestPairForTab:(ApolloFloatingTab *)tab {
+    NSString *key = tab.crestKey;
+    if (key.length == 0 || tab.crestURLs.count != 2) return;
+    if ([self.crestCache objectForKey:key] || [self.crestFetchesInFlight containsObject:key]) return;
+    if (tab.crestAttempts >= kFTCrestMaxAttempts) return;
+    NSURL *homeURL = [NSURL URLWithString:tab.crestURLs[0]];
+    NSURL *awayURL = [NSURL URLWithString:tab.crestURLs[1]];
+    if (!homeURL || !awayURL) { tab.crestState = ApolloFTCrestStateNone; return; }
+    tab.crestAttempts++;
+    [self.crestFetchesInFlight addObject:key];
+
+    // Two bounded downloads, composed once both have landed (main queue). A
+    // failure just drops the in-flight mark: the state stays Matched, so the
+    // next identity refresh retries within the attempt cap, and nothing
+    // re-triggers a refresh here (no failure loop).
+    __block UIImage *homeImage = nil, *awayImage = nil;
+    __block NSUInteger remaining = 2;
+    __weak __typeof(self) weakSelf = self;
+    __weak ApolloFloatingTab *weakTab = tab;
+    void (^landed)(void) = ^{
+        if (--remaining > 0) return;
+        __typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf.crestFetchesInFlight removeObject:key];
+        UIImage *face = (homeImage && awayImage) ? ApolloFTComposeCrestPair(homeImage, awayImage) : nil;
+        if (!face) {
+            ApolloLog(@"[FloatingTabs] Crests: image fetch failed (attempt %ld)", (long)weakTab.crestAttempts);
+            return;
+        }
+        // Cache even if the tab is gone: a re-pinned post, or another tab of
+        // the same fixture, gets the face for free.
+        [strongSelf.crestCache setObject:face forKey:key];
+        [strongSelf refreshAllIdentities];
+    };
+    ApolloBoundedDataCompletion homeDone = ^(NSData *data, __unused NSHTTPURLResponse *response, __unused NSError *error) {
+        homeImage = data ? [UIImage imageWithData:data] : nil;
+        landed();
+    };
+    ApolloBoundedDataCompletion awayDone = ^(NSData *data, __unused NSHTTPURLResponse *response, __unused NSError *error) {
+        awayImage = data ? [UIImage imageWithData:data] : nil;
+        landed();
+    };
+    ApolloStartBoundedDataRequest([NSURLRequest requestWithURL:homeURL], 2 * 1024 * 1024, nil,
+                                  dispatch_get_main_queue(), homeDone);
+    ApolloStartBoundedDataRequest([NSURLRequest requestWithURL:awayURL], 2 * 1024 * 1024, nil,
+                                  dispatch_get_main_queue(), awayDone);
 }
 
 - (void)resolveIconForTab:(ApolloFloatingTab *)tab {
@@ -2244,6 +2443,25 @@ void ApolloFloatingTabsDebugCommand(NSString *payload) {
         return;
     }
 
+    if ([command isEqualToString:@"emojis"] && parts.count > 1) {
+        // floattab emojis <subreddit> — dump the flair emoji catalogue names
+        // (the crest lookup's search space) so matcher rules can be checked
+        // against real data.
+        NSString *sub = parts[1];
+        ApolloUserFlairEnsureEmojisForSubreddit(sub, ^{
+            NSArray<NSDictionary<NSString *, NSString *> *> *emojis = ApolloUserFlairCachedEmojisForSubreddit(sub);
+            ApolloLog(@"[FloatingTabs][debug] emojis r/%@: %lu entries", sub, (unsigned long)emojis.count);
+            NSMutableArray<NSString *> *names = [NSMutableArray array];
+            for (NSDictionary *e in emojis) [names addObject:e[@"name"] ?: @"?"];
+            for (NSUInteger i = 0; i < names.count; i += 40) {
+                NSRange range = NSMakeRange(i, MIN(40, names.count - i));
+                ApolloLog(@"[FloatingTabs][debug] emojis[%lu]: %@", (unsigned long)i,
+                          [[names subarrayWithRange:range] componentsJoinedByString:@" "]);
+            }
+        });
+        return;
+    }
+
     if ([command isEqualToString:@"state"]) {
         ApolloLog(@"[FloatingTabs][debug] state: %lu tab(s), magnet=%d",
                   (unsigned long)controller.tabs.count, sFloatingPostTabsMagnet ? 1 : 0);
@@ -2255,7 +2473,9 @@ void ApolloFloatingTabsDebugCommand(NSString *payload) {
                       tab.stackID ?: @"-", (long)tab.stackOrder,
                       tab.commentsVC != nil, tab.snapshot != nil,
                       bubble.center.x, bubble.center.y,
-                      bubble.iconView.hidden ? @"monogram" : @"image",
+                      bubble.iconView.hidden ? @"monogram"
+                          : ([controller crestFaceForTab:tab] && bubble.iconView.image == [controller crestFaceForTab:tab]
+                             ? @"crests" : @"image"),
                       bubble.badgeContainer.hidden ? @"-"
                           : (bubble.badgeLabel.hidden ? @"image" : bubble.badgeLabel.text));
             i++;

--- a/src/ApolloFloatingTabsCrests.h
+++ b/src/ApolloFloatingTabsCrests.h
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Match-thread crest lookup for Floating Tabs (Foundation only, so it compiles
+// into a host-side harness). Two pure steps:
+//
+//   1. ApolloFTCrestTeamsFromTitle — pulls the two sides out of a match-thread
+//      style title ("Match Thread: FC Porto vs Manchester City | UEFA Champions
+//      League", "Post Match Thread: Spain 1 - 0 Argentina | …", "GAME THREAD:
+//      Lakers (10-5) @ Celtics (12-3) - (…)"). Gated on a "… Thread:" / "[…
+//      Thread]" / "GDT:"-style prefix so ordinary posts never get parsed.
+//   2. ApolloFTCrestURLForTeam — matches one side against the subreddit's
+//      user-flair emoji catalogue (r/soccer's is the club crests: "FC_Porto",
+//      "Manchester_City", …), returning the crest PNG URL, or nil when nothing
+//      matches unambiguously. Never guesses: a tie between different crests is
+//      a miss, so the caller falls back to the letter badge.
+
+// Returns YES and the two trimmed side names when `title` reads as a match
+// thread with two identifiable sides.
+BOOL ApolloFTCrestTeamsFromTitle(NSString *title,
+                                 NSString *_Nullable *_Nullable outHome,
+                                 NSString *_Nullable *_Nullable outAway);
+
+// `catalogue` is the subreddit's emoji list as @[ @{ @"name": token, @"url":
+// png } ] (ApolloUserFlairCachedEmojisForSubreddit). The normalised index is
+// cached per `subreddit` (bounded), so repeated lookups don't re-tokenise ~2k
+// names. `outName` receives the matched catalogue token (for logs).
+NSString *_Nullable ApolloFTCrestURLForTeam(NSString *team, NSString *subreddit,
+                                            NSArray<NSDictionary<NSString *, NSString *> *> *catalogue,
+                                            NSString *_Nullable *_Nullable outName);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloFloatingTabsCrests.m
+++ b/src/ApolloFloatingTabsCrests.m
@@ -214,25 +214,50 @@ static NSArray<ApolloFTCrestEntry *> *ApolloFTCrestIndexForCatalogue(NSString *s
     }
 }
 
-// 3 = identical tokens, 2 = every side token present verbatim, 1 = every side
-// token present verbatim or as a ≥3-character prefix either way, 0 = no.
-static NSInteger ApolloFTCrestScore(NSArray<NSString *> *side, NSArray<NSString *> *candidate) {
-    if ([side isEqualToArray:candidate]) return 3;
-    BOOL allExact = YES, allPrefix = YES;
+// How a side relates to a catalogue entry, strongest first:
+//   Exact    identical tokens, or identical once the spaces are removed —
+//            r/CFB names its schools "ohiostate" / "notredame" / "texasam".
+//   Forward  every side token is in the entry verbatim: "Marseille" →
+//            Olympique_de_Marseille. The entry is the longer name.
+//   Prefix   every side token is in the entry verbatim or as a ≥3-letter
+//            prefix either way: "Inter Milan" → FC_Internazionale_Milano.
+//   Reverse  every entry token is in the side verbatim: "Kansas City Chiefs"
+//            → Chiefs (r/nfl names teams by nickname). The side is longer.
+//            Ranked last because a namesake can hide in a longer side ("Inter
+//            Milan" contains AC_Milan's "Milan"), so it only wins when nothing
+//            above it matches.
+typedef NS_ENUM(NSInteger, ApolloFTCrestMatch) {
+    ApolloFTCrestMatchNone = 0,
+    ApolloFTCrestMatchReverse = 1,
+    ApolloFTCrestMatchPrefix = 2,
+    ApolloFTCrestMatchForward = 3,
+    ApolloFTCrestMatchExact = 4,
+};
+
+static BOOL ApolloFTCrestTokensContain(NSArray<NSString *> *haystack, NSArray<NSString *> *needles) {
+    for (NSString *needle in needles) if (![haystack containsObject:needle]) return NO;
+    return YES;
+}
+
+static ApolloFTCrestMatch ApolloFTCrestScore(NSArray<NSString *> *side, NSArray<NSString *> *candidate) {
+    if ([side isEqualToArray:candidate]) return ApolloFTCrestMatchExact;
+    if ([[side componentsJoinedByString:@""] isEqualToString:[candidate componentsJoinedByString:@""]]) {
+        return ApolloFTCrestMatchExact;
+    }
+    if (ApolloFTCrestTokensContain(candidate, side)) return ApolloFTCrestMatchForward;
+    BOOL prefix = YES;
     for (NSString *token in side) {
-        BOOL exact = NO, prefix = NO;
+        BOOL matched = NO;
         for (NSString *other in candidate) {
-            if ([other isEqualToString:token]) { exact = YES; break; }
             NSString *shorter = token.length <= other.length ? token : other;
             NSString *longer = token.length <= other.length ? other : token;
-            if (shorter.length >= 3 && [longer hasPrefix:shorter]) prefix = YES;
+            if (shorter.length >= 3 && [longer hasPrefix:shorter]) { matched = YES; break; }
         }
-        if (!exact) allExact = NO;
-        if (!exact && !prefix) allPrefix = NO;
+        if (!matched) { prefix = NO; break; }
     }
-    if (allExact) return 2;
-    if (allPrefix) return 1;
-    return 0;
+    if (prefix) return ApolloFTCrestMatchPrefix;
+    if (ApolloFTCrestTokensContain(side, candidate)) return ApolloFTCrestMatchReverse;
+    return ApolloFTCrestMatchNone;
 }
 
 NSString *ApolloFTCrestURLForTeam(NSString *team, NSString *subreddit,
@@ -241,17 +266,16 @@ NSString *ApolloFTCrestURLForTeam(NSString *team, NSString *subreddit,
     if (outName) *outName = nil;
     NSArray<NSString *> *side = ApolloFTCrestTokens(team ?: @"", YES);
     if (side.count == 0 || catalogue.count == 0) return nil;
-    // A side must carry at least one distinctive token; "AC" alone is nothing.
-    BOOL distinctive = NO;
-    for (NSString *token in side) if (token.length >= 4) { distinctive = YES; break; }
-    if (!distinctive) return nil;
 
-    // A partial (subset) match is only trusted when the side is specific
-    // enough: two words, or one long word ("Internazionale", "Leverkusen"),
-    // and the candidate adds at most one word ("Borussia Dortmund" for
-    // "Dortmund" is fine; "Chattanooga Red Wolves" for "Wolves" is not). The
-    // catalogue Reddit returns is capped, so a club's real entry can be
-    // missing and a namesake must not be picked in its place.
+    // Anything short of an exact match is only trusted when it can't be a
+    // namesake: a forward/prefix match needs a specific side (two words, or
+    // one long word — "Internazionale", "Leverkusen") and an entry adding at
+    // most one word ("Olympique de Marseille" for "Marseille" yes, "Chattanooga
+    // Red Wolves" for "Wolves" never); a reverse match needs an entry with a
+    // real word in it (≥4 letters, so "ES" or "PN" never match anything) and
+    // a side adding at most two ("Kansas City Chiefs" → Chiefs). The keyless
+    // catalogue is partial, so a club's real entry can be missing and a
+    // namesake must not be picked in its place.
     BOOL specific = side.count >= 2 || side.firstObject.length >= 9;
     NSArray<NSString *> *rawSide = ApolloFTCrestRawTokens(team);
 
@@ -264,10 +288,19 @@ NSString *ApolloFTCrestURLForTeam(NSString *team, NSString *subreddit,
     NSInteger bestScore = 0, bestRaw = 0;
     NSUInteger bestExtra = NSUIntegerMax;
     for (ApolloFTCrestEntry *entry in ApolloFTCrestIndexForCatalogue(subreddit, catalogue)) {
-        NSInteger score = ApolloFTCrestScore(side, entry.tokens);
-        if (score == 0) continue;
-        NSUInteger extra = entry.tokens.count > side.count ? entry.tokens.count - side.count : 0;
-        if (score < 3 && (!specific || extra > 1)) continue;
+        ApolloFTCrestMatch score = ApolloFTCrestScore(side, entry.tokens);
+        if (score == ApolloFTCrestMatchNone) continue;
+        NSUInteger longer = MAX(entry.tokens.count, side.count), shorter = MIN(entry.tokens.count, side.count);
+        NSUInteger extra = longer - shorter;
+        if (score != ApolloFTCrestMatchExact) {
+            if (score == ApolloFTCrestMatchReverse) {
+                BOOL entryHasWord = NO;
+                for (NSString *token in entry.tokens) if (token.length >= 4) { entryHasWord = YES; break; }
+                if (!entryHasWord || extra > 2) continue;
+            } else if (!specific || extra > 1) {
+                continue;
+            }
+        }
         NSInteger raw = ApolloFTCrestScore(rawSide, entry.rawTokens);
         if (!best || score > bestScore || (score == bestScore && extra < bestExtra)
             || (score == bestScore && extra == bestExtra && raw > bestRaw)) {

--- a/src/ApolloFloatingTabsCrests.m
+++ b/src/ApolloFloatingTabsCrests.m
@@ -1,0 +1,283 @@
+#import "ApolloFloatingTabsCrests.h"
+
+// =============================================================================
+// MARK: - Title → two sides
+// =============================================================================
+
+static NSRegularExpression *ApolloFTCrestRegex(NSString *pattern) {
+    // Compiled once per pattern; the four patterns below are process-lifetime.
+    static NSMutableDictionary<NSString *, NSRegularExpression *> *cache;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [NSMutableDictionary dictionary]; });
+    @synchronized (cache) {
+        NSRegularExpression *regex = cache[pattern];
+        if (!regex) {
+            regex = [NSRegularExpression regularExpressionWithPattern:pattern
+                                                              options:NSRegularExpressionCaseInsensitive
+                                                                error:NULL];
+            if (regex) cache[pattern] = regex;
+        }
+        return regex;
+    }
+}
+
+static NSString *ApolloFTCrestCollapseWhitespace(NSString *text) {
+    NSArray<NSString *> *parts = [text componentsSeparatedByCharactersInSet:
+                                  [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSMutableArray<NSString *> *kept = [NSMutableArray array];
+    for (NSString *part in parts) if (part.length > 0) [kept addObject:part];
+    return [kept componentsJoinedByString:@" "];
+}
+
+// Trims separators/punctuation left over from the split ("Boston Celtics -",
+// "- Barcelona") and anything after a second separator on the away side.
+static NSString *ApolloFTCrestCleanSide(NSString *side) {
+    NSCharacterSet *junk = [NSCharacterSet characterSetWithCharactersInString:@" \t-–—:;,.|"];
+    NSString *cleaned = [side stringByTrimmingCharactersInSet:junk];
+    // "Barcelona - El Clásico": keep the team, drop the tagline.
+    NSRange tail = [cleaned rangeOfString:@"\\s+[-–—|]\\s+" options:NSRegularExpressionSearch];
+    if (tail.location != NSNotFound) cleaned = [cleaned substringToIndex:tail.location];
+    cleaned = [cleaned stringByTrimmingCharactersInSet:junk];
+    if (cleaned.length < 2 || cleaned.length > 40) return nil;
+    if ([cleaned rangeOfCharacterFromSet:[NSCharacterSet letterCharacterSet]].location == NSNotFound) return nil;
+    return cleaned;
+}
+
+BOOL ApolloFTCrestTeamsFromTitle(NSString *title, NSString **outHome, NSString **outAway) {
+    if (outHome) *outHome = nil;
+    if (outAway) *outAway = nil;
+    NSString *trimmed = ApolloFTCrestCollapseWhitespace(title ?: @"");
+    if (trimmed.length < 6) return NO;
+
+    // Gate + body: "<Kind> Thread: body" or "[<Kind> Thread] body". The prefix
+    // must say thread/game/GDT/PGT so an ordinary "Messi vs Ronaldo?" post
+    // never gets crests.
+    NSString *prefix = nil, *body = nil;
+    NSRegularExpression *bracket = ApolloFTCrestRegex(@"^\\[([^\\]]{1,40})\\]\\s*(.+)$");
+    NSRegularExpression *colon = ApolloFTCrestRegex(@"^([^:\\[\\]]{1,40}):\\s*(.+)$");
+    NSRange whole = NSMakeRange(0, trimmed.length);
+    NSTextCheckingResult *match = [bracket firstMatchInString:trimmed options:0 range:whole]
+                               ?: [colon firstMatchInString:trimmed options:0 range:whole];
+    if (!match) return NO;
+    prefix = [[trimmed substringWithRange:[match rangeAtIndex:1]] lowercaseString];
+    body = [trimmed substringWithRange:[match rangeAtIndex:2]];
+    BOOL gated = NO;
+    for (NSString *word in @[@"thread", @"game", @"gdt", @"pgt", @"match"]) {
+        if ([prefix rangeOfString:word].location != NSNotFound) { gated = YES; break; }
+    }
+    if (!gated) return NO;
+
+    // Body: stop at the competition/date segment, drop records and "(aet)".
+    NSRange pipe = [body rangeOfString:@"|"];
+    if (pipe.location != NSNotFound) body = [body substringToIndex:pipe.location];
+    body = [ApolloFTCrestRegex(@"\\([^)]*\\)") stringByReplacingMatchesInString:body options:0
+                                                                           range:NSMakeRange(0, body.length)
+                                                                    withTemplate:@" "];
+    body = ApolloFTCrestCollapseWhitespace(body);
+    if (body.length < 5) return NO;
+
+    // Score form first ("Spain 1 - 0 Argentina", "México 2-3 Inglaterra"),
+    // then a plain separator ("A vs B", "A vs. B", "A v B", "A @ B", "A at B").
+    NSArray<NSString *> *patterns = @[
+        @"^(.+?)\\s+\\d{1,3}\\s*[-–—]\\s*\\d{1,3}\\s+(.+)$",
+        @"^(.+?)\\s+(?:vs\\.?|v\\.?|@|at)\\s+(.+)$",
+    ];
+    for (NSString *pattern in patterns) {
+        NSTextCheckingResult *split = [ApolloFTCrestRegex(pattern) firstMatchInString:body options:0
+                                                                                  range:NSMakeRange(0, body.length)];
+        if (!split) continue;
+        NSString *home = ApolloFTCrestCleanSide([body substringWithRange:[split rangeAtIndex:1]]);
+        NSString *away = ApolloFTCrestCleanSide([body substringWithRange:[split rangeAtIndex:2]]);
+        if (!home || !away) return NO;
+        if (outHome) *outHome = home;
+        if (outAway) *outAway = away;
+        return YES;
+    }
+    return NO;
+}
+
+// =============================================================================
+// MARK: - Side → catalogue entry
+// =============================================================================
+
+// Club-form filler that carries no identity ("FC Porto" and "Porto" are the
+// same club). Deliberately excludes suffixes like "FA"/"AB" that the catalogue
+// uses to tell variants apart ("Argentina" vs "Argentina_FA").
+static NSSet<NSString *> *ApolloFTCrestFillerTokens(void) {
+    static NSSet<NSString *> *set;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        set = [NSSet setWithArray:@[
+            @"fc", @"cf", @"sc", @"ac", @"afc", @"ssc", @"as", @"us", @"ss", @"cd", @"ud", @"rcd", @"rc",
+            @"sd", @"ad", @"fk", @"sk", @"bk", @"if", @"fsv", @"vfb", @"vfl", @"tsg", @"tsv", @"sv",
+            @"spvgg", @"club", @"de", @"del", @"di", @"da", @"do", @"la", @"le", @"los", @"las", @"the",
+            @"of", @"and", @"y", @"e", @"cp", @"cs", @"ca", @"kv", @"rsc", @"nk", @"hnk", @"gnk", @"ks",
+            @"pfc", @"jk", @"sf", @"cfc", @"afc", @"sfc", @"cb", @"rb",
+        ]];
+    });
+    return set;
+}
+
+// Spellings the thread titles use that the catalogue writes differently.
+static NSDictionary<NSString *, NSString *> *ApolloFTCrestAliases(void) {
+    static NSDictionary<NSString *, NSString *> *aliases;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        aliases = @{
+            @"man": @"manchester", @"utd": @"united", @"munchen": @"munich", @"muenchen": @"munich",
+            @"st": @"saint", @"psg": @"paris saint germain", @"spurs": @"tottenham hotspur",
+        };
+    });
+    return aliases;
+}
+
+// Lowercase, accent-folded, punctuation-free identity tokens for a name.
+static NSArray<NSString *> *ApolloFTCrestTokens(NSString *name, BOOL applyAliases) {
+    NSString *folded = [name stringByFoldingWithOptions:(NSDiacriticInsensitiveSearch | NSCaseInsensitiveSearch |
+                                                         NSWidthInsensitiveSearch)
+                                                 locale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
+    NSMutableString *spaced = [NSMutableString stringWithCapacity:folded.length];
+    NSCharacterSet *alnum = [NSCharacterSet alphanumericCharacterSet];
+    for (NSUInteger i = 0; i < folded.length; i++) {
+        unichar c = [folded characterAtIndex:i];
+        unichar out = [alnum characterIsMember:c] ? c : (unichar)' ';
+        [spaced appendFormat:@"%C", out];
+    }
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    NSSet<NSString *> *filler = ApolloFTCrestFillerTokens();
+    NSCharacterSet *digits = [NSCharacterSet decimalDigitCharacterSet];
+    for (NSString *raw in [spaced componentsSeparatedByString:@" "]) {
+        NSString *token = raw.lowercaseString;
+        if (token.length == 0 || [filler containsObject:token]) continue;
+        if ([token rangeOfCharacterFromSet:digits.invertedSet].location == NSNotFound) continue; // "04", "1919"
+        NSString *alias = applyAliases ? ApolloFTCrestAliases()[token] : nil;
+        if (alias) [tokens addObjectsFromArray:[alias componentsSeparatedByString:@" "]];
+        else [tokens addObject:token];
+    }
+    return tokens;
+}
+
+// Same folding without the filler/alias/digit rules: the whole name as typed.
+static NSArray<NSString *> *ApolloFTCrestRawTokens(NSString *name) {
+    NSString *folded = [name stringByFoldingWithOptions:(NSDiacriticInsensitiveSearch | NSCaseInsensitiveSearch |
+                                                         NSWidthInsensitiveSearch)
+                                                 locale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    NSCharacterSet *alnum = [NSCharacterSet alphanumericCharacterSet];
+    for (NSString *raw in [folded componentsSeparatedByCharactersInSet:alnum.invertedSet]) {
+        if (raw.length > 0) [tokens addObject:raw.lowercaseString];
+    }
+    return tokens;
+}
+
+@interface ApolloFTCrestEntry : NSObject
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *url;
+@property (nonatomic, copy) NSArray<NSString *> *tokens;     // filler-free identity tokens
+@property (nonatomic, copy) NSArray<NSString *> *rawTokens;  // with fillers ("fc barcelona" vs "barcelona sc")
+@end
+@implementation ApolloFTCrestEntry
+@end
+
+// Normalised catalogue per subreddit, keyed on the catalogue array's identity
+// so a refreshed list re-indexes and a repeated lookup is a dictionary hit.
+static NSArray<ApolloFTCrestEntry *> *ApolloFTCrestIndexForCatalogue(NSString *subreddit,
+                                                                     NSArray<NSDictionary<NSString *, NSString *> *> *catalogue) {
+    static NSCache<NSString *, NSArray<ApolloFTCrestEntry *> *> *cache;
+    static NSMutableDictionary<NSString *, NSValue *> *sources;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        cache = [NSCache new];
+        cache.countLimit = 8;
+        sources = [NSMutableDictionary dictionary];
+    });
+    NSString *key = subreddit.lowercaseString ?: @"";
+    @synchronized (sources) {
+        NSArray<ApolloFTCrestEntry *> *index = [cache objectForKey:key];
+        if (index && [sources[key] pointerValue] == (__bridge void *)catalogue) return index;
+        NSMutableArray<ApolloFTCrestEntry *> *built = [NSMutableArray arrayWithCapacity:catalogue.count];
+        for (NSDictionary *raw in catalogue) {
+            NSString *name = raw[@"name"], *url = raw[@"url"];
+            if (![name isKindOfClass:[NSString class]] || ![url isKindOfClass:[NSString class]]) continue;
+            NSArray<NSString *> *tokens = ApolloFTCrestTokens(name, NO);
+            if (tokens.count == 0) continue;
+            ApolloFTCrestEntry *entry = [ApolloFTCrestEntry new];
+            entry.name = name;
+            entry.url = url;
+            entry.tokens = tokens;
+            entry.rawTokens = ApolloFTCrestRawTokens(name);
+            [built addObject:entry];
+        }
+        [cache setObject:built forKey:key];
+        sources[key] = [NSValue valueWithPointer:(__bridge void *)catalogue];
+        return built;
+    }
+}
+
+// 3 = identical tokens, 2 = every side token present verbatim, 1 = every side
+// token present verbatim or as a ≥3-character prefix either way, 0 = no.
+static NSInteger ApolloFTCrestScore(NSArray<NSString *> *side, NSArray<NSString *> *candidate) {
+    if ([side isEqualToArray:candidate]) return 3;
+    BOOL allExact = YES, allPrefix = YES;
+    for (NSString *token in side) {
+        BOOL exact = NO, prefix = NO;
+        for (NSString *other in candidate) {
+            if ([other isEqualToString:token]) { exact = YES; break; }
+            NSString *shorter = token.length <= other.length ? token : other;
+            NSString *longer = token.length <= other.length ? other : token;
+            if (shorter.length >= 3 && [longer hasPrefix:shorter]) prefix = YES;
+        }
+        if (!exact) allExact = NO;
+        if (!exact && !prefix) allPrefix = NO;
+    }
+    if (allExact) return 2;
+    if (allPrefix) return 1;
+    return 0;
+}
+
+NSString *ApolloFTCrestURLForTeam(NSString *team, NSString *subreddit,
+                                  NSArray<NSDictionary<NSString *, NSString *> *> *catalogue,
+                                  NSString **outName) {
+    if (outName) *outName = nil;
+    NSArray<NSString *> *side = ApolloFTCrestTokens(team ?: @"", YES);
+    if (side.count == 0 || catalogue.count == 0) return nil;
+    // A side must carry at least one distinctive token; "AC" alone is nothing.
+    BOOL distinctive = NO;
+    for (NSString *token in side) if (token.length >= 4) { distinctive = YES; break; }
+    if (!distinctive) return nil;
+
+    // A partial (subset) match is only trusted when the side is specific
+    // enough: two words, or one long word ("Internazionale", "Leverkusen"),
+    // and the candidate adds at most one word ("Borussia Dortmund" for
+    // "Dortmund" is fine; "Chattanooga Red Wolves" for "Wolves" is not). The
+    // catalogue Reddit returns is capped, so a club's real entry can be
+    // missing and a namesake must not be picked in its place.
+    BOOL specific = side.count >= 2 || side.firstObject.length >= 9;
+    NSArray<NSString *> *rawSide = ApolloFTCrestRawTokens(team);
+
+    // Rank: score, then fewer extra identity tokens, then the raw name with
+    // fillers ("FC Barcelona" → FC_Barcelona, not Barcelona_SC). Anything
+    // still tied between different crests is a guess, and a wrong crest is
+    // far worse than the letter fallback — treat it as a miss.
+    ApolloFTCrestEntry *best = nil;
+    BOOL tied = NO;
+    NSInteger bestScore = 0, bestRaw = 0;
+    NSUInteger bestExtra = NSUIntegerMax;
+    for (ApolloFTCrestEntry *entry in ApolloFTCrestIndexForCatalogue(subreddit, catalogue)) {
+        NSInteger score = ApolloFTCrestScore(side, entry.tokens);
+        if (score == 0) continue;
+        NSUInteger extra = entry.tokens.count > side.count ? entry.tokens.count - side.count : 0;
+        if (score < 3 && (!specific || extra > 1)) continue;
+        NSInteger raw = ApolloFTCrestScore(rawSide, entry.rawTokens);
+        if (!best || score > bestScore || (score == bestScore && extra < bestExtra)
+            || (score == bestScore && extra == bestExtra && raw > bestRaw)) {
+            best = entry; bestScore = score; bestExtra = extra; bestRaw = raw; tied = NO;
+        } else if (score == bestScore && extra == bestExtra && raw == bestRaw
+                   && ![entry.url isEqualToString:best.url]) {
+            tied = YES;
+        }
+    }
+    if (!best || tied) return nil;
+    if (outName) *outName = best.name;
+    return best.url;
+}

--- a/src/ApolloUserFlair.h
+++ b/src/ApolloUserFlair.h
@@ -23,4 +23,9 @@ NSArray *_Nullable ApolloUserFlairBuildPiecesForText(NSString *flairText, NSStri
 // arbitrary queue). Fires immediately when the catalogue is already warm.
 void ApolloUserFlairEnsureEmojisForSubreddit(NSString *subreddit, void (^completion)(void));
 
+// The cached catalogue for a subreddit as @[ @{ @"name": token, @"url": png } ],
+// or nil when it hasn't been fetched yet (call the ensure function first).
+// Synchronous, network-free; a partial catalogue is returned as-is.
+NSArray<NSDictionary<NSString *, NSString *> *> *_Nullable ApolloUserFlairCachedEmojisForSubreddit(NSString *subreddit);
+
 NS_ASSUME_NONNULL_END

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -2000,6 +2000,14 @@ NSArray *ApolloUserFlairBuildPiecesForText(NSString *flairText, NSString *subred
     return ApolloUserFlairPiecesFromFlairText(flairText, subreddit.lowercaseString);
 }
 
+NSArray<NSDictionary<NSString *, NSString *> *> *ApolloUserFlairCachedEmojisForSubreddit(NSString *subreddit) {
+    NSString *key = subreddit.lowercaseString;
+    if (key.length == 0) return nil;
+    @synchronized (sApolloUserFlairEmojiCacheLock) {
+        return [ApolloUserFlairEmojiListCache()[key] copy];
+    }
+}
+
 void ApolloUserFlairEnsureEmojisForSubreddit(NSString *subreddit, void (^completion)(void)) {
     if (!completion) return;
     if (subreddit.length == 0) { completion(); return; }


### PR DESCRIPTION
## Updates and Fixes

| <img width="320" alt="Match thread tabs show the two teams' crests" src="https://github.com/user-attachments/assets/28947905-33f9-433c-af18-eb5b7686be3c" /> | <img width="320" alt="Posts with a thumbnail use it as the tab face" src="https://github.com/user-attachments/assets/939d17e8-31ad-48fb-8509-708a10aaa53c" /> |
|:--:|:--:|
| **Match threads** show the two teams' crests half and half, pulled from the subreddit's own flair crests, with the subreddit icon on the rim. If a crest can't be matched the tab falls back to a letter. | **Everything else** keeps working as before: a post with a thumbnail uses it as the tab face, a text post shows the subreddit icon, and two text posts from the same subreddit get a big letter each so they don't look like twins. |


## Summary

Two thumbless posts from the same subreddit used to be near-identical bubbles: the subreddit icon as the face and a 12pt letter on the rim, and for r/soccer match threads even the letter was the same ("Match Thread:" → M / M). Three layers, each derived from data the tweak already has, in priority order after a real post thumbnail:

**1. Crest faces for match threads.** A match-thread title ("Match Thread: FC Porto vs Manchester City | UEFA Champions League", "Post Match Thread: Spain 1 - 0 Argentina | …", "GAME THREAD: Lakers (10-5) @ Celtics (12-3) - (…)") is parsed into its two sides, each side is matched against the subreddit's user-flair emoji catalogue (r/soccer's is the club crests, already fetched and cached by `ApolloUserFlair` for the flair picker in both API-key and keyless modes), and the two crest PNGs are composed half-and-half into the bubble face with the subreddit icon on the rim. No outside service.
- Parser gate: the title prefix must read like a thread ("… Thread:", "[… Thread]", "GDT:", "GAME THREAD:"), so an ordinary "Messi vs Ronaldo?" post is never parsed. Handles "vs", "vs.", "v", "@", "at", score forms ("2-3", "1 - 0"), bracket records, "(aet)", and a trailing tagline after a dash.
- Matcher never guesses: club fillers ("FC", "SC", "de", …) are ignored; a partial match needs a specific side (two words, or one word of 9+ letters) and at most one extra word on the candidate ("Olympique de Marseille" for "Marseille" yes, "Chattanooga Red Wolves" for "Wolves" never, "Dortmund" alone is too weak); the raw name breaks ties ("FC Barcelona" → FC_Barcelona, not Barcelona_SC); anything still tied between different crests is a miss. A wrong crest is worse than the letter fallback.
- Resolution is async and per tab: unresolved → pending → matched / none, with an attempt cap of 3 per launch. A missing catalogue (offline) stays retryable, a "no crest" verdict is final for the launch, an image failure retries on the next identity refresh without triggering one itself (no failure loop). Nothing new is persisted; restored tabs re-resolve from their saved titles. Composed faces live in a count-limited `NSCache` and are re-fetched on demand after eviction. Async blocks hold the controller and the tab weakly.
- Coverage follows the catalogue: the API returns all 2,541 r/soccer emoji; the keyless web path gets the ~2,000 the old-Reddit flair selector embeds, so a club missing there (Spain, Sevilla, Tottenham, …) falls back to letters under a keyless account. Competition logos (UCL, World Cup, …) are not in the catalogue, so there is no competition badge.
- Other sports subs (checked against their real catalogues): r/nfl names teams by nickname ("Chiefs", "Bills") and r/CFB by space-less school ("ohiostate", "notredame", "texasam"), so the matcher also accepts an entry whose words all sit inside the side ("Kansas City Chiefs" → Chiefs; ranked last so "Inter Milan" still goes to Internazionale, not AC_Milan) and equality once spaces are removed. r/nba ("lal-1") and r/baseball ("bos2") use codes and r/hockey plain numbers, so those still miss and show letters; a per-league code table is a follow-up, not in this PR.

**Appearance.** The crest disc is rendered twice (near-white / charcoal, matching divider) and registered in one `UIImageAsset`, so it follows the bubble's light/dark appearance like the monogram and badge colours already do. That surfaced a gap the overlay always had: it's its own `UIWindow`, so it followed the *system* appearance while Apollo's window can be forced dark or light (Theme Manager › Light/Dark Mode set to manual or scheduled), leaving every bubble light on a dark app. The overlay now mirrors Apollo's window override, at creation and from a `UIWindow setOverrideUserInterfaceStyle:` hook (first-line bail without an overlay; ignores the overlay itself and non-app windows). The mirror is deferred one runloop turn because `ApolloThemeRuntime`'s repaint flips every window's override (ours included) and restores each from a snapshot on the next turn; a synchronous mirror got captured as the snapshot and left the overlay dark on a light app after a theme change.

**2. Letter faces for colliding text posts.** When two subreddit-faced tabs collide, each becomes the big accent monogram of its distinguishing letter with the subreddit icon on the rim, mirroring the thumbnail layout instead of hiding a tiny letter in the badge. The letter comes from the group lettering below.

**3. Group lettering** (first commit). Titles are compared word by word and tabs still tied on an initial are refined one word deeper until they split, so the letter is the first word that tells a tab apart, never a prefix they all share:

| tabs | before | after |
|---|---|---|
| Match Thread: Real Madrid vs Inter / Match Thread: Bayern vs Chelsea | M / M | R / B |
| Match Thread: Real Madrid … / Post Match Thread: Real Madrid … | M / P | M / P |
| Match Thread: Real Madrid … / Match Thread: Real Sociedad … | M / M | M / S |
| [Serious] Foo bar / [Serious] Baz qux | S / S | F / B |

A lone text post keeps the subreddit icon face with no badge, exactly as today. Thumbnail-faced tabs are untouched.

**Code:** parser + matcher are Foundation-only in `src/ApolloFloatingTabsCrests.{h,m}` (host-testable); `ApolloUserFlair` exports a read-only `ApolloUserFlairCachedEmojisForSubreddit` (under its existing lock, no behaviour change); everything else is in `ApolloFloatingTabs.xm`. No new hooks or settings. Sim-only: `floattab emojis <sub>` dumps a catalogue, and `floattab state` shows each face kind (crests / monogram / image) and badge.

## Verification

- Branch is on current `apollo-reborn/main` (68efa1b), fast-forward merge; no open PR touches `ApolloFloatingTabs.xm` or `ApolloUserFlair.{h,xm}` (the `Makefile` change is one added line next to the existing entry, like the other open PRs' additions). `git diff --check` clean. `make package` with the pinned iOS 26.0 SDK and the sim build both build clean, no warnings in the touched files.
- Host harness (Foundation only): 17 lettering cases; 19 title-parse cases incl. the gated-out ones (NBA/NHL/NFL/CFB title forms included); 80+ crest-match cases run against the real catalogues dumped from the sim — both r/soccer lists (1,994-entry keyless, 2,541-entry API) plus r/nfl, r/CFB and r/nba — covering nickname and space-less entries (Chiefs, ohiostate, USC), code catalogues that must miss (Lakers → not bw-lakers), variant entries (Aston_Villa_AB, Chelsea_s_Rampant_Lion, Argentina_FA, b_Spain, c_Tottenham, Sevilla_Atletico), ties (Rangers_FC vs FC_Rangers, FC_Barcelona vs Barcelona_SC → miss), namesakes when the real entry is missing (Sporting CP → never Defensor_Sporting, Wolves → never Chattanooga_Red_Wolves), aliases (Man City, Man Utd, PSG, München). All pass.
- Sim Apollo-FloatTabs, `[FloatingTabs] Module loaded; menu spec registered` + `Overlay window created` on launch:
  - Keyless account (u/remzerobestgirl), non-glass shell: pinned "Match Thread: Aston Villa vs. Arsenal" and "Match Thread: Arsenal vs Chelsea" → `Crests: r/soccer Aston_Villa / Arsenal` and `Arsenal / Chelsea`, faces are the crest pairs with the soccer icon on the rim. Added "Post Match Thread: Spain 1 - 0 Argentina" → `"Spain" → no crest … letter fallback` (partial keyless catalogue), plus a Daily Discussion tab → those two show letter faces P / D. State dump: `face=crests badge=image` ×2, `face=monogram badge=image` ×2.
  - API-key account (u/iChopPryde), Liquid Glass shell, cold relaunch: catalogue is the full 2,541 (`[UserFlair] fetched 2541 … keyless=no`), all three match threads resolve (Spain / Argentina included), the Daily Discussion tab is alone → plain subreddit icon, no badge.
  - Relaunch restores every face from the saved titles; closing a tab re-letters the rest (M / P), verified in the first round.
  - r/nfl: pinned "Post Game Thread: Green Bay Packers at Chicago Bears" → `Crests: r/nfl Packers / Bears`, NFL icon on the rim.
  - Appearance (state dump prints `overlayStyle` / `appWindowOverride` / `appWindowStyle`): system dark → charcoal discs, overlay 2/app 2; Apollo manual Dark on a light system → overlay mirrors 2 at launch and live; manual Light → 1; Use System back on → override 0, overlay follows the system; two theme changes (Default, Custom) through the runtime's flip-repaint leave the overlay equal to the app window every time (this is the case that was stuck dark before the deferral).
- Hooks: one new `%hook UIWindow -setOverrideUserInterfaceStyle:` (public UIKit API, no Hopper needed; no other module hooks it). Not applicable: iPad width (fixed bubble geometry), cancelled swipe-back (no nav state). No gestures over WebKit; memory is bounded (count-limited caches, evictable, re-fetch on demand).
- Device (iPhone, Liquid Glass build, API-key account): pinned three r/soccer match threads over a session, each resolved to crests with no fallbacks or fetch failures in the log: `Crests: r/soccer NEC_Nijmegen / Excelsior_Rotterdam`, `FC_Southampton / Swansea_City_AFC`, `Blackburn_Rovers / Sheffield_United_FC`, the last two from the part of the catalogue the keyless path can't see. The r/soccer catalogue came back as the full 2,541 (`keyless=no`), the first crest landed ~280 ms after the pin (catalogue fetch included) and later ones within ~40 ms. Also exercised on the phone: switching between two retained tabs, cold tabs reopening through the URL router, closing tabs down to zero with the overlay tearing down, and non-match tabs (r/StableDiffusion, r/ChatGPT) alongside the crest ones.

