### PR TITLE
Add configurable top bar hiding and improve Liquid Glass bar settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloModmailSubjectCounter.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
+    $(SRC_DIR)/ApolloTopBarScrollPresentation.m \
     $(SRC_DIR)/ApolloListBottomInsetGuard.xm \
     $(SRC_DIR)/ApolloTabBarHideStyle.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -4,6 +4,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
+#import "ApolloTopBarScrollPresentation.h"
 #import "ApolloListLayoutSupport.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
@@ -370,6 +371,7 @@ static void ApolloSetTabBarPresentationHidden(UITabBarController *tbc,
     if (style == ApolloTabBarHideStyleDown) {
         ApolloNormalizeDownTabBarGeometry(tbc);
     }
+    ApolloTopBarSetScrollHidden(tbc, hidden, animated, reason);
     CGFloat targetAlpha = (hidden && ApolloTabBarStyleFades(style)) ? 0.0 : 1.0;
     CATransform3D targetSublayerTransform = hidden
         ? ApolloTabBarHiddenSublayerTransform(tabBar, style)
@@ -456,6 +458,8 @@ static void ApolloSetTabBarPresentationHidden(UITabBarController *tbc,
 
 void ApolloRestoreHideOnScrollPresentation(UITabBarController *tabBarController,
                                            NSString *reason) {
+    ApolloTopBarSetScrollHidden(tabBarController, NO, NO,
+                               reason ?: @"external tab-bar restore");
     ApolloSetTabBarPresentationHidden(tabBarController, NO, NO,
                                       reason ?: @"external tab-bar restore");
 }
@@ -705,6 +709,127 @@ static BOOL ApolloResolveRevealProviderBridge(id provider, SEL callback) {
     return sApolloRevealProviderChecked && sApolloRevealProviderSupported;
 }
 
+// Left/Right collapse is driven by UIKit, including paths which never cross
+// our custom-style scroll threshold. Observe its existing progress callback
+// so the optional top bar follows the real bottom-bar direction. The weak
+// owner avoids adding a provider -> controller retain cycle.
+@interface ApolloNativeTopBarObserverState : NSObject
+@property (nonatomic, weak) UITabBarController *controller;
+@property (nonatomic, assign) BOOL hasProgress;
+@property (nonatomic, assign) CGFloat intentProgress;
+@property (nonatomic, assign) BOOL hasTarget;
+@property (nonatomic, assign) BOOL targetHidden;
+@end
+@implementation ApolloNativeTopBarObserverState
+@end
+
+static char kApolloNativeTopBarObserverStateKey;
+typedef void (*ApolloNativeProviderProgressIMP)(id, SEL, id, double, BOOL);
+static NSMutableSet<NSString *> *sApolloNativeProviderProgressClasses;
+
+static void ApolloObserveNativeProviderProgress(id provider, double rawProgress) {
+    ApolloNativeTopBarObserverState *observer =
+        objc_getAssociatedObject(provider, &kApolloNativeTopBarObserverStateKey);
+    UITabBarController *tbc = observer.controller;
+    if (!tbc || !ApolloTabBarManualNativeMorphEnabled() || !isfinite(rawProgress)) return;
+
+    CGFloat progress = MIN(1.0, MAX(0.0, rawProgress));
+    ApolloTabBarRuntimeState *runtimeState = ApolloRuntimeState(tbc, NO);
+    ApolloTabBarRevealAnimator *animator = runtimeState.revealAnimator;
+    if (animator && animator.provider == provider) {
+        // Explicit reveal/retarget already set the top-bar target. Its first
+        // provider sample still describes the old endpoint (e.g. 1 while
+        // revealing), which must not reverse that spring. Keep observing the
+        // position and authoritative target so native gestures resume from
+        // the final sample after the driver relinquishes ownership.
+        // Both normal completion and finishProviderTracking send their last
+        // callback before invalidate clears state.revealAnimator.
+        observer.hasProgress = YES;
+        observer.intentProgress = progress;
+        observer.hasTarget = YES;
+        observer.targetHidden = animator.targetProgress > 0.5;
+        return;
+    }
+    BOOL endpoint = progress <= 0.001 || progress >= 0.999;
+    if (!observer.hasProgress) {
+        observer.hasProgress = YES;
+        observer.intentProgress = progress;
+        if (!endpoint) return;
+    }
+    CGFloat delta = progress - observer.intentProgress;
+    // Ignore tiny settling fluctuations; real reversal accumulates from the
+    // last accepted direction sample instead of restarting the spring per tick.
+    if (!endpoint && fabs(delta) < 0.015) return;
+    BOOL hidden = endpoint ? progress >= 0.999 : delta > 0.0;
+    observer.intentProgress = progress;
+    // After a Two-Gesture reveal, the first downward gesture is deliberately
+    // consumed while the bottom bar stays expanded. UIKit's provider still
+    // reports direction samples during that gesture; mirroring them directly
+    // made the top bar behave like Classic and hide on the first gesture.
+    if (!sClassicTabBarScrollBehavior && runtimeState.twoGestureRevealActive && hidden) {
+        if (!observer.hasTarget || observer.targetHidden) {
+            observer.hasTarget = YES;
+            observer.targetHidden = NO;
+            ApolloTopBarSetScrollHidden(tbc, NO, YES,
+                @"two-gesture consumed downward progress");
+        }
+        return;
+    }
+    if (observer.hasTarget && observer.targetHidden == hidden) return;
+    observer.hasTarget = YES;
+    observer.targetHidden = hidden;
+    ApolloTopBarSetScrollHidden(tbc, hidden, YES, @"native bottom-bar progress");
+}
+
+static void ApolloPrepareNativeTopBarObserver(UITabBarController *tbc, id provider, SEL callback) {
+    if (!tbc || !provider || !ApolloRevealCallbackHasExpectedABI(provider, callback)) return;
+    Class cls = object_getClass(provider);
+    @synchronized ([UITabBar class]) {
+        if (!sApolloNativeProviderProgressClasses) {
+            sApolloNativeProviderProgressClasses = [NSMutableSet set];
+        }
+        NSString *key = NSStringFromClass(cls);
+        if (![sApolloNativeProviderProgressClasses containsObject:key]) {
+            Method method = class_getInstanceMethod(cls, callback);
+            ApolloNativeProviderProgressIMP original =
+                (ApolloNativeProviderProgressIMP)method_getImplementation(method);
+            if (!original) return;
+            // Capture this exact original instead of resolving it from self's
+            // runtime class: a subclass's super call must not recurse back
+            // into the subclass override. Every callback forwards unchanged.
+            IMP replacement = imp_implementationWithBlock(^(id owner, id interaction,
+                                                            double progress, BOOL tracking) {
+                original(owner, callback, interaction, progress, tracking);
+                ApolloObserveNativeProviderProgress(owner, progress);
+            });
+            if (!replacement) return;
+            // Add an override when the method is inherited; never replace an
+            // unrelated provider superclass's implementation globally.
+            class_replaceMethod(cls, callback, replacement,
+                                method_getTypeEncoding(method));
+            [sApolloNativeProviderProgressClasses addObject:key];
+            ApolloLog(@"[AutoHideTabBarFix] Observing native bottom-bar progress on %@", key);
+        }
+    }
+    ApolloNativeTopBarObserverState *observer =
+        objc_getAssociatedObject(provider, &kApolloNativeTopBarObserverStateKey);
+    if (!observer) {
+        observer = [ApolloNativeTopBarObserverState new];
+        objc_setAssociatedObject(provider, &kApolloNativeTopBarObserverStateKey, observer,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    BOOL known = NO;
+    NSInteger morph = ApolloTabBarVisualMorphTarget(tbc.tabBar, &known);
+    BOOL endpoint = known && (morph == 0 || morph == 2);
+    if (observer.controller != tbc || endpoint) {
+        observer.controller = tbc;
+        observer.hasProgress = endpoint;
+        observer.intentProgress = morph == 2 ? 1.0 : 0.0;
+        observer.hasTarget = observer.hasProgress;
+        observer.targetHidden = morph == 2;
+    }
+}
+
 typedef void (*ApolloScrollAwayDidScrollIMP)(id, SEL, id);
 typedef void (*ApolloScrollAwayDidEndDraggingIMP)(id, SEL, id, BOOL);
 static ApolloScrollAwayDidScrollIMP sApolloScrollAwayDidScrollOriginal = NULL;
@@ -829,6 +954,7 @@ static void ApolloPrepareNativeScrollAwayBottomGuard(UITabBarController *tbc) {
     id provider = ApolloTabBarVisualProvider(tbc.tabBar);
     SEL callback = NSSelectorFromString(@"scrollAwayInteraction:progressDidChange:tracking:");
     if (!ApolloResolveRevealProviderBridge(provider, callback)) return;
+    ApolloPrepareNativeTopBarObserver(tbc, provider, callback);
     id interaction = sApolloRevealInteractionIvar
         ? object_getIvar(provider, sApolloRevealInteractionIvar) : nil;
     if (interaction) ApolloInstallScrollAwayBottomGuard(interaction);
@@ -854,6 +980,7 @@ static ApolloTabBarRevealResult ApolloSetNativeTabBarManuallyHidden(
     ApolloTabBarRuntimeState *state = ApolloRuntimeState(tbc, YES);
     ApolloTabBarRevealAnimator *active = state.revealAnimator;
     if (active) {
+        ApolloTopBarSetScrollHidden(tbc, hidden, animated, reason);
         [active retargetToProgress:hidden ? 1.0 : 0.0];
         return ApolloTabBarRevealResultActive;
     }
@@ -862,9 +989,11 @@ static ApolloTabBarRevealResult ApolloSetNativeTabBarManuallyHidden(
     NSInteger morphTarget = ApolloTabBarVisualMorphTarget(tbc.tabBar, &morphKnown);
     if (!morphKnown) return ApolloTabBarRevealResultUnsupported;
     if (!hidden && morphTarget == 0) {
+        ApolloTopBarSetScrollHidden(tbc, NO, animated, reason);
         return ApolloTabBarRevealResultAlreadyExpanded;
     }
     if (hidden && morphTarget == 2) {
+        ApolloTopBarSetScrollHidden(tbc, YES, animated, reason);
         return ApolloTabBarRevealResultStarted;
     }
     // Never restart an animation from a guessed endpoint while UIKit reports
@@ -882,6 +1011,7 @@ static ApolloTabBarRevealResult ApolloSetNativeTabBarManuallyHidden(
     if (!ApolloResolveRevealProviderBridge(provider, callback)) {
         return ApolloTabBarRevealResultUnsupported;
     }
+    ApolloPrepareNativeTopBarObserver(tbc, provider, callback);
     id interaction = sApolloRevealInteractionIvar
         ? object_getIvar(provider, sApolloRevealInteractionIvar) : nil;
     if (!interaction) return ApolloTabBarRevealResultTransient;
@@ -892,6 +1022,7 @@ static ApolloTabBarRevealResult ApolloSetNativeTabBarManuallyHidden(
         @try {
             ((void (*)(id, SEL, id, double, BOOL))objc_msgSend)(
                 provider, callback, interaction, (double)targetProgress, NO);
+            ApolloTopBarSetScrollHidden(tbc, hidden, NO, reason);
             return ApolloTabBarRevealResultStarted;
         } @catch (NSException *exception) {
             ApolloLog(@"[AutoHideTabBarFix] Manual native morph failed: %@", exception.name);
@@ -906,6 +1037,7 @@ static ApolloTabBarRevealResult ApolloSetNativeTabBarManuallyHidden(
                                                  startProgress:startProgress
                                                 targetProgress:targetProgress];
     state.revealAnimator = animator;
+    ApolloTopBarSetScrollHidden(tbc, hidden, YES, reason);
     [animator start];
     ApolloLog(@"[AutoHideTabBarFix] Started manual native %@ reason=%@ morph=%ld",
               hidden ? @"collapse" : @"reveal", reason ?: @"unknown",
@@ -1041,6 +1173,7 @@ static void ApolloReconcileNativeMinimizeBehaviorAfterActivation(UITabBarControl
     if (anyWantsMinimize && ApolloTabBarManualNativeMorphEnabled()) {
         ApolloSetNativeTabBarManuallyHidden(tbc, NO, NO, @"foreground reconciliation");
     }
+    ApolloTopBarSetScrollHidden(tbc, NO, NO, @"foreground reconciliation");
     ApolloLog(@"[AutoHideTabBarFix] Reconciled native minimize desired=%d customMode=%d reason=%@",
               anyWantsMinimize, customPresentationMode, reason ?: @"unknown");
 }
@@ -1537,6 +1670,7 @@ static BOOL ApolloBarSwipeGestureActive(UINavigationController *nav) {
 %hook UINavigationController
 
 - (void)setNavigationBarHidden:(BOOL)hidden {
+    if (hidden) ApolloTopBarRestoreNavigationController(self);
     %orig;
     if (ApolloSupportsNativeTabBarScrollBehavior()) return;
     if (ApolloBarSwipeGestureActive(self)) return;
@@ -1544,6 +1678,7 @@ static BOOL ApolloBarSwipeGestureActive(UINavigationController *nav) {
 }
 
 - (void)setNavigationBarHidden:(BOOL)hidden animated:(BOOL)animated {
+    if (hidden) ApolloTopBarRestoreNavigationController(self);
     %orig;
     if (ApolloSupportsNativeTabBarScrollBehavior()) return;
     if (ApolloBarSwipeGestureActive(self)) return;
@@ -1606,6 +1741,7 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
 %hook UINavigationController
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    ApolloTopBarRestoreNavigationController(self);
     if (ApolloSupportsNativeTabBarScrollBehavior()) {
         UITabBarController *tbc = ApolloLocateTabBarController(self);
         if (tbc && ApolloTabBarIsHideOnScrollPresentationOwned(tbc.tabBar)) {
@@ -1613,6 +1749,41 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
         }
     }
     %orig(viewController, animated);
+}
+
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    ApolloTopBarRestoreNavigationController(self);
+    return %orig(animated);
+}
+
+- (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    ApolloTopBarRestoreNavigationController(self);
+    return %orig(viewController, animated);
+}
+
+- (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
+    ApolloTopBarRestoreNavigationController(self);
+    return %orig(animated);
+}
+
+- (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers animated:(BOOL)animated {
+    ApolloTopBarRestoreNavigationController(self);
+    %orig(viewControllers, animated);
+}
+
+- (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers {
+    ApolloTopBarRestoreNavigationController(self);
+    %orig(viewControllers);
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloTopBarRevalidateNavigationController(self);
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    %orig(animated);
+    if (!self.viewIfLoaded.window) ApolloTopBarRestoreNavigationController(self);
 }
 
 - (void)setHidesBarsOnSwipe:(BOOL)value {
@@ -1652,6 +1823,7 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
                 ApolloSetNativeTabBarManuallyHidden(tbc, NO, NO,
                                                      @"hide on scroll disabled");
                 ApolloSetTabBarPresentationHidden(tbc, NO, NO, @"hide on scroll disabled");
+                ApolloTopBarSetScrollHidden(tbc, NO, NO, @"hide on scroll disabled");
             } else if (customPresentationMode) {
                 // Custom styles do not use the private provider driver. Keep
                 // Two-Gesture's consumed-gesture state across repeat setup.
@@ -1880,6 +2052,7 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
             ApolloNativeHideBarsOnScrollPreferenceEnabled();
         ApolloForEachVisibleTabBarController(^(UITabBarController *tbc) {
             ApolloReapplyNativeMinimizeBehavior(tbc, @"scrollBehaviorChanged");
+            ApolloTopBarSetScrollHidden(tbc, NO, NO, @"scroll behavior changed");
             // Reapply cancels the previous timer/gesture state. A real mode
             // change must immediately re-arm the idle guarantee so a tab bar
             // that is already collapsed cannot remain there indefinitely.

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -499,6 +499,13 @@ static BOOL ApolloGalleryPush(ApolloGalleryViewController *gallery,
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    // Gallery can inherit an opaque navigation-bar appearance when Header
+    // Style is Hidden. UIKit would then place this controller's root view
+    // below the bar, leaving a solid strip behind when the top bar is moved
+    // offscreen. Keep the grid under navigation chrome just like Apollo's
+    // native feeds so scrolled tiles fill the space the bar vacates.
+    self.edgesForExtendedLayout = UIRectEdgeAll;
+    self.extendedLayoutIncludesOpaqueBars = YES;
     self.title = @"Gallery";
     self.view.backgroundColor = self.gridBackgroundColor ?: UIColor.systemBackgroundColor;
 
@@ -568,6 +575,52 @@ static BOOL ApolloGalleryPush(ApolloGalleryViewController *gallery,
     [self apollo_beginInitialLoad];
 }
 
+- (void)apollo_updateImmersiveTopInset {
+    if (!self.collectionView) return;
+
+    // Gallery is immersive: its tiles provide the pixels sampled by Soft,
+    // Hard, and Blur, while Hidden exposes those tiles directly. UIKit's
+    // automatic top inset otherwise leaves the controller background under
+    // the navigation controls, making every Header Style look like a solid
+    // Hard bar. Cancel only the automatic TOP contribution; retain UIKit's
+    // bottom adjustment so the final tiles remain reachable above the tab bar.
+    UIEdgeInsets contentInset = self.collectionView.contentInset;
+    CGFloat automaticTop = self.collectionView.adjustedContentInset.top - contentInset.top;
+    CGFloat desiredCompensation = -automaticTop;
+    if (fabs(contentInset.top - desiredCompensation) < 0.5) return;
+    CGFloat visibleContentY = self.collectionView.contentOffset.y +
+        self.collectionView.adjustedContentInset.top;
+    contentInset.top = desiredCompensation;
+    self.collectionView.contentInset = contentInset;
+    self.collectionView.scrollIndicatorInsets = contentInset;
+    CGPoint offset = self.collectionView.contentOffset;
+    offset.y = visibleContentY - self.collectionView.adjustedContentInset.top;
+    self.collectionView.contentOffset = offset;
+}
+
+- (void)apollo_applyImmersiveNavigationAppearance {
+    // Once the grid leaves its scroll edge, UINavigationBar normally swaps to
+    // an opaque standard appearance. That layer sits above the configured top
+    // edge effect and made a revealed Hidden header look solid. Gallery always
+    // supplies content beneath the controls, so keep both navigation states
+    // transparent and let Header Style remain the sole owner of the material.
+    UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
+    [appearance configureWithTransparentBackground];
+    self.navigationItem.standardAppearance = appearance;
+    self.navigationItem.scrollEdgeAppearance = appearance;
+    self.navigationItem.compactAppearance = appearance;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self apollo_applyImmersiveNavigationAppearance];
+}
+
+- (void)viewSafeAreaInsetsDidChange {
+    [super viewSafeAreaInsetsDidChange];
+    [self apollo_updateImmersiveTopInset];
+}
+
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -581,6 +634,7 @@ static BOOL ApolloGalleryPush(ApolloGalleryViewController *gallery,
 // a landscape grid back upright as it pops.
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+    [self apollo_updateImmersiveTopInset];
     if (@available(iOS 16.0, *)) {
         [self setNeedsUpdateOfSupportedInterfaceOrientations];
     }

--- a/src/ApolloScrollEdgeEffect.xm
+++ b/src/ApolloScrollEdgeEffect.xm
@@ -12,8 +12,9 @@
 // rendered where content scrolls under the nav/tab bars. iOS 26 defaults to a
 // soft gradient blur; iOS 27 betas default to a hard cutoff with a dividing
 // line, which some users find jarring. The "Header Style" setting lets users
-// choose the TOP (header) edge treatment explicitly: Soft, Hard, or Blur (a
-// tweak-drawn progressive blur — see ApolloProgressiveBlur.xm).
+// choose the TOP (header) edge treatment explicitly: Soft, Hard, Blur (a
+// tweak-drawn progressive blur — see ApolloProgressiveBlur.xm), or Hidden
+// (no native edge effect and no replacement blur).
 //
 // Only the top edge is ever touched. Earlier builds applied the chosen style
 // to all four edges, which painted a hard band behind the tab bar in Hard
@@ -57,6 +58,10 @@ NSInteger ApolloResolvedScrollEdgeEffectStyle(void) {
         sSystemDefaultsHard = [NSProcessInfo processInfo].operatingSystemVersion.majorVersion >= 27;
     });
     return sSystemDefaultsHard ? ApolloScrollEdgeEffectStyleHard : ApolloScrollEdgeEffectStyleSoft;
+}
+
+static BOOL ApolloHeaderStyleHidesNativeEffect(NSInteger mode) {
+    return mode == ApolloScrollEdgeEffectStyleBlur || mode == ApolloScrollEdgeEffectStyleHidden;
 }
 
 static id ApolloScrollEdgeEffectStyleObjectForMode(NSInteger mode) {
@@ -111,9 +116,9 @@ static void ApolloApplyHeaderStyleToTopEdge(UIScrollView *scrollView, NSInteger 
     SEL setHiddenSelector = NSSelectorFromString(@"setHidden:");
     BOOL hasSetHidden = [effect respondsToSelector:setHiddenSelector];
     if (hasSetHidden) {
-        if (mode == ApolloScrollEdgeEffectStyleBlur) {
+        if (ApolloHeaderStyleHidesNativeEffect(mode)) {
             // Blur replaces the system header effect with the tweak-drawn
-            // progressive blur, so the native effect must go away. Remember
+            // progressive blur; Hidden removes it without a replacement. Remember
             // only the visibility changes made BY THIS FEATURE: stamp an
             // effect solely when this call actually flips it visible→hidden.
             // An effect that is already hidden either belongs to UIKit/Apollo
@@ -133,12 +138,12 @@ static void ApolloApplyHeaderStyleToTopEdge(UIScrollView *scrollView, NSInteger 
         }
     }
 
-    // Blur leaves the (hidden) native effect's style alone; every other mode
-    // pushes its style object — Automatic pushes automaticStyle, which is also
+    // Blur and Hidden leave the hidden native effect's style alone; other modes
+    // push their style object — Automatic pushes automaticStyle, which is also
     // what restores system behavior after switching away from Soft/Hard.
     BOOL hasSetStyle = NO;
     id style = nil;
-    if (mode != ApolloScrollEdgeEffectStyleBlur) {
+    if (!ApolloHeaderStyleHidesNativeEffect(mode)) {
         SEL setStyleSelector = NSSelectorFromString(@"setStyle:");
         style = ApolloScrollEdgeEffectStyleObjectForMode(mode);
         hasSetStyle = (style != nil) && [effect respondsToSelector:setStyleSelector];
@@ -242,7 +247,7 @@ static void ApolloApplyScrollEdgeEffectStyleToAllScrollViews(void) {
 
 - (void)setHidden:(BOOL)hidden {
     if (IsLiquidGlass() &&
-        ApolloResolvedScrollEdgeEffectStyle() == ApolloScrollEdgeEffectStyleBlur &&
+        ApolloHeaderStyleHidesNativeEffect(ApolloResolvedScrollEdgeEffectStyle()) &&
         objc_getAssociatedObject(self, &kApolloScrollEdgeEffectIsTopKey)) {
         if (!hidden) {
             // The caller wanted it visible and we are overriding — exactly the
@@ -253,7 +258,7 @@ static void ApolloApplyScrollEdgeEffectStyleToAllScrollViews(void) {
         // hide WE created — the apply pass's own setHidden:YES routes through
         // this very hook, and clearing the stamp here erased the restore
         // record the moment it was written, leaving effects stuck hidden
-        // after switching away from Blur (the repro'd "Hard renders nothing").
+        // after switching away from Blur/Hidden.
         // hidden == YES with no stamp is UIKit/Apollo's own intent: leave it
         // unstamped so restore never un-hides an edge they keep disabled. If
         // UIKit genuinely wants an edge hidden while our stamp exists, it will

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -89,6 +89,7 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
+#import "ApolloTopBarScrollPresentation.h"
 
 @interface UIScrollView (ApolloScrollEdgePocket)
 - (void)_setOverrideGeometryView:(UIView *)view forEdge:(NSUInteger)edge;
@@ -263,6 +264,7 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
     if (sTransitionsInFlight > 0 &&
         ApolloEdgePocketsFrozenFor(ApolloEdgeOwningScrollView(self))) return;
     %orig;
+    ApolloTopBarRevalidateHeaderView(self);
 }
 
 %end

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -177,6 +177,9 @@ extern ApolloTabBarHideStyle sTabBarHideStyle;
 #ifdef __cplusplus
 extern "C" {
 #endif
+// Opt-in top navigation bar movement, following the bottom tab bar's scroll
+// behavior while Hide Bars on Scroll is enabled. Default NO.
+extern BOOL sHideTopBarOnScroll;
 BOOL ApolloSupportsNativeTabBarScrollBehavior(void);
 #ifdef __cplusplus
 }
@@ -231,7 +234,7 @@ extern BOOL sPerPostCommentSort;
 // iOS 26+ Liquid Glass. iOS 26 defaults to Soft; iOS 27 betas default to Hard,
 // which some users find jarring. Only the top (header) edge is governed — the
 // tab-bar/bottom edge always keeps the system's own treatment. See
-// ApolloScrollEdgeEffect.xm (Soft/Hard enforcement) and
+// ApolloScrollEdgeEffect.xm (Soft/Hard/Hidden enforcement) and
 // ApolloProgressiveBlur.xm (Blur's tweak-drawn variable blur).
 typedef NS_ENUM(NSInteger, ApolloScrollEdgeEffectStyle) {
     // Retired user-facing System Default value. Load-time migration resolves
@@ -239,9 +242,8 @@ typedef NS_ENUM(NSInteger, ApolloScrollEdgeEffectStyle) {
     ApolloScrollEdgeEffectStyleAutomatic = 0,
     ApolloScrollEdgeEffectStyleSoft      = 1,
     ApolloScrollEdgeEffectStyleHard      = 2,
-    // 3 was Hidden, retired: visually indistinguishable from Soft, so stored 3s
-    // migrate to Soft at load (Tweak.xm). Never reuse 3 for a new mode — the
-    // migration could not tell an old Hidden user from a new-mode user.
+    // Preserve the original Hidden value for existing preferences/backups.
+    ApolloScrollEdgeEffectStyleHidden    = 3,
     ApolloScrollEdgeEffectStyleBlur      = 4,
 };
 extern NSInteger sScrollEdgeEffectStyle;
@@ -274,7 +276,13 @@ void ApolloApplyScrollEdgeEffectStyle(UIScrollView *scrollView);
 // ASTableViewController, which layers an intercepting UIScrollView over its
 // ASTableView. Applying at the controller level mirrors SwiftUI's inherited
 // NavigationStack modifier and reaches both views.
+#ifdef __cplusplus
+extern "C" {
+#endif
 void ApolloApplyScrollEdgeEffectStyleToViewController(UIViewController *viewController);
+#ifdef __cplusplus
+}
+#endif
 // Whether the nav title for this view controller should size its JumpBar to
 // its actual content (with truncation if still too wide) instead of Apollo's
 // fixed native width (ApolloSubredditHeaders.xm's subreddit feeds).

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -65,6 +65,7 @@ BOOL sCommunityHighlights = NO;
 BOOL sCommunityHighlightsWeb = NO;
 NSString *const ApolloTabBarScrollBehaviorChangedNotification = @"ApolloTabBarScrollBehaviorChangedNotification";
 BOOL sClassicTabBarScrollBehavior = NO;
+BOOL sHideTopBarOnScroll = NO;
 ApolloTabBarHideStyle sTabBarHideStyle = ApolloTabBarHideStyleLeft;
 BOOL sIPadTabBarBottom = NO;   // opt-in (default OFF via registerDefaults, UDKeyIPadTabBarBottom); iPad-gated in the module
 BOOL sKeepSearchBarInPlace = NO;

--- a/src/ApolloTabBarHideStyle.xm
+++ b/src/ApolloTabBarHideStyle.xm
@@ -6,7 +6,7 @@
 #import "ApolloTabBarHideStyle.h"
 #import "UserDefaultConstants.h"
 
-// MARK: - Tab Bar Hide Style (Left / Right / Fade / Down / Off)
+// MARK: - Tab Bar Hide Style (Left / Right / Fade / Down)
 //
 // On iOS 26 (Liquid Glass), Apollo's native "Hide Bars on Scroll" toggle is
 // rerouted by ApolloAutoHideTabBar.xm into UITabBarController's native
@@ -32,15 +32,11 @@
 //     effects directly; the hidden Eureka row's cached value is never displayed.
 
 static NSString *const kApolloHideBarsChangedNote = @"com.christianselig.HideBarsOnSwipeChanged";
-static const NSInteger ApolloTabBarHideMenuModeOff = ApolloTabBarHideStyleDown + 1;
-
 BOOL ApolloTabBarHideBarsEnabled(void) {
     return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyNativeHideBarsOnScroll];
 }
 
-// Off maps to Apollo's native toggle; the styles use the legacy persisted key.
 NSInteger ApolloTabBarHideStyleCurrentOptionIndex(void) {
-    if (!ApolloTabBarHideBarsEnabled()) return ApolloTabBarHideMenuModeOff;
     return MIN(ApolloTabBarHideStyleDown,
                MAX(ApolloTabBarHideStyleLeft, sTabBarHideStyle));
 }
@@ -49,7 +45,7 @@ NSArray<NSString *> *ApolloTabBarHideStyleOptionTitles(void) {
     static NSArray<NSString *> *titles;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        titles = @[@"Left", @"Right", @"Fade", @"Down", @"Off"];
+        titles = @[@"Left", @"Right", @"Fade", @"Down"];
     });
     return titles;
 }
@@ -57,7 +53,7 @@ NSArray<NSString *> *ApolloTabBarHideStyleOptionTitles(void) {
 NSString *ApolloTabBarHideStyleCurrentTitle(void) {
     NSArray<NSString *> *titles = ApolloTabBarHideStyleOptionTitles();
     NSInteger index = ApolloTabBarHideStyleCurrentOptionIndex();
-    return (index >= 0 && index < (NSInteger)titles.count) ? titles[index] : @"Off";
+    return (index >= 0 && index < (NSInteger)titles.count) ? titles[index] : @"Left";
 }
 
 // MARK: Runtime pill mirroring
@@ -186,14 +182,9 @@ void ApolloTabBarHideBarsSetEnabled(BOOL enabled) {
 }
 
 void ApolloTabBarHideStyleApplyOptionIndex(NSInteger optionIndex) {
-    NSInteger mode = MIN(ApolloTabBarHideMenuModeOff,
+    NSInteger mode = MIN(ApolloTabBarHideStyleDown,
                          MAX(ApolloTabBarHideStyleLeft, optionIndex));
-    if (mode == ApolloTabBarHideMenuModeOff) {
-        TabBarHideStyleSetNativeHideBars(NO);
-    } else {
-        TabBarHideStyleSet((ApolloTabBarHideStyle)mode);
-        TabBarHideStyleSetNativeHideBars(YES);
-    }
+    TabBarHideStyleSet((ApolloTabBarHideStyle)mode);
     TabBarHideStyleReconcileRuntime();
 }
 

--- a/src/ApolloTopBarScrollPresentation.h
+++ b/src/ApolloTopBarScrollPresentation.h
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+__BEGIN_DECLS
+
+// Presentation-only companion to the bottom bar's existing scroll policy.
+// The caller supplies bottom-bar state; this module owns no gesture or timer.
+void ApolloTopBarSetScrollHidden(UITabBarController *controller, BOOL hidden,
+    BOOL animated, NSString *reason);
+void ApolloTopBarRestoreNavigationController(UINavigationController *controller);
+void ApolloTopBarRevalidateNavigationController(UINavigationController *controller);
+void ApolloTopBarRevalidateHeaderView(UIView *view);
+
+__END_DECLS

--- a/src/ApolloTopBarScrollPresentation.m
+++ b/src/ApolloTopBarScrollPresentation.m
@@ -1,0 +1,416 @@
+#import "ApolloTopBarScrollPresentation.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+#import <QuartzCore/QuartzCore.h>
+#import <objc/runtime.h>
+#import <math.h>
+#import <string.h>
+
+static char kApolloTopBarScrollStateKey;
+static NSString *const ApolloTopBarScrollAnimationKey = @"apollo.topBar.scrollTranslation";
+static NSString *const ApolloTopBarScrollGenerationKey = @"apollo.topBar.generation";
+
+// UIKit draws the top scroll-edge region inside the content scroll view,
+// independently of UINavigationBar. This owner remains present even when the
+// selected Header Style makes its effect transparent. Keep each exact top
+// effect owner with the same presentation animation; its siblings include the
+// BOTTOM effect and a capture-only source.
+@interface ApolloTopBarHeaderPart : NSObject
+@property (nonatomic, weak) UIView *view;
+@property (nonatomic) BOOL originalInteractionEnabled;
+@property (nonatomic) BOOL originalAccessibilityHidden;
+@end
+@implementation ApolloTopBarHeaderPart
+@end
+
+@class ApolloTopBarScrollState;
+static NSHashTable<ApolloTopBarScrollState *> *sApolloTopBarActiveStates;
+static void ApolloTopBarRestoreHeaderParts(ApolloTopBarScrollState *state);
+
+@interface ApolloTopBarScrollState : NSObject <CAAnimationDelegate>
+@property (nonatomic, weak) UINavigationController *navigationController;
+@property (nonatomic, weak) UINavigationBar *bar;
+@property (nonatomic) BOOL hidden;
+@property (nonatomic) BOOL originalInteractionEnabled;
+@property (nonatomic) BOOL originalAccessibilityHidden;
+@property (nonatomic) CGFloat hiddenOffset;
+@property (nonatomic) NSUInteger generation;
+@property (nonatomic, strong) NSMutableArray<ApolloTopBarHeaderPart *> *headerParts;
+@end
+
+@implementation ApolloTopBarScrollState
+- (void)animationDidStop:(CAAnimation *)animation finished:(__unused BOOL)finished {
+    if (self.hidden ||
+        [[animation valueForKey:ApolloTopBarScrollGenerationKey] unsignedIntegerValue] != self.generation) return;
+    UINavigationController *controller = self.navigationController;
+    if (controller && objc_getAssociatedObject(controller, &kApolloTopBarScrollStateKey) == self) {
+        // UIKit may recreate or unhide the scroll view's top-edge effect while
+        // returning the navigation bar to its visible pose. Reassert the
+        // selected Header Style after that transition; this is especially
+        // visible in Gallery, where Hidden must remain transparent on reveal.
+        ApolloApplyScrollEdgeEffectStyleToViewController(controller.topViewController);
+        // Only the rendered bar moves; its model hit targets stay put. Keep
+        // them disabled until the reveal finishes (or UIKit removes it and
+        // restores the canonical visible pose).
+        ApolloTopBarRestoreHeaderParts(self);
+        [sApolloTopBarActiveStates removeObject:self];
+        self.bar.userInteractionEnabled = self.originalInteractionEnabled;
+        self.bar.accessibilityElementsHidden = self.originalAccessibilityHidden;
+        objc_setAssociatedObject(controller, &kApolloTopBarScrollStateKey, nil,
+            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+@end
+
+static ApolloTopBarScrollState *ApolloTopBarState(UINavigationController *controller) {
+    return objc_getAssociatedObject(controller, &kApolloTopBarScrollStateKey);
+}
+
+static BOOL ApolloTopBarScrollEnabled(void) {
+    return sHideTopBarOnScroll && ApolloSupportsNativeTabBarScrollBehavior() &&
+        [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyNativeHideBarsOnScroll];
+}
+
+static void ApolloTopBarRestoreHeaderPart(ApolloTopBarHeaderPart *part) {
+    [part.view.layer removeAnimationForKey:ApolloTopBarScrollAnimationKey];
+    part.view.userInteractionEnabled = part.originalInteractionEnabled;
+    part.view.accessibilityElementsHidden = part.originalAccessibilityHidden;
+}
+
+static void ApolloTopBarRestoreHeaderParts(ApolloTopBarScrollState *state) {
+    for (ApolloTopBarHeaderPart *part in state.headerParts) ApolloTopBarRestoreHeaderPart(part);
+    [state.headerParts removeAllObjects];
+}
+
+static BOOL ApolloTopBarIsNativeTopEffect(UIView *view) {
+    static Class effectClass;
+    static ptrdiff_t edgeOffset;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        effectClass = objc_getClass("UIKit.ScrollEdgeEffectView");
+        Ivar edge = class_getInstanceVariable(effectClass, "edge");
+        // UIKit stores this Swift RectEdge raw value as an eight-byte field.
+        // It has no ObjC getter/type encoding. Validate its storage boundary
+        // before reading, and fail open if a future UIKit changes the layout.
+        edgeOffset = edge ? ivar_getOffset(edge) : -1;
+        Ivar next = class_getInstanceVariable(effectClass, "reducedTransparency");
+        if (edgeOffset < 0 || !next || ivar_getOffset(next) - edgeOffset != sizeof(uint64_t) ||
+            (size_t)edgeOffset + sizeof(uint64_t) > class_getInstanceSize(effectClass)) {
+            edgeOffset = -1;
+        }
+    });
+    if (!effectClass || edgeOffset < 0 || ![view isKindOfClass:effectClass]) return NO;
+    uint64_t edge = 0;
+    memcpy(&edge, (const uint8_t *)(__bridge const void *)view + edgeOffset, sizeof(edge));
+    return edge == 1; // UIKit top=1, bottom=4; never move the bottom material.
+}
+
+static BOOL ApolloTopBarHeaderBelongsToState(UIView *view, ApolloTopBarScrollState *state) {
+    UIView *content = state.navigationController.topViewController.viewIfLoaded;
+    if (!content || view.window != state.bar.window || ![view isDescendantOfView:content] ||
+        view.hidden || view.alpha < 0.01 || !ApolloTopBarIsNativeTopEffect(view)) return NO;
+    CGRect frame = [view convertRect:view.bounds toView:view.window];
+    CGRect barFrame = [state.bar convertRect:state.bar.bounds toView:view.window];
+    // Exclude independent scroll regions inside cells. A header pocket meets
+    // this navigation bar in window coordinates, even on inverted lists.
+    return CGRectIntersectsRect(frame, barFrame);
+}
+
+static void ApolloTopBarCopyAnimationToHeader(ApolloTopBarScrollState *state,
+    ApolloTopBarHeaderPart *part) {
+    UIView *view = part.view;
+    if (!view.window || !view.superview) return;
+    CABasicAnimation *source = (CABasicAnimation *)[state.bar.layer animationForKey:ApolloTopBarScrollAnimationKey];
+    if (!source) return;
+    // Convert window-space travel to the effect's local Y direction. Inverted
+    // scroll views must still move their rendered header toward the screen top.
+    CGPoint zero = [view.superview convertPoint:CGPointZero fromView:view.window];
+    CGPoint unit = [view.superview convertPoint:CGPointMake(0, 1) fromView:view.window];
+    CGFloat scale = unit.y - zero.y;
+    CAAnimation *animation;
+    if (!state.hidden && [source isKindOfClass:CASpringAnimation.class]) {
+        CASpringAnimation *spring = (CASpringAnimation *)source;
+        CGFloat mass = spring.mass;
+        CGFloat stiffness = spring.stiffness;
+        CGFloat damping = spring.damping;
+        CGFloat start = [spring.fromValue doubleValue];
+        CGFloat target = [spring.toValue doubleValue];
+        CGFloat omega0 = sqrt(stiffness / mass);
+        CGFloat zeta = damping / (2.0 * sqrt(stiffness * mass));
+        CGFloat omegaD = omega0 * sqrt(MAX(0.0, 1.0 - zeta * zeta));
+        NSUInteger sampleCount = MAX(2, MIN(240, (NSUInteger)ceil(spring.duration * 120.0) + 1));
+        NSMutableArray<NSNumber *> *translations = [NSMutableArray arrayWithCapacity:sampleCount];
+        NSMutableArray<NSNumber *> *scales = [NSMutableArray arrayWithCapacity:sampleCount];
+        CGFloat effectHeight = CGRectGetHeight([view convertRect:view.bounds toView:view.window]);
+        for (NSUInteger index = 0; index < sampleCount; index++) {
+            CFTimeInterval time = spring.duration * index / (sampleCount - 1);
+            CGFloat displacement;
+            if (omegaD > 0.0001) {
+                CGFloat initial = start - target;
+                CGFloat velocity = spring.initialVelocity * (target - start);
+                displacement = exp(-zeta * omega0 * time) *
+                    (initial * cos(omegaD * time) +
+                     ((velocity + zeta * omega0 * initial) / omegaD) * sin(omegaD * time));
+            } else {
+                // The current spring is underdamped, but keep a stable path if
+                // its constants change to critical damping in the future.
+                displacement = (start - target) * exp(-omega0 * time);
+            }
+            CGFloat windowOffset = target + displacement;
+            CGFloat overshoot = MAX(0.0, windowOffset - target);
+            // Preserve the complete spring at the material's bottom edge.
+            // During positive overshoot, move its center half as far and grow
+            // it by the other half. The top edge therefore remains pinned at
+            // the screen while the lower edge bounces with the bar controls.
+            CGFloat centerOffset = MIN(target, windowOffset) + overshoot / 2.0;
+            [translations addObject:@(centerOffset * scale)];
+            [scales addObject:@(1.0 + (effectHeight > 0.0 ? overshoot / effectHeight : 0.0))];
+        }
+        CAKeyframeAnimation *translation = [CAKeyframeAnimation animationWithKeyPath:source.keyPath];
+        translation.values = translations;
+        translation.calculationMode = kCAAnimationLinear;
+        translation.duration = spring.duration;
+        translation.additive = spring.additive;
+        CAKeyframeAnimation *stretch = [CAKeyframeAnimation animationWithKeyPath:@"transform.scale.y"];
+        stretch.values = scales;
+        stretch.calculationMode = kCAAnimationLinear;
+        stretch.duration = spring.duration;
+        CAAnimationGroup *group = [CAAnimationGroup animation];
+        group.animations = @[translation, stretch];
+        group.duration = spring.duration;
+        group.fillMode = spring.fillMode;
+        group.removedOnCompletion = spring.removedOnCompletion;
+        animation = group;
+    } else {
+        CABasicAnimation *copy = [source copy];
+        copy.fromValue = @([source.fromValue doubleValue] * scale);
+        copy.toValue = @([source.toValue doubleValue] * scale);
+        animation = copy;
+    }
+    animation.delegate = nil; // Only the bar owns completion/interaction cleanup.
+    animation.beginTime = [view.layer convertTime:source.beginTime fromLayer:state.bar.layer];
+    [view.layer addAnimation:animation forKey:ApolloTopBarScrollAnimationKey];
+}
+
+static void ApolloTopBarAttachHeader(UIView *view, ApolloTopBarScrollState *state) {
+    if (!ApolloTopBarHeaderBelongsToState(view, state)) return;
+    for (ApolloTopBarHeaderPart *part in state.headerParts) {
+        if (part.view == view) return;
+    }
+    ApolloTopBarHeaderPart *part = [ApolloTopBarHeaderPart new];
+    part.view = view;
+    part.originalInteractionEnabled = view.userInteractionEnabled;
+    part.originalAccessibilityHidden = view.accessibilityElementsHidden;
+    [state.headerParts addObject:part];
+    // The native effect contains a TouchBlocker. Its model-space hit region
+    // must not remain over the newly exposed content while it is offscreen.
+    view.userInteractionEnabled = NO;
+    view.accessibilityElementsHidden = YES;
+    ApolloTopBarCopyAnimationToHeader(state, part);
+}
+
+static void ApolloTopBarCollectHeaders(UIView *view, ApolloTopBarScrollState *state) {
+    if (!view || view.hidden || view.alpha < 0.01) return;
+    if (ApolloTopBarIsNativeTopEffect(view)) {
+        ApolloTopBarAttachHeader(view, state);
+        return;
+    }
+    for (UIView *child in view.subviews) ApolloTopBarCollectHeaders(child, state);
+}
+
+static void ApolloTopBarSynchronizeHeaders(ApolloTopBarScrollState *state) {
+    for (ApolloTopBarHeaderPart *part in [state.headerParts copy]) {
+        if (!part.view || !ApolloTopBarHeaderBelongsToState(part.view, state)) {
+            ApolloTopBarRestoreHeaderPart(part);
+            [state.headerParts removeObject:part];
+        }
+    }
+    ApolloTopBarCollectHeaders(state.navigationController.topViewController.viewIfLoaded, state);
+}
+
+static CGFloat ApolloTopBarHiddenOffset(ApolloTopBarScrollState *state) {
+    // Include Hard's full material height and the glass/shadow overhang so the
+    // band and controls both clear the screen. Model geometry stays native.
+    UIWindow *window = state.bar.window;
+    CGRect frame = [state.bar convertRect:state.bar.bounds toView:window];
+    CGFloat bottom = CGRectGetMaxY(frame);
+    for (ApolloTopBarHeaderPart *part in state.headerParts) {
+        bottom = MAX(bottom, CGRectGetMaxY([part.view convertRect:part.view.bounds toView:window]));
+    }
+    return -MAX(0.0, bottom - CGRectGetMinY(window.bounds) + 16.0);
+}
+
+static CGFloat ApolloTopBarPresentedOffset(ApolloTopBarScrollState *state) {
+    CALayer *layer = state.bar.layer;
+    if (![layer animationForKey:ApolloTopBarScrollAnimationKey]) return 0.0;
+    CALayer *presentation = layer.presentationLayer;
+    return presentation ? presentation.transform.m42 - layer.transform.m42 : state.hiddenOffset;
+}
+
+static void ApolloTopBarAnimate(ApolloTopBarScrollState *state, CGFloat from, CGFloat to, BOOL animated) {
+    // Additive layer translation leaves UINavigationBar's frame, transform,
+    // safe-area contribution, and UIKit's navigation transitions untouched.
+    // Keep the completed hide as a presentation layer; remove only our key
+    // when revealing or yielding to a real navigation transition.
+    CAPropertyAnimation *animation;
+    if (animated && !UIAccessibilityIsReduceMotionEnabled()) {
+        CASpringAnimation *spring = [CASpringAnimation animationWithKeyPath:@"transform.translation.y"];
+        // Stretch the whole motion by 35% so the top bar keeps pace with the
+        // bottom bar. Scaling stiffness by time squared and damping by time
+        // preserves the spring's bounce; increasing duration alone does not
+        // slow a physical spring. Header copies share these parameters/clock.
+        const CGFloat timeScale = 1.35;
+        spring.mass = 1.0;
+        spring.stiffness = (state.hidden ? 420.0 : 320.0) / (timeScale * timeScale);
+        spring.damping = (state.hidden ? 32.0 : 24.0) / timeScale;
+        spring.initialVelocity = 0.0;
+        spring.fromValue = @(from);
+        spring.toValue = @(to);
+        spring.duration = spring.settlingDuration;
+        animation = spring;
+    } else {
+        CABasicAnimation *hold = [CABasicAnimation animationWithKeyPath:@"transform.translation.y"];
+        hold.fromValue = @(to);
+        hold.toValue = @(to);
+        hold.duration = 0.001;
+        animation = hold;
+    }
+    animation.beginTime = [state.bar.layer convertTime:CACurrentMediaTime() fromLayer:nil];
+    animation.additive = YES;
+    animation.fillMode = kCAFillModeBoth;
+    animation.removedOnCompletion = !state.hidden;
+    animation.delegate = state;
+    [animation setValue:@(state.generation) forKey:ApolloTopBarScrollGenerationKey];
+    [state.bar.layer addAnimation:animation forKey:ApolloTopBarScrollAnimationKey];
+    for (ApolloTopBarHeaderPart *part in state.headerParts) ApolloTopBarCopyAnimationToHeader(state, part);
+}
+
+void ApolloTopBarRestoreNavigationController(UINavigationController *controller) {
+    ApolloTopBarScrollState *state = ApolloTopBarState(controller);
+    if (!state) return;
+    state.generation++;
+    ApolloTopBarRestoreHeaderParts(state);
+    [sApolloTopBarActiveStates removeObject:state];
+    [state.bar.layer removeAnimationForKey:ApolloTopBarScrollAnimationKey];
+    state.bar.userInteractionEnabled = state.originalInteractionEnabled;
+    state.bar.accessibilityElementsHidden = state.originalAccessibilityHidden;
+    objc_setAssociatedObject(controller, &kApolloTopBarScrollStateKey, nil,
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloTopBarSetNavigationHidden(UINavigationController *controller, BOOL hidden,
+    BOOL animated, NSString *reason) {
+    if (!controller) return;
+    UINavigationBar *bar = controller.navigationBar;
+    ApolloTopBarScrollState *state = ApolloTopBarState(controller);
+    if (state && state.bar != bar) {
+        ApolloTopBarRestoreNavigationController(controller);
+        state = nil;
+    }
+    if (hidden && (!ApolloTopBarScrollEnabled() || controller.navigationBarHidden ||
+        !bar.window || bar.hidden || bar.alpha < 0.01)) hidden = NO;
+    if (!hidden && !state) return;
+    if (!hidden && (!animated || !bar.window || controller.navigationBarHidden)) {
+        ApolloTopBarRestoreNavigationController(controller);
+        return;
+    }
+    if (state && state.hidden == hidden && [bar.layer animationForKey:ApolloTopBarScrollAnimationKey]) return;
+    if (!state) {
+        state = [ApolloTopBarScrollState new];
+        state.navigationController = controller;
+        state.bar = bar;
+        state.headerParts = [NSMutableArray array];
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            sApolloTopBarActiveStates = [NSHashTable weakObjectsHashTable];
+            [[NSNotificationCenter defaultCenter] addObserverForName:ApolloScrollEdgeEffectStyleChangedNotification
+                object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+                    // Style changes rebuild the native pockets. Reconcile on
+                    // the next turn, after the style owner's layout nudges.
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        for (ApolloTopBarScrollState *active in sApolloTopBarActiveStates.allObjects) {
+                            ApolloTopBarRevalidateNavigationController(active.navigationController);
+                        }
+                    });
+                }];
+        });
+        [sApolloTopBarActiveStates addObject:state];
+        state.originalInteractionEnabled = bar.userInteractionEnabled;
+        state.originalAccessibilityHidden = bar.accessibilityElementsHidden;
+        objc_setAssociatedObject(controller, &kApolloTopBarScrollStateKey, state,
+            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    ApolloTopBarSynchronizeHeaders(state);
+    CGFloat from = ApolloTopBarPresentedOffset(state);
+    state.hidden = hidden;
+    state.hiddenOffset = hidden ? ApolloTopBarHiddenOffset(state) : 0.0;
+    state.generation++;
+    bar.userInteractionEnabled = NO;
+    bar.accessibilityElementsHidden = YES;
+    ApolloTopBarAnimate(state, from, state.hiddenOffset, animated);
+    ApolloLog(@"[AutoHideTopBar] %@ offset=%.1f headerEffects=%lu reason=%@",
+        hidden ? @"hidden" : @"revealed", state.hiddenOffset, (unsigned long)state.headerParts.count, reason);
+}
+
+static UINavigationController *ApolloTopBarNavigationController(UIViewController *controller) {
+    return [controller isKindOfClass:UINavigationController.class]
+        ? (UINavigationController *)controller : controller.navigationController;
+}
+
+void ApolloTopBarSetScrollHidden(UITabBarController *controller, BOOL hidden,
+    BOOL animated, NSString *reason) {
+    UINavigationController *selected = ApolloTopBarNavigationController(controller.selectedViewController);
+    // A tab switch must release the OLD bar as well as configure the new one.
+    // Each navigation controller retains only its own state, with weak views.
+    for (UIViewController *child in controller.viewControllers) {
+        UINavigationController *navigation = ApolloTopBarNavigationController(child);
+        if (navigation != selected) ApolloTopBarRestoreNavigationController(navigation);
+    }
+    ApolloTopBarSetNavigationHidden(selected, hidden, animated, reason);
+}
+
+void ApolloTopBarRevalidateNavigationController(UINavigationController *controller) {
+    ApolloTopBarScrollState *state = ApolloTopBarState(controller);
+    if (!state) return;
+    UINavigationBar *bar = controller.navigationBar;
+    if (!ApolloTopBarScrollEnabled() || state.bar != bar || controller.navigationBarHidden ||
+        !bar.window || bar.hidden || bar.alpha < 0.01) {
+        ApolloTopBarRestoreNavigationController(controller);
+        return;
+    }
+    ApolloTopBarSynchronizeHeaders(state);
+    if (!state.hidden) return;
+    CGFloat offset = ApolloTopBarHiddenOffset(state);
+    CAAnimation *current = [bar.layer animationForKey:ApolloTopBarScrollAnimationKey];
+    if (offset < state.hiddenOffset - 0.5 || !current) {
+        // A newly created/taller Hard pocket may need more travel. Retarget
+        // from the rendered pose while the spring is running. Keep sufficient
+        // travel when search collapses and makes the native header shorter;
+        // shrinking that target mid-flight would snap it back toward the edge.
+        CGFloat from = ApolloTopBarPresentedOffset(state);
+        CFTimeInterval now = [bar.layer convertTime:CACurrentMediaTime() fromLayer:nil];
+        BOOL inFlight = current && now < current.beginTime + current.duration;
+        state.hiddenOffset = MIN(state.hiddenOffset, offset);
+        state.generation++;
+        ApolloTopBarAnimate(state, from, state.hiddenOffset, inFlight);
+    }
+}
+
+// Called after UIKit lays out an effect. New/replaced pockets join the same
+// spring at its existing timestamp instead of flashing a stationary band.
+void ApolloTopBarRevalidateHeaderView(UIView *view) {
+    if (!sApolloTopBarActiveStates.count) return;
+    for (ApolloTopBarScrollState *state in sApolloTopBarActiveStates) {
+        if (!ApolloTopBarHeaderBelongsToState(view, state)) continue;
+        ApolloTopBarAttachHeader(view, state);
+        if (state.hidden && ApolloTopBarHiddenOffset(state) < state.hiddenOffset - 0.5) {
+            ApolloTopBarRevalidateNavigationController(state.navigationController);
+        }
+        for (ApolloTopBarHeaderPart *part in state.headerParts) {
+            if (part.view == view && ![view.layer animationForKey:ApolloTopBarScrollAnimationKey]) {
+                ApolloTopBarCopyAnimationToHeader(state, part);
+            }
+        }
+    }
+}

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3785,6 +3785,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
                                     UDKeyCommunityHighlightsWeb: @NO,
                                     UDKeyAutoHideTabBarShowOnIdle: @YES,
                                     UDKeyClassicTabBarScrollBehavior: @NO,
+                                    UDKeyHideTopBarOnScroll: @NO,
                                     UDKeyTabBarCollapseSide: @0,
                                     UDKeyKeepSearchBarInPlace: @NO,
                                     UDKeyIPadTabBarBottom: @NO,
@@ -4044,6 +4045,7 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];
     sCommunityHighlightsWeb = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlightsWeb];
     sClassicTabBarScrollBehavior = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyClassicTabBarScrollBehavior];
+    sHideTopBarOnScroll = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTopBarOnScroll];
     if (ApolloSupportsNativeTabBarScrollBehavior() &&
         ![standardDefaults boolForKey:UDKeyAutoHideTabBarShowOnIdle]) {
         // Idle re-expansion is now bundled into both selectable scroll modes.
@@ -4090,13 +4092,9 @@ static BOOL ApolloDefaultsKeyChangesNativeFavorites(NSString *key) {
         // result once, then store the explicit Soft/Hard choice users now see.
         sScrollEdgeEffectStyle = systemHeaderStyle;
         [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];
-    } else if (sScrollEdgeEffectStyle == 3) {
-        // Retired Hidden mode: closest surviving intent (no hard cutoff line)
-        // is Soft. 3 stays reserved — see the enum note in ApolloState.h.
-        sScrollEdgeEffectStyle = ApolloScrollEdgeEffectStyleSoft;
-        [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];
     } else if (sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleSoft &&
                sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleHard &&
+               sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleHidden &&
                sScrollEdgeEffectStyle != ApolloScrollEdgeEffectStyleBlur) {
         sScrollEdgeEffectStyle = systemHeaderStyle;
         [standardDefaults setInteger:sScrollEdgeEffectStyle forKey:UDKeyScrollEdgeEffectStyle];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -267,6 +267,9 @@ static NSString *const UDKeyClassicTabBarScrollBehavior = @"ClassicTabBarScrollB
 // Apollo's native preference, mirrored in Reborn's Interface > Tab Bar screen
 // and consumed by the Liquid Glass compatibility layer as its source of truth.
 static NSString *const UDKeyNativeHideBarsOnScroll = @"HideBarsOnScroll";
+// Liquid Glass only. Also hides/reveals the top navigation bar with the bottom
+// tab bar while Hide Bars on Scroll is enabled. Default NO; remembered when off.
+static NSString *const UDKeyHideTopBarOnScroll = @"HideTopBarOnScroll";
 // Liquid Glass "Hide Bars on Scroll" presentation: 0 = collapsed pill on the
 // Left (system default), 1 = collapsed pill on the Right, 2 = fade the full tab
 // bar out, 3 = sink the full tab bar down while fading. The styles plus Off are
@@ -338,7 +341,7 @@ static NSString *const UDKeyPerPostCommentSortMapping = @"PerPostCommentSortMapp
 static NSString *const UDKeyApolloRememberSubredditCommentsSort = @"RememberRedditCommentsSort";
 // Override for the UIScrollView top scroll edge effect (Liquid Glass, iOS 26+).
 // 0 = retired System Default (migrates to 1 on iOS 26 or 2 on iOS 27),
-// 1 = Soft, 2 = Hard, 3 = retired Hidden, 4 = Blur.
+// 1 = Soft, 2 = Hard, 3 = Hidden, 4 = Blur.
 static NSString *const UDKeyScrollEdgeEffectStyle = @"ScrollEdgeEffectStyle";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -17,7 +17,6 @@
 #import "settings/ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
 #import "ApolloAccountCredentials.h"
-#import "ApolloWebJSON.h"           // ApolloWebJSONBearerIsSynthetic() — widget setup code
 #import "ApolloPerAccountFavorites.h"
 #import "ApolloFavoritesSorting.h"
 #import "ApolloState.h"
@@ -64,6 +63,63 @@
 // mirror the video player's own speed menu minus 1.0× (holding at normal speed
 // would be a no-op). ApolloSanitizedHoldSpeed() guards the stored value to this set.
 static const float kVideoHoldSpeeds[] = { 0.25f, 0.5f, 0.75f, 1.25f, 1.5f, 2.0f };
+static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailable);
+
+// Compact native pull-down used by Liquid Glass settings. The current value
+// stays visible in the row and the paired chevrons communicate that it opens
+// a menu rather than navigating to another screen.
+static UIButton *ApolloSettingsMenuButton(NSString *menuTitle,
+                                          NSString *currentTitle,
+                                          NSArray<NSString *> *titles,
+                                          NSInteger currentIndex,
+                                          void (^apply)(NSInteger index)) {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    UIImageSymbolConfiguration *symbolConfiguration =
+        [UIImageSymbolConfiguration configurationWithPointSize:9.0 weight:UIImageSymbolWeightSemibold];
+    UIImage *chevrons = [UIImage systemImageNamed:@"chevron.up.chevron.down"
+                                withConfiguration:symbolConfiguration];
+    UIColor *foreground = UIColor.secondaryLabelColor;
+    if (@available(iOS 15.0, *)) {
+        UIButtonConfiguration *configuration = [UIButtonConfiguration plainButtonConfiguration];
+        configuration.title = currentTitle;
+        configuration.image = chevrons;
+        configuration.imagePlacement = NSDirectionalRectEdgeTrailing;
+        configuration.imagePadding = 3.0;
+        configuration.contentInsets = NSDirectionalEdgeInsetsZero;
+        configuration.baseForegroundColor = foreground;
+        configuration.titleTextAttributesTransformer =
+            ^NSDictionary<NSAttributedStringKey, id> *(NSDictionary<NSAttributedStringKey, id> *attributes) {
+                NSMutableDictionary *compact = [attributes mutableCopy];
+                compact[NSFontAttributeName] = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+                compact[NSForegroundColorAttributeName] = foreground;
+                return compact;
+            };
+        button.configuration = configuration;
+    } else {
+        [button setTitle:currentTitle forState:UIControlStateNormal];
+        [button setImage:chevrons forState:UIControlStateNormal];
+        [button setTitleColor:foreground forState:UIControlStateNormal];
+        button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+        button.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    }
+    button.tintColor = foreground;
+    NSMutableArray<UIAction *> *actions = [NSMutableArray arrayWithCapacity:titles.count];
+    [titles enumerateObjectsUsingBlock:^(NSString *title, NSUInteger index, __unused BOOL *stop) {
+        UIAction *action = [UIAction actionWithTitle:title image:nil identifier:nil
+                                             handler:^(__unused UIAction *selected) {
+            if (apply) apply((NSInteger)index);
+        }];
+        action.state = ((NSInteger)index == currentIndex)
+            ? UIMenuElementStateOn : UIMenuElementStateOff;
+        [actions addObject:action];
+    }];
+    button.menu = [UIMenu menuWithTitle:menuTitle image:nil identifier:nil
+                                options:UIMenuOptionsSingleSelection children:actions];
+    button.showsMenuAsPrimaryAction = YES;
+    button.accessibilityLabel = currentTitle;
+    [button sizeToFit];
+    return button;
+}
 
 // "0.25×" / "0.5×" / … / "2×", using the U+00D7 multiplication sign Apollo uses.
 static NSString *ApolloVideoHoldSpeedTitle(float speed) {
@@ -838,9 +894,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self reloadRowWithID:@"linkPreviews.settings"];
     [self reloadRowWithID:@"polls.settings"];
     [self reloadRowWithID:@"sub.feedShortcuts"];
-    // Refresh the tab-bar presentation and its dependent gesture row after
+    // Refresh the tab-bar presentation and its dependent rows after
     // returning to Interface or after preferences are restored elsewhere.
+    [self visibilityDidChange];
     [self reloadRowWithID:@"interface.hideBarsOnScroll"];
+    [self reloadRowWithID:@"interface.hideTopBarToo"];
     [self reloadRowWithID:@"interface.tabBarScrollBehavior"];
     // Refresh the Profile Layout summary after returning from that screen
     // (Density/Avatar/band switches may have just changed).
@@ -1542,7 +1600,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onSelect:^{ [weakSelf copyWidgetSetupCode]; }];
 
     return [ApolloSettingsSection sectionWithTitle:@"Extras"
-                                            footer:@"Copy a code to set up Apollo's home-screen widgets. Include your account for Home and multireddit feeds."
+                                            footer:@"Copy a code to set up the Apollo home-screen widget."
                                               rows:@[ widgetSetupCode ]];
 }
 
@@ -1764,65 +1822,75 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf hideUsernameTabSwitchToggled:sender]; }];
     hideUsernameTab.visible = ^BOOL { return !sHideTabBarTitles; };
 
-    ApolloSettingsRow *hideBarsOnScroll;
-    if (ApolloSupportsNativeTabBarScrollBehavior()) {
-        hideBarsOnScroll =
-            [ApolloSettingsRow valueRowWithID:@"interface.hideBarsOnScroll"
-                                        title:@"Hide Bars on Scroll"
-                                       detail:^NSString * { return ApolloTabBarHideStyleCurrentTitle(); }
-                                     onSelect:^{
-                ApolloSettingsPresentPicker(weakSelf,
-                    [weakSelf cellForRowID:@"interface.hideBarsOnScroll"],
-                    @"Hide Bars on Scroll",
-                    ApolloTabBarHideStyleOptionTitles(),
-                    ApolloTabBarHideStyleCurrentOptionIndex(),
-                    ^(NSInteger pickedIndex) {
-                        ApolloTabBarHideStyleApplyOptionIndex(pickedIndex);
-                        [weakSelf reloadRowWithID:@"interface.hideBarsOnScroll"];
-                        [weakSelf reloadRowWithID:@"interface.tabBarScrollBehavior"];
-                    });
-            }];
-        hideBarsOnScroll.configure = ^(UITableViewCell *cell) {
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-        };
-    } else {
-        // Before Liquid Glass, retain the original on/off control rather than
-        // offering presentation styles the system cannot display.
-        hideBarsOnScroll =
-            [ApolloSettingsRow switchRowWithID:@"interface.hideBarsOnScroll"
-                                         title:@"Hide Bars on Scroll"
-                                          isOn:^BOOL { return ApolloTabBarHideBarsEnabled(); }
-                                      onToggle:^(UISwitch *sender) {
-                ApolloTabBarHideBarsSetEnabled(sender.isOn);
-                [weakSelf reloadRowWithID:@"interface.tabBarScrollBehavior"];
-            }];
-    }
+    ApolloSettingsRow *hideBarsOnScroll =
+        [ApolloSettingsRow switchRowWithID:@"interface.hideBarsOnScroll"
+                                     title:@"Hide Bars on Scroll"
+                                      isOn:^BOOL { return ApolloTabBarHideBarsEnabled(); }
+                                  onToggle:^(UISwitch *sender) {
+            ApolloTabBarHideBarsSetEnabled(sender.isOn);
+            [weakSelf visibilityDidChange];
+        }];
+
+    ApolloSettingsRow *hideStyle =
+        [ApolloSettingsRow customRowWithID:@"interface.hideStyle"
+                                      cell:^UITableViewCell *(UITableView *table, __unused ApolloSettingsRow *row) {
+            UITableViewCell *cell = [table dequeueReusableCellWithIdentifier:@"ApolloHideStyleMenu"];
+            if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                                      reuseIdentifier:@"ApolloHideStyleMenu"];
+            cell.textLabel.text = @"Hide Style";
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.accessoryView = ApolloSettingsMenuButton(@"Hide Style", ApolloTabBarHideStyleCurrentTitle(),
+                ApolloTabBarHideStyleOptionTitles(), ApolloTabBarHideStyleCurrentOptionIndex(),
+                ^(NSInteger index) {
+                    ApolloTabBarHideStyleApplyOptionIndex(index);
+                    [weakSelf reloadRowWithID:@"interface.hideStyle"];
+                });
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
+            return cell;
+        } onSelect:nil];
+    hideStyle.visible = ^BOOL {
+        return ApolloSupportsNativeTabBarScrollBehavior() && ApolloTabBarHideBarsEnabled();
+    };
+
+    // Keep the remembered choice while Hide Bars is off; only its row hides.
+    ApolloSettingsRow *hideTopBarToo =
+        [ApolloSettingsRow switchRowWithID:@"interface.hideTopBarToo"
+                                     title:@"Hide Header on Scroll"
+                                      isOn:^BOOL { return sHideTopBarOnScroll; }
+                                  onToggle:^(UISwitch *sender) {
+            if (sHideTopBarOnScroll == sender.isOn) return;
+            sHideTopBarOnScroll = sender.isOn;
+            [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyHideTopBarOnScroll];
+            [[NSNotificationCenter defaultCenter]
+                postNotificationName:ApolloTabBarScrollBehaviorChangedNotification object:nil];
+        }];
+    hideTopBarToo.visible = ^BOOL {
+        return ApolloSupportsNativeTabBarScrollBehavior() && ApolloTabBarHideBarsEnabled();
+    };
 
     // Both behavior choices include idle re-expansion. A single picker keeps
     // the gesture models mutually exclusive and explicit.
     ApolloSettingsRow *tabBarScrollBehavior =
-        [ApolloSettingsRow valueRowWithID:@"interface.tabBarScrollBehavior"
-                                    title:@"Scroll Behavior"
-                                   detail:^NSString * { return sClassicTabBarScrollBehavior ? @"Classic" : @"Two-Gesture"; }
-                                 onSelect:^{
-            ApolloSettingsPresentPicker(weakSelf,
-                [weakSelf cellForRowID:@"interface.tabBarScrollBehavior"],
-                @"Scroll Behavior",
-                @[ @"Two-Gesture", @"Classic" ],
-                sClassicTabBarScrollBehavior ? 1 : 0,
-                ^(NSInteger pickedIndex) {
-                    [weakSelf setTabBarScrollBehaviorClassic:(pickedIndex == 1)];
+        [ApolloSettingsRow customRowWithID:@"interface.tabBarScrollBehavior"
+                                      cell:^UITableViewCell *(UITableView *table, __unused ApolloSettingsRow *row) {
+            UITableViewCell *cell = [table dequeueReusableCellWithIdentifier:@"ApolloScrollBehaviorMenu"];
+            if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                                      reuseIdentifier:@"ApolloScrollBehaviorMenu"];
+            cell.textLabel.text = @"Scroll Behavior";
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.accessoryView = ApolloSettingsMenuButton(@"Scroll Behavior",
+                sClassicTabBarScrollBehavior ? @"Classic" : @"Two-Gesture",
+                @[ @"Two-Gesture", @"Classic" ], sClassicTabBarScrollBehavior ? 1 : 0,
+                ^(NSInteger index) {
+                    [weakSelf setTabBarScrollBehaviorClassic:(index == 1)];
+                    [weakSelf reloadRowWithID:@"interface.tabBarScrollBehavior"];
                 });
-        }];
-    tabBarScrollBehavior.configure = ^(UITableViewCell *cell) {
-        cell.accessoryType = [weakSelf apollo_nativeHideBarsOnScrollEnabled]
-            ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
+            return cell;
+        } onSelect:nil];
+    tabBarScrollBehavior.visible = ^BOOL {
+        return ApolloSupportsNativeTabBarScrollBehavior() && ApolloTabBarHideBarsEnabled();
     };
-    tabBarScrollBehavior.enabled = ^BOOL {
-        return ApolloSupportsNativeTabBarScrollBehavior() &&
-               [weakSelf apollo_nativeHideBarsOnScrollEnabled];
-    };
-    tabBarScrollBehavior.visible = ^BOOL { return ApolloSupportsNativeTabBarScrollBehavior(); };
 
     // Temporary iPad stopgap (#387): only show it where the option can work.
     ApolloSettingsRow *iPadTabBarBottom =
@@ -1840,7 +1908,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     return [ApolloSettingsSection sectionWithTitle:@"Tab Bar"
                                             footer:footer
                                               rows:@[ profileTabAvatar, iconOnlyTabBar, hideUsernameTab,
-                                                      hideBarsOnScroll, tabBarScrollBehavior,
+                                                      hideBarsOnScroll, hideStyle, hideTopBarToo, tabBarScrollBehavior,
                                                       iPadTabBarBottom ]];
 }
 
@@ -1860,30 +1928,49 @@ typedef NS_ENUM(NSInteger, Tag) {
     // Glass only — hidden otherwise rather than shown-disabled, since the row
     // has nothing to preview/explain on a non-Glass device.
     ApolloSettingsRow *scrollEdgeEffect =
-        [ApolloSettingsRow valueRowWithID:@"gen.scrollEdgeEffect"
-                                    title:@"Header Style"
-                                   detail:^NSString * { return [weakSelf scrollEdgeEffectStyleText]; }
-                                 onSelect:^{
-            [weakSelf presentScrollEdgeEffectStyleSheetFromSourceView:[weakSelf cellForRowID:@"gen.scrollEdgeEffect"]];
-        }];
-    scrollEdgeEffect.configure = ^(UITableViewCell *cell) { cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator; };
+        [ApolloSettingsRow customRowWithID:@"gen.scrollEdgeEffect"
+                                      cell:^UITableViewCell *(UITableView *table, __unused ApolloSettingsRow *row) {
+            UITableViewCell *cell = [table dequeueReusableCellWithIdentifier:@"ApolloHeaderStyleMenu"];
+            if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                                      reuseIdentifier:@"ApolloHeaderStyleMenu"];
+            BOOL blurAvailable = ApolloProgressiveBlurAvailable();
+            NSMutableArray<NSString *> *titles = [NSMutableArray arrayWithObjects:@"Soft", @"Hard", nil];
+            if (blurAvailable) [titles addObject:@"Blur"];
+            [titles addObject:@"Hidden"];
+            NSInteger currentIndex = 0;
+            NSInteger currentStyle = ApolloResolvedScrollEdgeEffectStyle();
+            for (NSInteger index = 0; index < (NSInteger)titles.count; index++) {
+                if (ApolloHeaderStylePickerValue(index, blurAvailable) == currentStyle) {
+                    currentIndex = index;
+                    break;
+                }
+            }
+            cell.textLabel.text = @"Header Style";
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            cell.accessoryView = ApolloSettingsMenuButton(@"Header Style", [weakSelf scrollEdgeEffectStyleText],
+                titles, currentIndex, ^(NSInteger index) {
+                    [weakSelf setScrollEdgeEffectStyle:ApolloHeaderStylePickerValue(index, blurAvailable)];
+                });
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
+            return cell;
+        } onSelect:nil];
     scrollEdgeEffect.visible = ^BOOL { return IsLiquidGlass(); };
 
     return [ApolloSettingsSection sectionWithTitle:@"Display & Navigation"
-                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nIn Liquid Glass, navigation titles stay centered unless expanded actions need room. Tap the top-right ellipsis to reveal navigation actions; scrolling collapses them. Header Style: Soft is the iOS 26 default; Hard is the iOS 27 default."
+                                            footer:@"User Profile Pictures adds avatars beside usernames in posts, comments, messages, inbox rows, and moderator lists. Liquid Glass is required for the remaining options.\n\nIn Liquid Glass, navigation titles stay centered unless expanded actions need room. Tap the top-right ellipsis to reveal navigation actions; scrolling collapses them. Header Style: Soft is the iOS 26 default; Hard is the iOS 27 default. Hidden removes the header edge effect entirely."
                                               rows:@[ userAvatars, scrollEdgeEffect ]];
 }
 
-// Display order of the Header Style picker. Raw values are NOT contiguous
-// (3 was the retired Hidden mode, Blur is 4), so the picker maps index↔value
-// through this table instead of using the enum value as the index.
+// Display order differs from stored values; Blur is optional, while Hidden
+// always remains the last choice. Map picker indices explicitly.
 static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailable) {
     const NSInteger values[] = {
         ApolloScrollEdgeEffectStyleSoft,
         ApolloScrollEdgeEffectStyleHard,
-        ApolloScrollEdgeEffectStyleBlur,
+        blurAvailable ? ApolloScrollEdgeEffectStyleBlur : ApolloScrollEdgeEffectStyleHidden,
+        ApolloScrollEdgeEffectStyleHidden,
     };
-    NSInteger count = blurAvailable ? 3 : 2;
+    NSInteger count = blurAvailable ? 4 : 3;
     if (index < 0 || index >= count) return ApolloScrollEdgeEffectStyleSoft;
     return values[index];
 }
@@ -1893,6 +1980,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
         case ApolloScrollEdgeEffectStyleSoft: return @"Soft";
         case ApolloScrollEdgeEffectStyleHard: return @"Hard";
         case ApolloScrollEdgeEffectStyleBlur: return @"Blur";
+        case ApolloScrollEdgeEffectStyleHidden: return @"Hidden";
         default: return @"Soft";
     }
 }
@@ -1911,6 +1999,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     NSMutableArray<NSString *> *options =
         [NSMutableArray arrayWithObjects:@"Soft", @"Hard", nil];
     if (blurAvailable) [options addObject:@"Blur"];
+    [options addObject:@"Hidden"];
 
     NSInteger currentIndex = 0;
     NSInteger currentStyle = ApolloResolvedScrollEdgeEffectStyle();
@@ -3366,42 +3455,6 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     }
 }
 
-// The signed-in account's OAuth refresh token plus the client id it was issued
-// under, for the "with account" widget setup code. Nil when nobody is signed
-// in, when the active account is a web-session (keyless) one — those carry a
-// synthetic bearer and no refresh token — or when the credential is missing.
-static NSDictionary *ApolloWidgetAccountCredentials(void) {
-    id client = ApolloActiveAccountClient();
-    if (!client) return nil;
-    NSString *username = ApolloActiveAccountUsername();
-    if (username.length > 0 && ApolloWebSessionFor(username) != nil) return nil;
-
-    id refreshToken = nil, accessToken = nil, credentialClientId = nil;
-    @try {
-        id credential = [client valueForKey:@"authorizationCredential"];
-        id token = [credential valueForKey:@"accessToken"];
-        refreshToken = [token valueForKey:@"refreshToken"];
-        accessToken = [token valueForKey:@"accessToken"];
-        credentialClientId = [credential valueForKey:@"clientIdentifier"];
-    } @catch (__unused NSException *e) {
-        return nil;
-    }
-    if (![refreshToken isKindOfClass:[NSString class]] || [refreshToken length] == 0) return nil;
-    if ([accessToken isKindOfClass:[NSString class]] && ApolloWebJSONBearerIsSynthetic(accessToken)) return nil;
-
-    // Reddit binds a refresh token to the client id that issued it, and the
-    // credential's own id is what RedditKit presents on every refresh — so
-    // that's the id the widget must present too. Fall back to the effective
-    // (per-account, then global) key only when the credential carries none.
-    NSString *clientId = ([credentialClientId isKindOfClass:[NSString class]] && [credentialClientId length] > 0)
-        ? credentialClientId : (ApolloEffectiveRedditClientId() ?: sRedditClientId);
-    if (clientId.length == 0) return nil;
-
-    NSMutableDictionary *account = [@{ @"clientID": clientId, @"refreshToken": refreshToken } mutableCopy];
-    if (username.length > 0) account[@"username"] = username;
-    return account;
-}
-
 - (void)copyWidgetSetupCode {
     NSString *clientID = sRedditClientId ?: @"";
     if (clientID.length == 0) {
@@ -3410,58 +3463,11 @@ static NSDictionary *ApolloWidgetAccountCredentials(void) {
         return;
     }
 
-    // With a signed-in API-key account the code can carry its login, which is
-    // what the widgets need for Home and private multireddits — but that's the
-    // user's choice, so ask. Keyless/no account: the plain code, as before.
-    NSDictionary *account = ApolloWidgetAccountCredentials();
-    if (!account) {
-        [self copyWidgetSetupCodeWithAccount:nil];
-        return;
-    }
-    __weak typeof(self) weakSelf = self;
-    UIAlertController *sheet = [UIAlertController
-        alertControllerWithTitle:@"Widget Setup Code"
-                         message:@"Include your account so widgets can show Home and your private multireddits."
-                  preferredStyle:UIAlertControllerStyleActionSheet];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy with Account" style:UIAlertActionStyleDefault
-                                            handler:^(__unused UIAlertAction *action) {
-        [weakSelf copyWidgetSetupCodeWithAccount:account];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Copy without Account" style:UIAlertActionStyleDefault
-                                            handler:^(__unused UIAlertAction *action) {
-        [weakSelf copyWidgetSetupCodeWithAccount:nil];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-    UITableViewCell *cell = [self cellForRowID:@"api.widgetSetupCode"];
-    sheet.popoverPresentationController.sourceView = cell ?: self.view;
-    sheet.popoverPresentationController.sourceRect = (cell ?: self.view).bounds;
-    [self presentViewController:sheet animated:YES completion:nil];
-}
-
-- (void)copyWidgetSetupCodeWithAccount:(NSDictionary *)account {
-    // base64( JSON { v, clientID, userAgent[, clientSecret][, refreshToken,
-    // username] } ) — decoded by the widget's SetupCode parser. userAgent is
-    // included so the widget's Reddit requests carry the same identity as the
-    // configured (spoofed) app. clientSecret only exists for "web app" keys,
-    // whose token endpoint refuses the empty password installed apps use.
-    // With an account the code is v2 and carries the OAuth refresh token —
-    // that is what lets the widget read Home and private multireddits. Reddit
-    // does not rotate refresh tokens on use, so the widget minting its own
-    // access tokens never invalidates the app's session. `issued` (unix
-    // seconds) lets the widgets treat the most recently copied code as the
-    // one that wins everywhere — so copying "without account" and pasting it
-    // into any widget is how account access is removed again.
-    NSString *clientID = account[@"clientID"] ?: (sRedditClientId ?: @"");
-    NSMutableDictionary *payload = [@{ @"v": account ? @2 : @1,
-                                       @"clientID": clientID,
-                                       @"issued": @((long long)[NSDate date].timeIntervalSince1970) } mutableCopy];
+    // base64( JSON { v, clientID, userAgent } ) — decoded by the widget's
+    // SetupCode parser. userAgent is included so the widget's Reddit requests
+    // carry the same identity as the configured (spoofed) app.
+    NSMutableDictionary *payload = [@{ @"v": @1, @"clientID": clientID } mutableCopy];
     if (sUserAgent.length > 0) payload[@"userAgent"] = sUserAgent;
-    NSString *secret = ApolloSecretForClientId(clientID);
-    if (secret.length > 0) payload[@"clientSecret"] = secret;
-    if (account) {
-        payload[@"refreshToken"] = account[@"refreshToken"];
-        if ([account[@"username"] length] > 0) payload[@"username"] = account[@"username"];
-    }
 
     NSData *json = [NSJSONSerialization dataWithJSONObject:payload options:0 error:NULL];
     if (!json) {
@@ -3476,11 +3482,8 @@ static NSDictionary *ApolloWidgetAccountCredentials(void) {
     };
     [[UIPasteboard generalPasteboard] setItems:@[item] options:options];
 
-    NSString *how = @"Long-press an Apollo widget → Edit Widget and paste it into Setup Code. One paste covers every widget";
     [self showAlertWithTitle:@"Copied"
-                     message:account
-                         ? [NSString stringWithFormat:@"Setup code copied. %@. It includes your account login, so don't share it.", how]
-                         : [NSString stringWithFormat:@"Setup code copied. %@ and removes any account you added before.", how]];
+                     message:@"Setup code copied. On your Home Screen, add the Apollo “Showerthoughts” widget, long-press it → Edit Widget, and paste this code into Setup Code."];
 }
 
 - (void)testNotificationBackendConnection {


### PR DESCRIPTION
## Summary

This adds optional top navigation bar hiding alongside Apollo’s existing Hide Bars on Scroll behavior on Liquid Glass.

When **Hide Header on Scroll** is enabled, the navigation bar and its header material follow the bottom tab bar as it hides and reappears. The implementation supports both scroll modes:

- **Two-Gesture:** preserves the first consumed downward gesture before hiding again.
- **Classic:** follows the original immediate hide and reveal behavior.

## Settings improvements

The Interface settings now separate the related controls:

- **Hide Bars on Scroll** is an independent toggle.
- **Hide Style** selects Left, Right, Fade, or Down.
- **Hide Header on Scroll** controls whether the top bar follows the bottom bar.
- **Scroll Behavior** selects Two-Gesture or Classic.

Hide Style, Scroll Behavior, and Header Style now use native Liquid Glass menus with:

- A title inside each menu.
- The currently selected value displayed in the row.
- Compact gray up/down chevrons.

The dependent settings are hidden while Hide Bars on Scroll is disabled, while their saved selections are preserved.

## Header style fixes

Gallery view now respects the selected Header Style while scrolling and after the top bar reappears. Its content extends beneath the navigation controls, preventing an opaque Hard-style strip from remaining visible when another style is selected.

The selected header treatment is reapplied after reveal animations so swiping the bars away and back does not restore an unwanted background.

## Preview 

<img width="302" height="656" alt="Screenshot Apollo-Sim 09-11-2026 at 12 38 10 AM" src="https://github.com/user-attachments/assets/7effb019-90aa-489f-83b7-afc449aa00a7" />

## Validation

Tested in the iOS simulator with Liquid Glass enabled, including:

- Hiding and revealing the top and bottom bars.
- Two-Gesture and Classic behavior.
- Left, Right, Fade, and Down hide styles.
- Soft, Hard, Blur, and Hidden header styles.
- Gallery scrolling and repeated hide/reveal cycles.
- Disabling Hide Bars on Scroll while the bars are hidden.