### PR TITLE
Restore Hidden header style option

### DIFF
--- a/src/ApolloScrollEdgeEffect.xm
+++ b/src/ApolloScrollEdgeEffect.xm
@@ -12,8 +12,9 @@
 // rendered where content scrolls under the nav/tab bars. iOS 26 defaults to a
 // soft gradient blur; iOS 27 betas default to a hard cutoff with a dividing
 // line, which some users find jarring. The "Header Style" setting lets users
-// choose the TOP (header) edge treatment explicitly: Soft, Hard, or Blur (a
-// tweak-drawn progressive blur — see ApolloProgressiveBlur.xm).
+// choose the TOP (header) edge treatment explicitly: Soft, Hard, Blur (a
+// tweak-drawn progressive blur — see ApolloProgressiveBlur.xm), or Hidden
+// (no native edge effect and no replacement blur).
 //
 // Only the top edge is ever touched. Earlier builds applied the chosen style
 // to all four edges, which painted a hard band behind the tab bar in Hard
@@ -57,6 +58,10 @@ NSInteger ApolloResolvedScrollEdgeEffectStyle(void) {
         sSystemDefaultsHard = [NSProcessInfo processInfo].operatingSystemVersion.majorVersion >= 27;
     });
     return sSystemDefaultsHard ? ApolloScrollEdgeEffectStyleHard : ApolloScrollEdgeEffectStyleSoft;
+}
+
+static BOOL ApolloHeaderStyleHidesNativeEffect(NSInteger mode) {
+    return mode == ApolloScrollEdgeEffectStyleBlur || mode == ApolloScrollEdgeEffectStyleHidden;
 }
 
 static id ApolloScrollEdgeEffectStyleObjectForMode(NSInteger mode) {
@@ -111,9 +116,9 @@ static void ApolloApplyHeaderStyleToTopEdge(UIScrollView *scrollView, NSInteger 
     SEL setHiddenSelector = NSSelectorFromString(@"setHidden:");
     BOOL hasSetHidden = [effect respondsToSelector:setHiddenSelector];
     if (hasSetHidden) {
-        if (mode == ApolloScrollEdgeEffectStyleBlur) {
+        if (ApolloHeaderStyleHidesNativeEffect(mode)) {
             // Blur replaces the system header effect with the tweak-drawn
-            // progressive blur, so the native effect must go away. Remember
+            // progressive blur; Hidden removes it without a replacement. Remember
             // only the visibility changes made BY THIS FEATURE: stamp an
             // effect solely when this call actually flips it visible→hidden.
             // An effect that is already hidden either belongs to UIKit/Apollo
@@ -133,12 +138,12 @@ static void ApolloApplyHeaderStyleToTopEdge(UIScrollView *scrollView, NSInteger 
         }
     }
 
-    // Blur leaves the (hidden) native effect's style alone; every other mode
-    // pushes its style object — Automatic pushes automaticStyle, which is also
+    // Blur and Hidden leave the hidden native effect's style alone; other modes
+    // push their style object — Automatic pushes automaticStyle, which is also
     // what restores system behavior after switching away from Soft/Hard.
     BOOL hasSetStyle = NO;
     id style = nil;
-    if (mode != ApolloScrollEdgeEffectStyleBlur) {
+    if (!ApolloHeaderStyleHidesNativeEffect(mode)) {
         SEL setStyleSelector = NSSelectorFromString(@"setStyle:");
         style = ApolloScrollEdgeEffectStyleObjectForMode(mode);
         hasSetStyle = (style != nil) && [effect respondsToSelector:setStyleSelector];
@@ -242,7 +247,7 @@ static void ApolloApplyScrollEdgeEffectStyleToAllScrollViews(void) {
 
 - (void)setHidden:(BOOL)hidden {
     if (IsLiquidGlass() &&
-        ApolloResolvedScrollEdgeEffectStyle() == ApolloScrollEdgeEffectStyleBlur &&
+        ApolloHeaderStyleHidesNativeEffect(ApolloResolvedScrollEdgeEffectStyle()) &&
         objc_getAssociatedObject(self, &kApolloScrollEdgeEffectIsTopKey)) {
         if (!hidden) {
             // The caller wanted it visible and we are overriding — exactly the
@@ -253,7 +258,7 @@ static void ApolloApplyScrollEdgeEffectStyleToAllScrollViews(void) {
         // hide WE created — the apply pass's own setHidden:YES routes through
         // this very hook, and clearing the stamp here erased the restore
         // record the moment it was written, leaving effects stuck hidden
-        // after switching away from Blur (the repro'd "Hard renders nothing").
+        // after switching away from Blur/Hidden.
         // hidden == YES with no stamp is UIKit/Apollo's own intent: leave it
         // unstamped so restore never un-hides an edge they keep disabled. If
         // UIKit genuinely wants an edge hidden while our stamp exists, it will

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -231,7 +231,7 @@ extern BOOL sPerPostCommentSort;
 // iOS 26+ Liquid Glass. iOS 26 defaults to Soft; iOS 27 betas default to Hard,
 // which some users find jarring. Only the top (header) edge is governed — the
 // tab-bar/bottom edge always keeps the system's own treatment. See
-// ApolloScrollEdgeEffect.xm (Soft/Hard enforcement) and
+// ApolloScrollEdgeEffect.xm (Soft/Hard/Hidden enforcement) and
 // ApolloProgressiveBlur.xm (Blur's tweak-drawn variable blur).
 typedef NS_ENUM(NSInteger, ApolloScrollEdgeEffectStyle) {
     // Retired user-facing System Default value. Load-time migration resolves
@@ -239,9 +239,8 @@ typedef NS_ENUM(NSInteger, ApolloScrollEdgeEffectStyle) {
     ApolloScrollEdgeEffectStyleAutomatic = 0,
     ApolloScrollEdgeEffectStyleSoft      = 1,
     ApolloScrollEdgeEffectStyleHard      = 2,
-    // 3 was Hidden, retired: visually indistinguishable from Soft, so stored 3s
-    // migrate to Soft at load (Tweak.xm). Never reuse 3 for a new mode — the
-    // migration could not tell an old Hidden user from a new-mode user.
+    // Preserve the original Hidden value for existing preferences/backups.
+    ApolloScrollEdgeEffectStyleHidden    = 3,
     ApolloScrollEdgeEffectStyleBlur      = 4,
 };
 extern NSInteger sScrollEdgeEffectStyle;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -4090,13 +4090,9 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
         // result once, then store the explicit Soft/Hard choice users now see.
         sScrollEdgeEffectStyle = systemHeaderStyle;
         [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];
-    } else if (sScrollEdgeEffectStyle == 3) {
-        // Retired Hidden mode: closest surviving intent (no hard cutoff line)
-        // is Soft. 3 stays reserved — see the enum note in ApolloState.h.
-        sScrollEdgeEffectStyle = ApolloScrollEdgeEffectStyleSoft;
-        [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];
     } else if (sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleSoft &&
                sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleHard &&
+               sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleHidden &&
                sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleBlur) {
         sScrollEdgeEffectStyle = systemHeaderStyle;
         [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -338,7 +338,7 @@ static NSString *const UDKeyPerPostCommentSortMapping = @"PerPostCommentSortMapp
 static NSString *const UDKeyApolloRememberSubredditCommentsSort = @"RememberRedditCommentsSort";
 // Override for the UIScrollView top scroll edge effect (Liquid Glass, iOS 26+).
 // 0 = retired System Default (migrates to 1 on iOS 26 or 2 on iOS 27),
-// 1 = Soft, 2 = Hard, 3 = retired Hidden, 4 = Blur.
+// 1 = Soft, 2 = Hard, 3 = Hidden, 4 = Blur.
 static NSString *const UDKeyScrollEdgeEffectStyle = @"ScrollEdgeEffectStyle";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1870,20 +1870,20 @@ typedef NS_ENUM(NSInteger, Tag) {
     scrollEdgeEffect.visible = ^BOOL { return IsLiquidGlass(); };
 
     return [ApolloSettingsSection sectionWithTitle:@"Display & Navigation"
-                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nIn Liquid Glass, navigation titles stay centered unless expanded actions need room. Tap the top-right ellipsis to reveal navigation actions; scrolling collapses them. Header Style: Soft is the iOS 26 default; Hard is the iOS 27 default."
+                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nIn Liquid Glass, navigation titles stay centered unless expanded actions need room. Tap the top-right ellipsis to reveal navigation actions; scrolling collapses them. Header Style: Soft is the iOS 26 default; Hard is the iOS 27 default. Hidden removes the header edge effect entirely."
                                               rows:@[ userAvatars, scrollEdgeEffect ]];
 }
 
-// Display order of the Header Style picker. Raw values are NOT contiguous
-// (3 was the retired Hidden mode, Blur is 4), so the picker maps index↔value
-// through this table instead of using the enum value as the index.
+// Display order differs from stored values; Blur is optional, while Hidden
+// always remains the last choice. Map picker indices explicitly.
 static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailable) {
     const NSInteger values[] = {
         ApolloScrollEdgeEffectStyleSoft,
         ApolloScrollEdgeEffectStyleHard,
-        ApolloScrollEdgeEffectStyleBlur,
+        blurAvailable ? ApolloScrollEdgeEffectStyleBlur : ApolloScrollEdgeEffectStyleHidden,
+        ApolloScrollEdgeEffectStyleHidden,
     };
-    NSInteger count = blurAvailable ? 3 : 2;
+    NSInteger count = blurAvailable ? 4 : 3;
     if (index < 0 || index >= count) return ApolloScrollEdgeEffectStyleSoft;
     return values[index];
 }
@@ -1893,6 +1893,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
         case ApolloScrollEdgeEffectStyleSoft: return @"Soft";
         case ApolloScrollEdgeEffectStyleHard: return @"Hard";
         case ApolloScrollEdgeEffectStyleBlur: return @"Blur";
+        case ApolloScrollEdgeEffectStyleHidden: return @"Hidden";
         default: return @"Soft";
     }
 }
@@ -1911,6 +1912,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     NSMutableArray<NSString *> *options =
         [NSMutableArray arrayWithObjects:@"Soft", @"Hard", nil];
     if (blurAvailable) [options addObject:@"Blur"];
+    [options addObject:@"Hidden"];
 
     NSInteger currentIndex = 0;
     NSInteger currentStyle = ApolloResolvedScrollEdgeEffectStyle();


### PR DESCRIPTION
## Summary

Restores Hidden as a Header Style option for Liquid Glass.
Selecting Hidden removes the native top scroll-edge effect without adding a replacement blur. The setting preserves its original stored value (3), so existing preferences and backups using Hidden work again.

## Changes

- Restores Hidden in the Header Style picker
- Keeps the bottom/tab-bar edge effect unchanged
- Updates the settings description to explain Hidden

## Validation

Tested on device.
- Hidden appears in the picker and persists
- The top edge effect is hidden at runtime
- Navigation title controls remain visible