### PR TITLE
Action menu: handle injected rows in willSelect so third-party didSelect hooks never see them (fixes #1071)

### DIFF
--- a/src/ApolloActionMenu.h
+++ b/src/ApolloActionMenu.h
@@ -19,6 +19,13 @@
 // irrelevant; slots are computed lazily, per controller, the first time any of
 // them is asked about.
 //
+// This owner also adds tableView:willSelectRowAtIndexPath: to ActionController
+// (Apollo doesn't implement it) and handles every injected row's tap THERE,
+// returning nil so UIKit never sends didSelectRowAtIndexPath: for an injected
+// row. That keeps injected indices away from any didSelect implementation that
+// sits outside ours — Translomatic's does, and it crashed on "Keep in Floating
+// Tab" (#1071). Don't add a didSelect-only tap path for an injected row.
+//
 // Additive only: this owns injecting/replacing rows, not hiding native ones.
 // A feature that needs to remove a native row (e.g. ApolloTranslation.xm's
 // bulk-translate row removal) mutates Apollo's raw Swift `actions` buffer

--- a/src/ApolloActionMenu.xm
+++ b/src/ApolloActionMenu.xm
@@ -22,6 +22,12 @@
 // captured opportunistically off whatever row happened to build first. Same
 // technique as ApolloSettingsGeneralTable.xm's factory(vc, donor).
 //
+// TAP DISPATCH: an injected row's tap is handled in
+// tableView:willSelectRowAtIndexPath: (added to ActionController at %ctor) and
+// answered with nil, so UIKit never sends tableView:didSelectRowAtIndexPath:
+// for it — see ApolloActionMenuWillSelectRow for why (#1071: a third-party
+// tweak's didSelect hook wrapping ours crashed on our row's index).
+//
 // GEOMETRY: legacy rows are always appended after the last native row (Apollo's
 // own cellForRow dequeues with the index path it's handed; UIKit asserts if a
 // native row's index shifts) and the presented sheet's frame grows by
@@ -491,6 +497,105 @@ void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *childre
 
 #pragma mark - Legacy path: the single table/geometry owner
 
+#pragma mark - Injected-row tap dispatch
+
+// The spec behind `indexPath`, or nil when the row is native or was appended
+// by someone else (a third-party tweak stacking its own row after ours).
+static ApolloActionMenuSpec *ApolloActionMenuSpecAtIndexPath(id controller, NSIndexPath *indexPath) {
+    if (!indexPath || indexPath.section != 0) return nil;
+    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(controller, nil);
+    NSInteger nativeCount = state.nativeRowCount;
+    if (state.specs.count == 0 || nativeCount < 0 || indexPath.row < nativeCount) return nil;
+    NSInteger slotIndex = indexPath.row - nativeCount;
+    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) return nil;
+    return state.specs[(NSUInteger)slotIndex];
+}
+
+// Run an injected row's tap: dismiss-then-perform (the default), or perform in
+// place for a spec whose perform forwards into a native row's own
+// self-dismissing flow (PublicSticky).
+static void ApolloActionMenuPerformSpec(id controller, UITableView *tableView,
+                                        ApolloActionMenuSpec *spec, NSIndexPath *indexPath) {
+    // Keep the tap feedback native rows get. On the didSelect path UIKit has
+    // selected the row and this deselect fades it out under the dismissal; on
+    // the willSelect path the row is never selected (UIKit already dropped the
+    // touch-down highlight before asking willSelect, and nil stops it there),
+    // so re-arm the cell's own highlight and fade that instead — cell-level
+    // state only, nothing re-entrant on the table's selection bookkeeping.
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (cell && !cell.isSelected) {
+        [cell setHighlighted:YES animated:NO];
+        [cell setHighlighted:NO animated:YES];
+    }
+
+    __strong id strongSelf = controller;
+    void (^perform)(id) = spec.perform;
+    if (spec.legacyDismissesSheet) {
+        [(UIViewController *)controller dismissViewControllerAnimated:YES completion:^{
+            if (perform) perform(strongSelf);
+        }];
+    } else if (perform) {
+        perform(strongSelf);
+    }
+}
+
+// tableView:willSelectRowAtIndexPath: on ActionController — where an injected
+// row's tap is handled. Returning nil makes UIKit skip both the selection and
+// the tableView:didSelectRowAtIndexPath: send for that row
+// (-[UITableView _selectRowAtIndexPath:…notifyDelegate:] consults willSelect
+// first and bails on nil), so the tap never reaches ANY didSelect
+// implementation: not Apollo's, and not one another tweak installed on top of
+// ours.
+//
+// Why (#1071): Translomatic hooks this class's didSelectRowAtIndexPath: too.
+// Loading after the IPA-embedded tweak, its replacement wraps ours — UIKit
+// calls it first — and it doesn't expect rows past Apollo's own action list:
+// the crash report shows it null-dereferencing inside its own code, called
+// straight from UIKit's row selection, on our "Keep in Floating Tab" row.
+// Whoever ends up outermost on didSelect, an injected row now never gets there.
+//
+// Apollo's ActionController doesn't implement willSelect (1.15.11 headers), so
+// this is ADDED at %ctor rather than hooked; should some build or tweak have
+// implemented it first, that implementation is wrapped and still consulted for
+// every non-injected row.
+typedef NSIndexPath *(*ApolloActionMenuWillSelectIMP)(id, SEL, UITableView *, NSIndexPath *);
+static ApolloActionMenuWillSelectIMP sApolloActionMenuOrigWillSelect = NULL;
+
+static NSIndexPath *ApolloActionMenuWillSelectRow(id self, SEL _cmd, UITableView *tableView, NSIndexPath *indexPath) {
+    ApolloActionMenuSpec *spec = ApolloActionMenuSpecAtIndexPath(self, indexPath);
+    if (!spec) {
+        if (sApolloActionMenuOrigWillSelect) return sApolloActionMenuOrigWillSelect(self, _cmd, tableView, indexPath);
+        return indexPath;
+    }
+    ApolloLog(@"[ActionMenu] Injected row %ld ('%@') tapped — handled at willSelect, not delivered to didSelectRowAtIndexPath:",
+              (long)indexPath.row, spec.identifier);
+    ApolloActionMenuPerformSpec(self, tableView, spec, indexPath);
+    return nil;
+}
+
+static void ApolloActionMenuInstallWillSelect(void) {
+    Class cls = objc_getClass("_TtC6Apollo16ActionController");
+    if (!cls) {
+        ApolloLog(@"[ActionMenu] ActionController class missing — willSelect dispatch not installed");
+        return;
+    }
+    SEL sel = @selector(tableView:willSelectRowAtIndexPath:);
+    Method existing = class_getInstanceMethod(cls, sel);
+    if (!existing) {
+        BOOL added = class_addMethod(cls, sel, (IMP)ApolloActionMenuWillSelectRow, "@@:@@");
+        ApolloLog(@"[ActionMenu] willSelectRowAtIndexPath: %@ on ActionController", added ? @"added" : @"NOT added");
+        return;
+    }
+    // Already implemented (own or inherited): keep it reachable for native rows.
+    if (class_addMethod(cls, sel, (IMP)ApolloActionMenuWillSelectRow, method_getTypeEncoding(existing))) {
+        sApolloActionMenuOrigWillSelect = (ApolloActionMenuWillSelectIMP)method_getImplementation(existing); // inherited
+    } else {
+        sApolloActionMenuOrigWillSelect = (ApolloActionMenuWillSelectIMP)method_setImplementation(existing, (IMP)ApolloActionMenuWillSelectRow); // own
+    }
+    ApolloLog(@"[ActionMenu] willSelectRowAtIndexPath: wrapped an existing implementation on ActionController");
+}
+
 %hook _TtC6Apollo16ActionController
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -561,37 +666,23 @@ void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *childre
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    ApolloActionMenuSlotState *state = ApolloActionMenuSlotsForController(self, nil);
-    NSInteger nativeCount = state.nativeRowCount;
-
-    if (state.specs.count == 0 || indexPath.section != 0 || nativeCount < 0 || indexPath.row < nativeCount) {
-        %orig;
-        return;
-    }
-
-    NSInteger slotIndex = indexPath.row - nativeCount;
-    if (slotIndex < 0 || (NSUInteger)slotIndex >= state.specs.count) {
+    ApolloActionMenuSpec *spec = ApolloActionMenuSpecAtIndexPath(self, indexPath);
+    if (!spec) {
         // Keep the Logos directive on its own line. Logos 2.4.1 consumes the
         // remainder of a line containing %orig, which previously dropped the
         // return and closing brace from generated Objective-C++.
         %orig;
         return;
     }
-
-    ApolloActionMenuSpec *spec = state.specs[(NSUInteger)slotIndex];
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
-
-    __strong id strongSelf = self;
-    void (^perform)(id) = spec.perform;
-    if (spec.legacyDismissesSheet) {
-        [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
-            if (perform) perform(strongSelf);
-        }];
-    } else if (perform) {
-        perform(strongSelf);
-    }
+    // Normally unreachable: ApolloActionMenuWillSelectRow returns nil for
+    // injected rows, so UIKit never sends didSelect for them. Kept as the
+    // fallback for any selection path that skips willSelect, so a tap still
+    // does something rather than falling into Apollo's native handler with an
+    // out-of-range row.
+    ApolloLog(@"[ActionMenu] Injected row %ld ('%@') reached didSelect (willSelect bypassed) — performing here",
+              (long)indexPath.row, spec.identifier);
+    ApolloActionMenuPerformSpec(self, tableView, spec, indexPath);
 }
-
 %end
 
 %hook _TtC6Apollo38ActionControllerPresentationController
@@ -617,5 +708,6 @@ void ApolloActionMenuInjectMenuElements(NSMutableArray<UIMenuElement *> *childre
 
 %ctor {
     %init;
+    ApolloActionMenuInstallWillSelect();
     ApolloLog(@"[ActionMenu] Action-menu registry hooks installed");
 }


### PR DESCRIPTION
Fixes #1071

## What happened

With FoxfortMobile's **Translomatic** loaded (iOS 17.0, TrollStore, 3.7.0), tapping **Keep in Floating Tab** on the legacy "..." sheet kills the app instantly. The reporter's `apollo-reborn-crash.json`:

- `EXC_BAD_ACCESS` / `KERN_INVALID_ADDRESS` at `0x0`, crashed thread 0, frame 0 inside **`Translomatic.dylib`** (no ApolloReborn frame on the crashed thread; threads 5/6 are KSCrash's own monitors).
- The UIKit frames were `<redacted>`, so I symbolicated them against the iOS 17.0 (21A329, iPhone15,3) shared cache: the caller is **`-[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:isCellMultiSelect:deselectPrevious:performCustomSelectionAction:] + 1232`** ← `_userSelectRowAtPendingSelectionIndexPath:` ← `_UIAfterCACommitBlock run` — that is exactly the point where UITableView sends `tableView:didSelectRowAtIndexPath:` to its delegate.

So Translomatic hooks `_TtC6Apollo16ActionController`'s `didSelectRowAtIndexPath:` too (that's how it adds its "Translate" row). Its replacement loads after the IPA-embedded tweak, wraps ours, and UIKit calls it **first**. It only expects Apollo's own rows: handed the index of a row this module appended after them, it null-dereferences inside its own code before `%orig` (our hook) ever runs. Every row `ApolloActionMenu` appends on the legacy path is exposed the same way — Floating Tabs, Deleted Comments, Gallery View, Public Sticky.

## The fix

Injected rows are now handled in **`tableView:willSelectRowAtIndexPath:`**, added to `ActionController` at `%ctor` (Apollo doesn't implement it — 1.15.11 headers / `__objc_classlist`; if some build or tweak had it first, the existing IMP is wrapped and still consulted for every other row). Returning `nil` there makes UIKit skip the selection **and** the `didSelectRowAtIndexPath:` send for that row (`_selectRowAtIndexPath:` consults `willSelect` first and bails on nil — checked in the UIKitCore decompile), so no `didSelect` implementation — Apollo's, ours, or a third party's stacked on top of ours — is ever handed an injected index.

- The `didSelect` hook keeps the same dispatch as a fallback for any selection path that bypasses `willSelect`; it logs when that happens.
- Tap feedback is kept: on the willSelect path the row is never selected (UIKit drops the touch-down highlight before asking), so the cell's own highlight is re-armed and faded out under the dismissal, matching what native rows and the old didSelect path showed.
- Native rows and rows a third party appends *after* ours are untouched: `willSelect` returns the index path (or the wrapped original's answer) and UIKit proceeds exactly as before.
- Glass path (`ApolloNativeActionMenus.xm`, UIMenu) is not involved; the only shared change is the `%ctor` addition.

## Verification

- **Reproduced in the simulator** with a mock third-party tweak (`MockForeignMenu.dylib`, source below) inserted *after* `ApolloReborn.dylib` so its hooks wrap ours, appending its own "Translate (mock)" row and dereferencing NULL for any `didSelect` index past Apollo's `actions` count:
  - **Baseline (main 2427e2b):** tap "Keep in Floating Tab" → `[MockForeign] didSelect: row=14 total=16 native=14` → `EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x0`, frame 0 in the mock called from `-[UITableView _selectRowAtIndexPath:…]` ← `_userSelectRowAtPendingSelectionIndexPath:` ← `_UIAfterCACommitBlock run` — the reporter's stack, one for one. Our KSCrash captured it and showed the relaunch prompt.
  - **Fix, mock still in crash mode:** feed ••• → "Keep in Floating Tab" → `[ActionMenu] Injected row 14 ('FloatingTabs') tapped — handled at willSelect, not delivered to didSelectRowAtIndexPath:` → `[FloatingTabs] Added tab … 1/5`, bubble on screen, process alive, no `.ips`. Comments "..." (Deleted Comments + Floating Tabs both injected, Floating Tabs at row 17 = the reporter's layout) → tab 2/5. "Show Deleted Comments" → toggle + comments refresh. Subreddit ••• → "Gallery View" → gallery opens. Native row ("Soccer") → mock sees row 5, forwards, Apollo navigates. Mock's own row → `didSelect: my own Translate row tapped -> handled by mock`.
  - **Fix without the mock:** "Remove Floating Tab" → handled at willSelect → `Closed 1 tab(s)`.
- **Non-glass sim** (Apollo-Sim2, shell vtool-downgraded to sdk 16 → the legacy `ActionController` table sheet, the path iOS 17 users get). **Glass sim:** same dylib on the Liquid Glass shell (sdk 19, UIMenu path, `IsLiquidGlass: YES`): feed ••• → "Keep in Floating Tab" → `Added tab … 2/5`, path untouched, no crash.
- **Modes:** API-key account (OAuth client) throughout. Keyless not separately run: the sheet is the same `ActionController` in both modes and the change is a UIKit delegate call with no networking. Cancelled swipe-back: n/a (modal sheet; no nav-stack state added).
- **Launch log lines:** `[ActionMenu] willSelectRowAtIndexPath: added on ActionController` · `[ActionMenu] Action-menu registry hooks installed`; the mock (whose ctor runs after ours either way) logs `willSelect present on class: 0` against the baseline build and `1` against the fix.
- **Selectors verified** against the Apollo Mach-O (`__objc_classlist` + Apollo-Headers 1.15.11): `tableView:numberOfRowsInSection:` / `cellForRowAtIndexPath:` / `heightForRowAtIndexPath:` / `didSelectRowAtIndexPath:` exist on `_TtC6Apollo16ActionController`; `willSelectRowAtIndexPath:` does not (added at runtime). Hopper wasn't needed for this one.
- `make package` (device, pinned iOS 26.0 SDK) → `packages/com.apollo.reborn_3.7.0-1+debug_iphoneos-arm.deb`; sim build with the internal Logos generator; `git diff --check` clean. Branch is on current `apollo-reborn/main` (2427e2b); the only open PR touching menu code is #1069 and it doesn't touch `ApolloActionMenu.{h,xm}`.
- **Not run:** a device with Translomatic itself (paid Havoc tweak, not available here). The mock reproduces the crash mechanism and stack exactly, but the real confirmation is the reporter (u/JeleiaFish) trying the next build — worth asking on the issue.

<details>
<summary>MockForeignMenu.m (sim-only stand-in for a third-party menu tweak)</summary>

```objc
// MockForeignMenu — a stand-in for a third-party tweak (Translomatic-style)
// that appends its own row to Apollo's legacy "..." ActionController sheet and
// hooks the same UITableView delegate/dataSource methods Apollo Reborn hooks.
// Loaded AFTER ApolloReborn.dylib (second in DYLD_INSERT_LIBRARIES), so its
// replacements wrap ours — exactly the ordering the #1071 crash stack shows
// (UIKit -> Translomatic -> ... never reaching ApolloReborn's didSelect).
//
// Behaviour:
//   numberOfRows: orig + 1 (its "Translate (mock)" row goes last)
//   cellForRow:   last row -> its own cell; everything else -> orig
//   didSelect:    last row -> "translate"; otherwise it reads the tapped
//                 action out of Apollo's Swift `actions` array by row, the way
//                 a tweak that inspects native rows would. Rows at or past the
//                 native count (Apollo Reborn's injected rows) are then
//                 dereferenced as a NULL action -> EXC_BAD_ACCESS at 0x0, the
//                 #1071 signature. MOCK_FOREIGN_NO_CRASH=1 logs instead.
#import <UIKit/UIKit.h>
#import <objc/runtime.h>
#import <os/log.h>

static os_log_t sLog;
#define MLOG(fmt, ...) os_log_with_type(sLog, OS_LOG_TYPE_DEFAULT, "[MockForeign] " fmt, ##__VA_ARGS__)

static NSInteger (*orig_numberOfRows)(id, SEL, UITableView *, NSInteger);
static UITableViewCell *(*orig_cellForRow)(id, SEL, UITableView *, NSIndexPath *);
static void (*orig_didSelect)(id, SEL, UITableView *, NSIndexPath *);

static NSInteger ApolloNativeActionCount(id self) {
    // Swift Array<T> stored inline as one buffer pointer; count lives at +0x10
    // of the buffer (Swift stdlib _ContiguousArrayStorage header).
    Ivar ivar = class_getInstanceVariable(object_getClass(self), "actions");
    if (!ivar) return -1;
    void **slot = (void **)((char *)(__bridge void *)self + ivar_getOffset(ivar));
    char *buffer = (char *)*slot;
    if (!buffer) return 0;
    return *(int64_t *)(buffer + 0x10);
}

static NSInteger hook_numberOfRows(id self, SEL _cmd, UITableView *tv, NSInteger section) {
    NSInteger n = orig_numberOfRows(self, _cmd, tv, section);
    if (section != 0) return n;
    MLOG("numberOfRows: orig=%ld -> %ld (native actions=%ld)", (long)n, (long)n + 1, (long)ApolloNativeActionCount(self));
    return n + 1;
}

static UITableViewCell *hook_cellForRow(id self, SEL _cmd, UITableView *tv, NSIndexPath *ip) {
    NSInteger total = [self tableView:tv numberOfRowsInSection:0];
    if (ip.section == 0 && ip.row == total - 1) {
        UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"MockForeignTranslate"];
        cell.textLabel.text = @"Translate (mock)";
        cell.textLabel.textColor = [UIColor systemOrangeColor];
        cell.backgroundColor = [UIColor clearColor];
        return cell;
    }
    return orig_cellForRow(self, _cmd, tv, ip);
}

static void hook_didSelect(id self, SEL _cmd, UITableView *tv, NSIndexPath *ip) {
    NSInteger total = [self tableView:tv numberOfRowsInSection:0];
    NSInteger native = ApolloNativeActionCount(self);
    MLOG("didSelect: row=%ld total=%ld native=%ld", (long)ip.row, (long)total, (long)native);
    if (ip.section == 0 && ip.row == total - 1) {
        MLOG("didSelect: my own Translate row tapped -> handled by mock");
        [(UIViewController *)self dismissViewControllerAnimated:YES completion:nil];
        return;
    }
    if (ip.section == 0 && native >= 0 && ip.row >= native) {
        // A row that is neither Apollo's nor mine: reading the "action" for it
        // yields nothing. A tweak that doesn't expect foreign rows here
        // dereferences that nothing.
        MLOG("didSelect: row %ld is past Apollo's %ld native actions — foreign row reached this hook", (long)ip.row, (long)native);
        if (!getenv("MOCK_FOREIGN_NO_CRASH")) {
            MLOG("didSelect: dereferencing NULL action (crash mode)");
            volatile int *nullAction = NULL;
            (void)*nullAction; // EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x0
        }
        MLOG("didSelect: MOCK_FOREIGN_NO_CRASH set — forwarding to orig instead");
    }
    orig_didSelect(self, _cmd, tv, ip);
}

__attribute__((constructor))
static void MockForeignMenuInit(void) {
    sLog = os_log_create("mockforeign", "menu");
    Class cls = objc_getClass("_TtC6Apollo16ActionController");
    if (!cls) { MLOG("ActionController class not found"); return; }
    Method m;
    m = class_getInstanceMethod(cls, @selector(tableView:numberOfRowsInSection:));
    orig_numberOfRows = (void *)method_setImplementation(m, (IMP)hook_numberOfRows);
    m = class_getInstanceMethod(cls, @selector(tableView:cellForRowAtIndexPath:));
    orig_cellForRow = (void *)method_setImplementation(m, (IMP)hook_cellForRow);
    m = class_getInstanceMethod(cls, @selector(tableView:didSelectRowAtIndexPath:));
    orig_didSelect = (void *)method_setImplementation(m, (IMP)hook_didSelect);
    BOOL hasWillSelect = class_getInstanceMethod(cls, @selector(tableView:willSelectRowAtIndexPath:)) != NULL;
    MLOG("hooks installed on ActionController (numberOfRows/cellForRow/didSelect); willSelect present on class: %d", hasWillSelect);
}
```

Built with `xcrun -sdk iphonesimulator clang -arch arm64 -mios-simulator-version-min=15.0 -dynamiclib -fobjc-arc -framework Foundation -framework UIKit MockForeignMenu.m -o MockForeignMenu.dylib && codesign -s - MockForeignMenu.dylib`, launched with `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="<work>/ApolloReborn.dylib:<path>/MockForeignMenu.dylib" xcrun simctl launch <dev> com.christianselig.Apollo -FloatingPostTabs YES`.
</details>

## Reviewer checklist

- **Guard width:** the new early-outs in `ApolloActionMenuSpecAtIndexPath` (section ≠ 0, no specs, `nativeRowCount < 0`, `row < nativeCount`, slot out of range) all resolve to "not ours" → `willSelect` returns the index path / wrapped original and UIKit continues into `didSelect` exactly as before; `didSelect`'s own gating is the same set it had.
- **Regression / feature off:** with no matched specs the added `willSelect` is inert (returns its input); native rows, foreign-appended rows, Gallery View, Deleted Comments and Floating Tabs all exercised above. Theme chains, titles, placement untouched.
- **Hook scoping:** the method is added on the class this module already owns (`_TtC6Apollo16ActionController`); selector confirmed absent on it (headers + runtime log), and an existing IMP would be wrapped, not replaced.
- **Threads / hot paths / ownership:** all on main from UIKit's selection path; `%ctor` cost is one `class_getInstanceMethod` + `class_addMethod`; the dismissal completion keeps the pre-existing `strongSelf` capture, no new associations or retained instances, nothing to tear down.
- **Toggle-off / per-screen state:** no new toggle or per-screen state; the one static is the wrapped-original IMP, class-level by nature.
- **Comments / tripwires:** why-comment on `ApolloActionMenuWillSelectRow`, header contract updated, log line on the injected-row path and on the fallback path.
- **Modes matrix / iOS 14 floor:** `class_addMethod` + `willSelectRowAtIndexPath:` are iOS 2 APIs; account mode doesn't reach this code.
- **Rebase:** on current main; no overlap with #1069.
- Not applicable: wrong-object/duplicate-title matching, failure-as-success caching, stale async completions, cancelled interactive pop, account isolation, in-flight changes, memory pressure, restored affordances, device gesture/WebKit scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
