### PR TITLE
Consolidate Profile and Subreddit Layout settings under new Layout section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloAISettingsViewController.m \
     $(SRC_DIR)/settings/ApolloDeletedCommentsSettingsViewController.m \
     $(SRC_DIR)/settings/ApolloProfileLayoutViewController.m \
+    $(SRC_DIR)/settings/ApolloLayoutViewController.m \
     $(SRC_DIR)/settings/ApolloLayoutPreviewCard.m \
     $(SRC_DIR)/settings/ApolloLinkPreviewSettingsViewController.m \
     $(SRC_DIR)/settings/InlineMediaSettingsViewController.m \

--- a/src/settings/ApolloLayoutViewController.h
+++ b/src/settings/ApolloLayoutViewController.h
@@ -1,0 +1,6 @@
+#import "ApolloSettingsForm.h"
+
+// Dedicated "Layout" screen for profile and subreddit layout settings.
+// The individual settings remain in their existing dedicated controllers.
+@interface ApolloLayoutViewController : ApolloSettingsFormViewController
+@end

--- a/src/settings/ApolloLayoutViewController.m
+++ b/src/settings/ApolloLayoutViewController.m
@@ -11,6 +11,13 @@
     self.title = @"Layout";
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    [self reloadRowWithID:@"layout.profile"];
+    [self reloadRowWithID:@"layout.subreddit"];
+}
+
 - (NSString *)profileLayoutSummaryText {
     if (!sShowDetailedProfiles) {
         return @"Native";

--- a/src/settings/ApolloLayoutViewController.m
+++ b/src/settings/ApolloLayoutViewController.m
@@ -1,0 +1,79 @@
+#import "ApolloLayoutViewController.h"
+
+#import "settings/ApolloProfileLayoutViewController.h"
+#import "settings/ApolloSubredditLayoutViewController.h"
+#import "ApolloState.h"
+
+@implementation ApolloLayoutViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Layout";
+}
+
+- (NSString *)profileLayoutSummaryText {
+    if (!sShowDetailedProfiles) {
+        return @"Native";
+    }
+
+    return sProfileHeaderImmersive ? @"Immersive" : @"Compact";
+}
+
+- (NSString *)subredditLayoutSummaryText {
+    NSString *layout;
+
+    if (!sShowSubredditHeaders) {
+        layout = @"Native";
+    } else {
+        layout = sSubredditHeaderImmersive ? @"Immersive" : @"Compact";
+    }
+
+    NSString *highlights;
+
+    if (!sCommunityHighlights) {
+        highlights = @"Off";
+    } else if (sCommunityHighlightsWeb) {
+        highlights = @"Full";
+    } else {
+        highlights = @"Partial";
+    }
+
+    return [NSString stringWithFormat:@"%@ · Highlights: %@", layout, highlights];
+}
+
+- (NSArray<ApolloSettingsSection *> *)buildForm {
+    __weak typeof(self) weakSelf = self;
+
+    ApolloSettingsRow *profileLayout =
+        [self hubDisclosureRowWithID:@"layout.profile"
+                               title:@"Profile Layout"
+                            subtitle:^NSString * {
+        return [weakSelf profileLayoutSummaryText];
+    }
+                                push:^UIViewController * {
+        return [[ApolloProfileLayoutViewController alloc]
+            initWithStyle:UITableViewStyleInsetGrouped];
+    }];
+
+    ApolloSettingsRow *subredditLayout =
+        [self hubDisclosureRowWithID:@"layout.subreddit"
+                               title:@"Subreddit Layout"
+                            subtitle:^NSString * {
+        return [weakSelf subredditLayoutSummaryText];
+    }
+                                push:^UIViewController * {
+        return [[ApolloSubredditLayoutViewController alloc]
+            initWithStyle:UITableViewStyleInsetGrouped];
+    }];
+
+    return @[
+        [ApolloSettingsSection sectionWithTitle:nil
+                                         footer:nil
+                                           rows:@[
+            profileLayout,
+            subredditLayout
+        ]]
+    ];
+}
+
+@end

--- a/src/settings/ApolloSettingsForm.h
+++ b/src/settings/ApolloSettingsForm.h
@@ -111,6 +111,11 @@ typedef UITableViewCell *_Nonnull (^ApolloSettingsCellBlock)(UITableView *tableV
 // Override: return the full model (including conditionally-visible rows).
 // Called once from viewDidLoad; call -rebuildForm to rebuild from scratch.
 - (NSArray<ApolloSettingsSection *> *)buildForm;
+// Shared plain disclosure-row builder for settings navigation rows.
+- (ApolloSettingsRow *)hubDisclosureRowWithID:(NSString *)rowID
+                                        title:(NSString *)title
+                                     subtitle:(nullable NSString * (^)(void))subtitle
+                                         push:(UIViewController * (^)(void))makeVC;
 
 // Recompute row visibility and animate the per-section insert/delete diff.
 - (void)visibilityDidChange;

--- a/src/settings/ApolloSettingsForm.m
+++ b/src/settings/ApolloSettingsForm.m
@@ -173,6 +173,42 @@ static const void *kApolloSFSwitchRowKey = &kApolloSFSwitchRowKey;
     BOOL _footerHeightCheckPending;
 }
 
+// Shared plain disclosure-row builder for settings navigation rows.
+- (ApolloSettingsRow *)hubDisclosureRowWithID:(NSString *)rowID
+                                        title:(NSString *)title
+                                    subtitle:(nullable NSString * (^)(void))subtitle
+                                        push:(UIViewController * (^)(void))makeVC {
+    __weak typeof(self) weakSelf = self;
+    NSString *reuseID = [@"Cell_Hub_" stringByAppendingString:rowID];
+    return [ApolloSettingsRow customRowWithID:rowID
+                                        cell:^UITableViewCell *(UITableView *tableView, __unused ApolloSettingsRow *row) {
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseID];
+        if (!cell) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseID];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            cell.detailTextLabel.numberOfLines = 0;
+            cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+        }
+        cell.textLabel.text = title;
+        cell.textLabel.numberOfLines = 0;
+        cell.detailTextLabel.text = subtitle ? subtitle() : nil;
+        [weakSelf apollo_applyPrimaryTextColorToCell:cell];
+        return cell;
+    }
+                                    onSelect:^{
+        UIViewController *vc = makeVC();
+        if (!vc) return;
+        if (weakSelf.navigationController) {
+            [weakSelf.navigationController pushViewController:vc animated:YES];
+        } else {
+            UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:vc];
+            [weakSelf presentViewController:navigation animated:YES completion:nil];
+        }
+    }];
+}
+
 - (NSArray<ApolloSettingsSection *> *)buildForm {
     return @[];   // subclass responsibility
 }

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1016,7 +1016,6 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (ApolloSettingsSection *)buildFeaturesSection {
-    __weak typeof(self) weakSelf = self;
 
     ApolloSettingsRow *posts =
         [self hubDisclosureRowWithID:@"feat.posts" title:@"Posts & Feeds" subtitle:nil
@@ -2323,7 +2322,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
 
     return [ApolloSettingsSection sectionWithTitle:nil
                                             footer:@"Feed Shortcuts customizes the Home, Popular, All and Moderator Posts rows — their icons, layout, visibility and descriptions. Subreddit Sections arranges the rest of the subreddit list — section order, followed users, multireddit descriptions and the list style toggles live there."
-                                              rows:@[ feedShortcuts, subredditSections, subredditLayout ]];
+                                              rows:@[ feedShortcuts, subredditSections ]];
 }
 
 - (ApolloSettingsSection *)buildFeedShortcutsVisibilitySection {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -963,43 +963,6 @@ typedef NS_ENUM(NSInteger, Tag) {
                                               rows:@[ themeManager, openInApp, pip, translation, savedCategories, tagFilters, colorFlairs ]];
 }
 
-// Shared plain disclosure-row builder for the hub's navigation rows: title
-// (+ optional status subtitle block, re-evaluated on reload) and a push.
-- (ApolloSettingsRow *)hubDisclosureRowWithID:(NSString *)rowID
-                                        title:(NSString *)title
-                                     subtitle:(NSString * (^)(void))subtitle
-                                         push:(UIViewController * (^)(void))makeVC {
-    __weak typeof(self) weakSelf = self;
-    NSString *reuseID = [@"Cell_Hub_" stringByAppendingString:rowID];
-    return [ApolloSettingsRow customRowWithID:rowID
-                                         cell:^UITableViewCell *(UITableView *tableView, __unused ApolloSettingsRow *row) {
-        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseID];
-        if (!cell) {
-            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseID];
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            cell.detailTextLabel.numberOfLines = 0;
-            cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
-        }
-        cell.textLabel.text = title;
-        cell.textLabel.numberOfLines = 0;
-        cell.detailTextLabel.text = subtitle ? subtitle() : nil;
-        [weakSelf apollo_applyPrimaryTextColorToCell:cell];
-        return cell;
-    }
-                                     onSelect:^{
-        UIViewController *vc = makeVC();
-        if (!vc) return;
-        if (weakSelf.navigationController) {
-            [weakSelf.navigationController pushViewController:vc animated:YES];
-        } else {
-            UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:vc];
-            [weakSelf presentViewController:navigation animated:YES completion:nil];
-        }
-    }];
-}
-
 - (ApolloSettingsSection *)buildSetupSection {
     ApolloSettingsRow *apiKeys =
         [self hubDisclosureRowWithID:@"setup.apiKeys"

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1002,8 +1002,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         }];
     ApolloSettingsRow *layout =
         [self hubDisclosureRowWithID:@"feat.layout"
-                               title:@"Layout"
-                            subtitle:^NSString * { return @"Profiles and subreddits"; }
+                               title:@"Profiles & Subreddits Layout"
+                            subtitle:nil
                                 push:^UIViewController * {
             return [[ApolloLayoutViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
         }];

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -28,7 +28,7 @@
 #import "ApolloLinkPreviewShapeMemory.h"
 #import "settings/ApolloDeletedCommentsSettingsViewController.h"
 #import "settings/ApolloLinkPreviewSettingsViewController.h"
-#import "settings/ApolloProfileLayoutViewController.h"
+#import "settings/ApolloLayoutViewController.h"
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
 #import "ApolloSubredditInfoCache.h"
@@ -52,7 +52,6 @@
 #import "crash/ApolloCrashReportsViewController.h"
 #import "settings/ApolloOpenInAppViewController.h"
 #import "settings/SavedCategoriesViewController.h"
-#import "settings/ApolloSubredditLayoutViewController.h"
 #import "settings/ApolloSubredditSectionsViewController.h"
 #import "ApolloFollowingSection.h"
 #import "settings/TranslationSettingsViewController.h"
@@ -841,9 +840,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     // returning to Interface or after preferences are restored elsewhere.
     [self reloadRowWithID:@"interface.hideBarsOnScroll"];
     [self reloadRowWithID:@"interface.tabBarScrollBehavior"];
-    // Refresh the Profile Layout summary after returning from that screen
-    // (Density/Avatar/band switches may have just changed).
-    [self reloadRowWithID:@"feat.profileLayout"];
+    // Refresh the Layout summaries after returning from that screen.
+    [self reloadRowWithID:@"feat.layout"];
     // The Setup section footer (onboarding nudge) collapses once a Reddit key
     // exists, which may have just been entered on the pushed API Keys screen.
     // Section 0 is Setup on the hub; reloading it re-evaluates the footer.
@@ -1040,12 +1038,12 @@ typedef NS_ENUM(NSInteger, Tag) {
                                 push:^UIViewController * {
             return [[ApolloSubredditsSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
         }];
-    ApolloSettingsRow *profileLayout =
-        [self hubDisclosureRowWithID:@"feat.profileLayout"
-                               title:@"Profile Layout"
-                            subtitle:^NSString * { return [weakSelf profileLayoutSummaryText]; }
+    ApolloSettingsRow *layout =
+        [self hubDisclosureRowWithID:@"feat.layout"
+                               title:@"Layout"
+                            subtitle:^NSString * { return @"Profiles and subreddits"; }
                                 push:^UIViewController * {
-            return [[ApolloProfileLayoutViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+            return [[ApolloLayoutViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
         }];
     ApolloSettingsRow *interface_ =
         [self hubDisclosureRowWithID:@"feat.interface" title:@"Interface" subtitle:nil
@@ -1060,15 +1058,15 @@ typedef NS_ENUM(NSInteger, Tag) {
     comments.iconSystemName     = @"text.bubble.fill";            comments.iconTileColor     = [UIColor systemGreenColor];
     media.iconSystemName        = @"play.rectangle.fill";         media.iconTileColor        = [UIColor systemPinkColor];
     subreddits.iconSystemName   = @"person.3.fill";               subreddits.iconTileColor   = [UIColor systemRedColor];
-    profileLayout.iconSystemName = @"person.crop.circle.fill";   profileLayout.iconTileColor = [UIColor systemTealColor];
+    layout.iconSystemName = @"photo.fill.on.rectangle.fill";      layout.iconTileColor       = [UIColor systemTealColor];
     interface_.iconSystemName   = @"slider.horizontal.3";         interface_.iconTileColor   = [UIColor systemPurpleColor];
     linkPreviews.iconSystemName = @"link";                        linkPreviews.iconTileColor = [UIColor systemBlueColor];
     polls.iconSystemName        = @"chart.bar.fill";              polls.iconTileColor        = [UIColor systemYellowColor];
     apolloAI.iconSystemName     = @"sparkles";                    apolloAI.iconTileColor     = [UIColor systemIndigoColor];
 
     return [ApolloSettingsSection sectionWithTitle:@"Features"
-                                            footer:@"Fine-tune posts, comments, media, subreddits, profile layout and the interface."
-                                              rows:@[ posts, comments, media, subreddits, profileLayout, interface_,
+                                            footer:nil
+                                              rows:@[ posts, comments, media, subreddits, layout, interface_,
                                                       linkPreviews, polls, apolloAI ]];
 }
 
@@ -2295,26 +2293,6 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
                                               rows:@[ proxyImgur, albumFallback ]];
 }
 
-- (NSString *)profileLayoutSummaryText {
-    if (!sShowDetailedProfiles) return @"Native (Apollo)";
-    NSMutableArray<NSString *> *parts = [NSMutableArray array];
-    [parts addObject:sProfileHeaderImmersive ? @"Immersive" : @"Compact"];
-    switch (sProfileAvatarStyle) {
-        case 1:  [parts addObject:@"Circle"]; break;
-        case 2:  [parts addObject:@"Square"]; break;
-        default: [parts addObject:@"Full"]; break;
-    }
-    NSInteger hiddenCount = (!sProfileShowBanner ? 1 : 0)
-        + (!sProfileShowStatCards ? 1 : 0)
-        + (!sProfileShowSocialLinks ? 1 : 0)
-        + (!sBadgeBookEnabled ? 1 : 0)
-        + (!sProfileShowActions ? 1 : 0);
-    if (hiddenCount > 0) {
-        [parts addObject:[NSString stringWithFormat:@"%ld hidden", (long)hiddenCount]];
-    }
-    return [parts componentsJoinedByString:@" · "];
-}
-
 // Subreddits group screen (ApolloSubredditsSettingsViewController), two
 // sections: the list/browsing toggles and the custom Sources.
 - (ApolloSettingsSection *)buildSubredditsMainSection {
@@ -2332,19 +2310,6 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             return ApolloSettingsRouteInstantiate(@"feed-shortcuts");
         }];
 
-    // Pushes the dedicated Subreddit Layout screen — the single customize
-    // screen for everything subreddit-page-related: Density (New, Classic, or
-    // Apollo's native header), the Apollo Reborn header show switches, and
-    // Community Highlights (also a subreddit-page feature, not a
-    // subreddit-list one).
-    ApolloSettingsRow *subredditLayout =
-        [self hubDisclosureRowWithID:@"sub.layout"
-                                title:@"Subreddit Layout"
-                             subtitle:^NSString * { return [weakSelf subredditLayoutSummaryText]; }
-                                 push:^UIViewController * {
-            return [[ApolloSubredditLayoutViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
-        }];
-
     // Pushes the dedicated Subreddit Sections screen: the FOLLOWING section
     // for followed users, drag-to-reorder for the special sections, and a
     // live preview of the list layout (see ApolloSubredditSectionsViewController).
@@ -2357,7 +2322,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
         }];
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Feed Shortcuts customizes the Home, Popular, All and Moderator Posts rows — their icons, layout, visibility and descriptions. Subreddit Sections arranges the rest of the subreddit list — section order, followed users, multireddit descriptions and the list style toggles live there. Subreddit Layout customizes subreddit pages."
+                                            footer:@"Feed Shortcuts customizes the Home, Popular, All and Moderator Posts rows — their icons, layout, visibility and descriptions. Subreddit Sections arranges the rest of the subreddit list — section order, followed users, multireddit descriptions and the list style toggles live there."
                                               rows:@[ feedShortcuts, subredditSections, subredditLayout ]];
 }
 
@@ -2531,20 +2496,6 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     return [ApolloSettingsSection sectionWithTitle:@"Favorites"
                                             footer:@"Per-Account Favorites saves a separate list and sorting preference for each account. First enable copies the current list to existing accounts; new accounts start empty. Turning it off restores the shared list.\nAlphabetical sorting keeps existing and new favorites in order. Turn it off to rearrange them manually while editing the subreddit list."
                                               rows:@[ perAccountFavorites, sortFavoritesAlphabetically ]];
-}
-
-- (NSString *)subredditLayoutSummaryText {
-    if (!sShowSubredditHeaders) return @"Native (Apollo)";
-    NSMutableArray<NSString *> *parts = [NSMutableArray array];
-    [parts addObject:sSubredditHeaderImmersive ? @"New (Immersive)" : @"Classic (Compact)"];
-    NSMutableArray<NSString *> *hidden = [NSMutableArray array];
-    if (!sSubredditShowBanner) [hidden addObject:@"Banner"];
-    if (!sSubredditShowJoinButton) [hidden addObject:@"Join Button"];
-    if (!sSubredditShowDisplayName) [hidden addObject:@"Subreddit Name"];
-    if (hidden.count > 0) {
-        [parts addObject:[NSString stringWithFormat:@"%@ off", [hidden componentsJoinedByString:@", "]]];
-    }
-    return [parts componentsJoinedByString:@" · "];
 }
 
 - (ApolloSettingsSection *)buildSubredditsSourcesSection {


### PR DESCRIPTION
Adds a new top-level **Layout** settings screen alongside **Subreddit List** (formerly **Subreddits**).

The new Layout screen contains **Profile Layout** and **Subreddit Layout**, consolidating the two layout-related settings in one place.

Subreddit List now contains its relevant settings - Feed Shortcuts, Subreddit List Sections and Per-Account Favorites. (Sources still lives here for now, though this relates to the Search tab.)

Also moves the shared disclosure-row builder into ApolloSettingsForm so it can be reused by the new Layout controller.