### PR TITLE
Video unmute: keep rotation-driven inline visibility ticks off the fullscreen player (#1072)

### DIFF
--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -18,6 +18,8 @@
 #import "ApolloAccountCredentials.h"
 #import "ApolloChatRoomDirectory.h"
 #import "ApolloCommentVoteInsights.h"
+#import <AVFoundation/AVFoundation.h>
+#import <objc/runtime.h>
 #import "ApolloCommon.h"
 #import "ApolloFloatingTabs.h"
 #import "ApolloLinkPreviewFetcher.h"
@@ -69,6 +71,84 @@ static NSString *ApolloSimTapFile(void) {
 static NSString *ApolloSimTapNotify(void) {
     NSString *env = NSProcessInfo.processInfo.environment[@"APOLLOFIX_TAP_NOTIFY"];
     return env.length ? env : kApolloSimDefaultTapNotify;
+}
+
+// "mediastate": dump the presented fullscreen viewer's player + the audio
+// session, for the rotation-mute diagnosis (issue #1072).
+static id ApolloSimDebugIvar(id obj, const char *name) {
+    if (!obj) return nil;
+    Ivar ivar = class_getInstanceVariable([obj class], name);
+    return ivar ? object_getIvar(obj, ivar) : nil;
+}
+
+static void ApolloSimDebugDumpMediaState(void) {
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    UIWindowScene *scene = ApolloAllWindows().firstObject.windowScene;
+    ApolloLog(@"[SimDebugTap] mediastate: session=%@ orientation=%ld",
+              session.category, (long)scene.interfaceOrientation);
+    for (UIWindow *window in ApolloAllWindows()) {
+        UIViewController *vc = window.rootViewController;
+        while (vc) {
+            NSString *name = NSStringFromClass([vc class]);
+            ApolloLog(@"[SimDebugTap] mediastate: presented chain -> %@ bounds=%@", name,
+                      NSStringFromCGRect(vc.view.bounds));
+            if ([name containsString:@"MediaPageViewController"]) {
+                NSArray *pages = [vc respondsToSelector:@selector(viewControllers)]
+                    ? [(UIPageViewController *)vc viewControllers] : @[];
+                for (UIViewController *page in pages) {
+                    AVPlayer *player = ApolloSimDebugIvar(page, "player");
+                    NSString *source = @"player";
+                    if (!player) {
+                        id container = ApolloSimDebugIvar(page, "playerLayerContainerView");
+                        id layer = ApolloSimDebugIvar(container, "playerLayer");
+                        if ([layer isKindOfClass:[AVPlayerLayer class]]) {
+                            player = [(AVPlayerLayer *)layer player];
+                            source = @"playerLayerContainerView";
+                        }
+                    }
+                    ApolloLog(@"[SimDebugTap] mediastate: page=%@ player=%p (%@) muted=%d rate=%.2f bounds=%@",
+                              NSStringFromClass([page class]), player, source,
+                              player ? (int)[player isMuted] : -1, player ? [player rate] : 0.0f,
+                              NSStringFromCGRect(page.view.bounds));
+                }
+            }
+            vc = vc.presentedViewController;
+        }
+        // The feed table under the viewer: offset/insets, visible rows and
+        // each visible cell's video player, so a rotation-driven visibility
+        // change can be correlated with the fullscreen player above it.
+        UIViewController *root = window.rootViewController;
+        UIViewController *content = root;
+        if ([content isKindOfClass:[UITabBarController class]]) content = [(UITabBarController *)content selectedViewController];
+        if ([content isKindOfClass:[UINavigationController class]]) content = [(UINavigationController *)content topViewController];
+        UITableView *table = nil;
+        if ([content.view isKindOfClass:[UITableView class]]) table = (UITableView *)content.view;
+        for (UIView *sub in content.view.subviews) {
+            if ([sub isKindOfClass:[UITableView class]]) { table = (UITableView *)sub; break; }
+        }
+        if (!table) continue;
+        ApolloLog(@"[SimDebugTap] mediastate: feed %@ table bounds=%@ offset=%@ insets=%@ window=%p",
+                  NSStringFromClass([content class]), NSStringFromCGRect(table.bounds),
+                  NSStringFromCGPoint(table.contentOffset),
+                  NSStringFromUIEdgeInsets(table.adjustedContentInset), table.window);
+        for (UITableViewCell *cell in table.visibleCells) {
+            NSIndexPath *ip = [table indexPathForCell:cell];
+            id node = [cell respondsToSelector:@selector(node)] ? [(id)cell node] : nil;
+            id rich = ApolloSimDebugIvar(node, "richMediaNode");
+            id videoNode = ApolloSimDebugIvar(rich, "videoNode");
+            SEL layerSel = NSSelectorFromString(@"playerLayer");
+            id layer = [videoNode respondsToSelector:layerSel]
+                ? ((id (*)(id, SEL))objc_msgSend)(videoNode, layerSel) : nil;
+            AVPlayer *player = [layer isKindOfClass:[AVPlayerLayer class]] ? [(AVPlayerLayer *)layer player] : nil;
+            SEL playerSel = NSSelectorFromString(@"player");
+            if (!player && [videoNode respondsToSelector:playerSel]) {
+                player = ((id (*)(id, SEL))objc_msgSend)(videoNode, playerSel);
+            }
+            ApolloLog(@"[SimDebugTap] mediastate:   row %ld frame=%@ node=%@ videoNode=%p player=%p muted=%d rate=%.2f",
+                      (long)ip.row, NSStringFromCGRect(cell.frame), NSStringFromClass([node class]),
+                      videoNode, player, player ? (int)[player isMuted] : -1, player ? [player rate] : 0.0f);
+        }
+    }
 }
 
 static void ApolloSimDebugSendTouch(UITouch *touch) {
@@ -829,6 +909,10 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
         if ([contents hasPrefix:@"devvitsweep"]) {
             extern void ApolloDevvitDebugSweep(void);
             ApolloDevvitDebugSweep();
+            return;
+        }
+        if ([contents hasPrefix:@"mediastate"]) {
+            ApolloSimDebugDumpMediaState();
             return;
         }
         // "rotate <landscape|portrait>" command: rotate the scene from inside

--- a/src/ApolloVideoUnmute.xm
+++ b/src/ApolloVideoUnmute.xm
@@ -124,6 +124,14 @@ static __weak id sFeedAudibleVideoNode = nil;
 // unmute a video that's already off-screen.
 static NSUInteger sFeedUnmuteRetryGeneration = 0;
 
+// The fullscreen pager (MediaPageViewController) currently on screen. Set in
+// viewWillAppear: — which UIKit also re-sends when an interactive dismissal is
+// cancelled — and cleared in viewDidDisappear:, so it is nil exactly when no
+// fullscreen viewer is up. Fullscreen owns its player's audio: only its own
+// mute button and its dismissal may change that player's mute state or the
+// audio session while it is presented (see PlayerIsPresentedFullscreen).
+static __weak id sPresentedMediaPageVC = nil;
+
 // =============================================================================
 // MARK: - Helpers
 // =============================================================================
@@ -394,6 +402,26 @@ static AVPlayer *GetPlayerFromMediaPageVC(id mediaPageVC) {
     return nil;
 }
 
+// The player the presented fullscreen viewer is showing right now — nil for an
+// image page or when no viewer is up. Read live rather than cached: the pager
+// can be swiped from a video page to an image page and back.
+static AVPlayer *PresentedFullscreenPlayer(void) {
+    id pageVC = sPresentedMediaPageVC;
+    return pageVC ? GetPlayerFromMediaPageVC(pageVC) : nil;
+}
+
+// Rotating the phone while the fullscreen viewer is up re-lays the feed or
+// comments table out underneath it (the viewer keeps its presenter in the
+// hierarchy), and the shorter landscape viewport hands the cells fresh
+// visibility events — including "invisible" for a cell that no longer fits.
+// For a shareable v.redd.it video that cell holds the SAME AVPlayer the
+// viewer is playing, so an inline-driven mute or protection change lands on
+// the fullscreen video (issue #1072). Every inline visibility path below
+// checks this before touching a player.
+static BOOL PlayerIsPresentedFullscreen(AVPlayer *player) {
+    return player != nil && player == PresentedFullscreenPlayer();
+}
+
 // Update the MuteUnmuteVideoButtonNode's visual state to match actual mute state.
 // Sets the `isMuted` ivar (Swift Bool) and updates the `icon` ASImageNode's image.
 //
@@ -660,6 +688,16 @@ static BOOL ApplyFeedUnmuteIfNeeded(id richMediaNode, NSString *reason) {
     if (!player) return NO;
     if (ApolloPiP_IsOwnedPlayer(player)) return NO;
 
+    // A fullscreen viewer is up: the feed is not the surface being watched.
+    // Its ticks still arrive underneath the viewer (rotation re-lays the feed
+    // out), and acting on them lands on the fullscreen video — re-arming
+    // protection on the shared player makes our AVPlayer.setMuted: hook veto
+    // the user's fullscreen mute, and unmuting a cell Apollo's midpoint
+    // autoplay started under the viewer plays a second audio track beneath
+    // it. Report the tick as handled so no retry chain is scheduled either;
+    // the next tick after dismissal applies the policy as usual.
+    if (sPresentedMediaPageVC != nil) return YES;
+
     // Steady state: already the audible one. Cheapest possible early-out, and
     // the reason this is safe to call from every visibility tick.
     if (player == sAutoUnmutedPlayer && ![player isMuted]) return YES;
@@ -702,19 +740,29 @@ static void ScheduleFeedUnmuteRetry(id richMediaNode, NSUInteger attemptsRemaini
 static void ReleaseFeedAudioIfOwnedBy(id richMediaNode) {
     if (!richMediaNode || !ObjectsMatch(richMediaNode, sFeedAudibleRichMediaNode)) return;
 
-    ApolloLog(@"[VideoUnmute] Feed audible cell left the screen - releasing protection");
-
     id videoNode = GetVideoNodeFromRichMediaNode(richMediaNode);
     AVPlayer *player = videoNode ? GetPlayerFromVideoNode(videoNode) : nil;
+
+    // Rotation under the fullscreen viewer recycled the cell (see
+    // PlayerIsPresentedFullscreen): the viewer is still playing this player,
+    // so it stays audible — the viewer's own dismissal mutes it and sets the
+    // icon. The cell itself is off-screen now, so it is forgotten as usual and
+    // the post-dismiss re-apply cannot reach for an invisible video.
+    BOOL presentedFullscreen = PlayerIsPresentedFullscreen(player);
+    ApolloLog(@"[VideoUnmute] Feed audible cell left the screen - releasing protection%@",
+              presentedFullscreen ? @" (player stays unmuted: the fullscreen viewer is showing it)" : @"");
+
     if (player && player == sAutoUnmutedPlayer) sAutoUnmutedPlayer = nil;
-    if (player) [player setMuted:YES];
-    if (videoNode) {
-        SEL setMutedSel = NSSelectorFromString(@"setMuted:");
-        if ([videoNode respondsToSelector:setMutedSel]) {
-            ((void (*)(id, SEL, BOOL))objc_msgSend)(videoNode, setMutedSel, YES);
+    if (!presentedFullscreen) {
+        if (player) [player setMuted:YES];
+        if (videoNode) {
+            SEL setMutedSel = NSSelectorFromString(@"setMuted:");
+            if ([videoNode respondsToSelector:setMutedSel]) {
+                ((void (*)(id, SEL, BOOL))objc_msgSend)(videoNode, setMutedSel, YES);
+            }
         }
+        SyncMuteButtonIcon(richMediaNode, YES);
     }
-    SyncMuteButtonIcon(richMediaNode, YES);
 
     sFeedAudibleRichMediaNode = nil;
     sFeedAudibleVideoNode = nil;
@@ -774,18 +822,25 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
             ApolloLog(@"[VideoUnmute] %@ cell invisible during back navigation — keeping protection", contextLabel);
             return;
         }
-        ApolloLog(@"[VideoUnmute] %@ cell invisible — clearing protection and refs", contextLabel);
+        id videoNode = GetVideoNodeFromRichMediaNode(richMediaNode);
+        AVPlayer *player = videoNode ? GetPlayerFromVideoNode(videoNode) : nil;
+
+        // Rotation under the fullscreen viewer (see PlayerIsPresentedFullscreen):
+        // the header cell fell off the shorter viewport, but the viewer is still
+        // playing this player, so it stays unmuted — the viewer's own dismissal
+        // mutes it. Refs are still dropped: the header is off-screen, and the
+        // post-dismiss re-unmute must not sound an invisible video.
+        BOOL presentedFullscreen = PlayerIsPresentedFullscreen(player);
+        ApolloLog(@"[VideoUnmute] %@ cell invisible — clearing protection and refs%@", contextLabel,
+                  presentedFullscreen ? @" (player stays unmuted: the fullscreen viewer is showing it)" : @"");
 
         sAutoUnmutedPlayer = nil;  // Clear first so our setMuted: hook doesn't block
 
-        id videoNode = GetVideoNodeFromRichMediaNode(richMediaNode);
-        if (videoNode) {
+        if (videoNode && !presentedFullscreen) {
             SEL setMutedSel = NSSelectorFromString(@"setMuted:");
             if ([videoNode respondsToSelector:setMutedSel]) {
                 ((void (*)(id, SEL, BOOL))objc_msgSend)(videoNode, setMutedSel, YES);
             }
-
-            AVPlayer *player = GetPlayerFromVideoNode(videoNode);
             if (player) [player setMuted:YES];
         }
 
@@ -826,7 +881,7 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 
             SyncMuteButtonIcon(rmNode, [retryPlayer isMuted]);
 
-            if (sUnmuteCommentsVideos == 2
+            if (sUnmuteCommentsVideos == 2 && sPresentedMediaPageVC == nil
                 && !objc_getAssociatedObject(strongOwner, kAutoUnmuteAppliedKey)) {
                 objc_setAssociatedObject(strongOwner, kAutoUnmuteAppliedKey, @YES,
                                          OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -842,6 +897,9 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 
     if (sUnmuteCommentsVideos != 2) return;
     if (unmuteApplied) return;
+    // Never (re-)arm protection from a tick underneath the fullscreen viewer
+    // (the header holds the very player it is showing).
+    if (sPresentedMediaPageVC != nil) return;
 
     objc_setAssociatedObject(visibilityOwner, kAutoUnmuteAppliedKey, @YES,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1130,23 +1188,21 @@ static BOOL PlayerWasDeliberatelyStopped(AVPlayer *player);
 // ---------------------------------------------------------------------------
 %hook MediaPageViewController
 
-// - (void)viewWillAppear:(BOOL)animated {
-//     %orig;
-//     if (sAutoUnmutedPlayer) {
-//         // Only suspend protection if the fullscreen viewer is showing the SAME
-//         // video we're protecting. Opening an image viewer (no player) or a
-//         // different video should not disrupt the comments header's audio.
-//         AVPlayer *fullscreenPlayer = GetPlayerFromMediaPageVC(self);
-//         if (fullscreenPlayer && fullscreenPlayer == sAutoUnmutedPlayer) {
-//             ApolloLog(@"[VideoUnmute] MediaPageVC appearing with protected player — suspending protection for fullscreen");
-//             sAutoUnmutedPlayer = nil;
-//         } else {
-//             ApolloLog(@"[VideoUnmute] MediaPageVC appearing (image or different video) — keeping protection");
-//         }
-//     }
-// }
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    // Fullscreen is (about to be) up: inline visibility paths must leave its
+    // player alone from here until viewDidDisappear:. UIKit re-sends this when
+    // an interactive dismissal is cancelled, which is why viewWillDisappear:
+    // does not clear it.
+    sPresentedMediaPageVC = self;
+}
 
 - (void)viewDidDisappear:(BOOL)animated {
+    // Gone for good (a cancelled interactive dismissal never gets here): the
+    // inline paths may act on this player again, starting with the feed
+    // re-apply scheduled below.
+    if (sPresentedMediaPageVC == self) sPresentedMediaPageVC = nil;
+
     // Only process re-unmute for video content. Image viewers have no player
     // and should not trigger any mute/unmute logic.
     AVPlayer *fullscreenPlayer = GetPlayerFromMediaPageVC(self);
@@ -1307,6 +1363,76 @@ static BOOL PlayerWasDeliberatelyStopped(AVPlayer *player);
         ApolloLog(@"[VideoUnmute] animateTransition: different player — keeping protection");
     }
 }
+
+%end
+
+// ---------------------------------------------------------------------------
+// TouchHintVideoNode.didExitVisibleState: inline exits under the fullscreen
+// viewer. This is Apollo's inline exit handler (sub_10058cb30): for an UNMUTED
+// inline player it flips the cell's mute icon and runs the mute dance
+// (sub_1003414cc — pause-all, Ambient + setActive:NO at T+50ms, setMuted:YES
+// + unpause-all at T+100ms). Rotation under the viewer fires it for the cells
+// the shorter viewport dropped. Apollo itself skips the dance for a shareable
+// node whose layer the viewer has adopted, but any other unmuted inline
+// player (non-shareable hosts keep their own AVPlayer) still downgrades the
+// ONE audio session to Ambient — which silences the fullscreen video even
+// though its player reads muted == NO. While a fullscreen video is up, keep
+// inline exits away from the session: run the ASDK part (super), mute the
+// exiting player quietly the way Apollo would have, and leave the dance to
+// the viewer's own dismissal.
+// ---------------------------------------------------------------------------
+%group FullscreenExitGuard
+
+// The class the hook below is installed on, captured at %init time so the
+// super dispatch inside it never depends on the instance's runtime class.
+static Class sTouchHintVideoNodeClass = nil;
+
+%hook TouchHintVideoNode
+
+- (void)didExitVisibleState {
+    AVPlayer *fullscreenPlayer = PresentedFullscreenPlayer();
+    if (!fullscreenPlayer) {
+        %orig;
+        return;
+    }
+
+    // Apollo's override is [super didExitVisibleState] + the exit handler;
+    // keep the ASDK half so node bookkeeping is untouched. Dispatch from the
+    // hooked class, not object_getClass(self): for a KVO / isa-swizzled
+    // subclass "super" would otherwise resolve back to this very method.
+    struct objc_super superInfo;
+    superInfo.receiver = self;
+    superInfo.super_class = class_getSuperclass(sTouchHintVideoNodeClass ?: object_getClass(self));
+    ((void (*)(struct objc_super *, SEL))objc_msgSendSuper)(&superInfo, @selector(didExitVisibleState));
+
+    AVPlayer *player = GetPlayerFromVideoNode(self);
+    // The viewer's own player (shared layer) is the video being watched; a
+    // tweak-protected player is released by ReleaseFeedAudioIfOwnedBy / the
+    // comments handler on this same event. Neither is ours to mute here.
+    if (!player || player == fullscreenPlayer || player == sAutoUnmutedPlayer
+        || [player isMuted] || ApolloPiP_IsOwnedPlayer(player)) {
+        ApolloLog(@"[VideoUnmute] Inline video exited under the fullscreen viewer — skipping its mute dance");
+        return;
+    }
+
+    ApolloLog(@"[VideoUnmute] Inline video exited under the fullscreen viewer — muting it without the session dance");
+    [player setMuted:YES];
+    SEL setMutedSel = NSSelectorFromString(@"setMuted:");
+    if ([self respondsToSelector:setMutedSel]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(self, setMutedSel, YES);
+    }
+    // The node's ASVideoNodeDelegate is its RichMediaNode, which owns the
+    // mute button whose icon the skipped handler would have flipped.
+    static Class sRichMediaNodeClass = nil;
+    if (!sRichMediaNodeClass) sRichMediaNodeClass = objc_getClass("_TtC6Apollo13RichMediaNode");
+    id delegate = [self respondsToSelector:@selector(delegate)]
+        ? ((id (*)(id, SEL))objc_msgSend)(self, @selector(delegate)) : nil;
+    if (sRichMediaNodeClass && [delegate isKindOfClass:sRichMediaNodeClass]) {
+        SyncMuteButtonIcon(delegate, YES);
+    }
+}
+
+%end
 
 %end
 
@@ -2066,6 +2192,15 @@ static void ReclaimSearchResultsPlayerLayers(UIViewController *searchVC, NSStrin
         ApolloLog(@"[VideoUnmute] ctor: feed unmute installed (mode=%ld)", (long)sUnmuteFeedVideos);
     } else {
         ApolloLog(@"[VideoUnmute] ctor: LargePostCellNode missing - feed unmute unavailable");
+    }
+
+    Class touchHintVideoNodeClass = objc_getClass("_TtC6Apollo18TouchHintVideoNode");
+    if (touchHintVideoNodeClass) {
+        sTouchHintVideoNodeClass = touchHintVideoNodeClass;
+        %init(FullscreenExitGuard, TouchHintVideoNode = touchHintVideoNodeClass);
+        ApolloLog(@"[VideoUnmute] ctor: fullscreen exit guard installed");
+    } else {
+        ApolloLog(@"[VideoUnmute] ctor: TouchHintVideoNode missing - fullscreen exit guard unavailable");
     }
 
     Class searchResultsVCClass = PostsSearchResultsViewControllerClass();


### PR DESCRIPTION
Fixes #1072 (video with sound → open fullscreen → rotate the phone → it goes quiet).

## What's going on

Rotating with the fullscreen viewer up re-lays the feed (or comments) table out **underneath** the viewer — the viewer keeps its presenter in the hierarchy — and the shorter landscape viewport hands those cells fresh visibility events. For a shareable v.redd.it video the feed cell holds the **same AVPlayer** the viewer is playing, so anything the tweak does to "the inline video" on those ticks lands on the fullscreen video. Four paths were doing exactly that:

1. **"Unmute Videos in Feed" re-armed protection on the viewer's player** from a feed tick (sim-verified: `Feed auto-unmute (visible) … establishing protection` fired on rotate). After that our `AVPlayer.setMuted:` hook vetoes the user's fullscreen mute button.
2. **A cell Apollo's midpoint autoplay started under the viewer got auto-unmuted** (sim-verified) — a second audio track playing beneath the fullscreen video.
3. **The feed release / comments "cell invisible" handlers mute the shared player** when the audible cell is recycled under the viewer (sim-verified on the non-glass run: `Feed audible cell left the screen` fired for the viewer's player; pre-fix that `setMuted:YES` hits the fullscreen video). The comments handler only reaches the player while the header node still resolves it — in the sim the viewer had already taken the header's layer, so that one is belt-and-braces.
4. **Apollo's own inline exit handler** (`TouchHintVideoNode.didExitVisibleState` → `sub_10058cb30`) runs the mute dance (`sub_1003414cc`: pause-all, Ambient + `setActive:NO` at T+50ms, `setMuted:YES` + unpause-all at T+100ms) for any unmuted inline player whose layer the viewer did **not** adopt — the T+50ms Ambient downgrade silences the fullscreen player even though it reads `muted == NO`. (RE: the dance has no `activeAudioPlayer` gate; the shareable case is only skipped because `sub_10058cb30` checks the player layer is still in the node's sublayers.)

## The fix (`ApolloVideoUnmute.xm`)

- Track the presented `MediaPageViewController` (`viewWillAppear:` → `viewDidDisappear:`; UIKit re-sends `viewWillAppear:` on a cancelled interactive dismissal, so the ref survives that) and expose `PresentedFullscreenPlayer()` / `PlayerIsPresentedFullscreen()` (read live from the pager's current page — video → image → video swipes work).
- While a viewer is up, feed and comments auto-unmute ticks are ignored (reported as handled so no retry chain runs); the next tick after dismissal applies the policy as before.
- The "cell left the screen" paths still forget the cell (it *is* off-screen, so the post-dismiss re-apply can't reach for an invisible video) but leave the viewer's player unmuted — its own mute button and dismissal keep owning the audio.
- New `%hook TouchHintVideoNode didExitVisibleState` (own `%group`, installed only if the class exists): while a fullscreen **video** is up, run the ASDK super (dispatched from the hooked class, not `object_getClass(self)`, so a KVO/isa-swizzled subclass can't loop back into the hook), quietly `setMuted:YES` the exiting inline player the way Apollo would have (icon synced through the node's `RichMediaNode` delegate), and skip the session dance. The viewer's player, a tweak-protected player and a PiP-owned player are left alone. Chains with the PiP module's hook on the same selector (PiP has already yielded for a fullscreen-adopted player).
- Sim debug (`#if APOLLO_SIM_BUILD`): `mediastate` dumps the presented viewer's player, the audio session category and the visible feed/comments cells' players — that is how the paths above were caught.

## Reviewer checklist

- **Guard width** (N1): callers of `ApplyFeedUnmuteIfNeeded` = visible tick, retry chain, after-dismiss re-apply; the after-dismiss one runs after `viewDidDisappear:` clears the ref, the other two are the ones being gated. `ReleaseFeedAudioIfOwnedBy` has one caller (event 2). The comments retry closure got the same gate as its synchronous path.
- **Regression with the toggle OFF** (N2): feed unmute Never → `HandleFeedCellVisibilityEvent` still returns first line; comments Default → the new gate sits after the icon sync, which is unchanged. Native mute-button unmute + fullscreen + rotate exercised (comments path).
- **Wrong object** (N3): every decision is keyed on player identity against the pager's *current* page, never on a class or first match.
- **Failure as success** (N4): the tick under a viewer is reported "handled" deliberately — no retry storm; nothing cached.
- **Teardown / sticky state after a cancelled interactive dismissal** (N5, N8): the pager ref is set in `viewWillAppear:` (re-sent on cancel) and cleared only in `viewDidDisappear:` (never sent on cancel); `__weak`, so a torn-down pager can't pin it. A short pan that was released without dismissing kept the viewer up and the next rotation stayed gated (sim); whether UIKit issued the cancelled-transition appearance calls for that pan was not instrumented, the ref logic covers it by construction.
- **Stale async** (N6): the comments "player not ready" retry re-checks the ref at delivery.
- **Threads** (N7): all touched paths are main-thread visibility events / VC lifecycle.
- **Modes matrix** (N9): API-key-free (web session) account on the test sim; glass and non-glass shells; the code is auth-agnostic (players and VC lifecycle only). iOS 14 floor: no new API.
- **Hot paths** (N10): the added work per feed tick is one weak load and, only while a viewer is up, two ivar reads.
- **Hook scoping** (N11): `viewWillAppear:` on MediaPageViewController and `didExitVisibleState` on TouchHintVideoNode verified in Hopper (`-[MediaPageViewController viewWillAppear:]` 0x10025cae8, `viewDidDisappear:` 0x10025d238, `-[TouchHintVideoNode didExitVisibleState]` 0x100687c18); ivars `player` / `playerLayerContainerView` / `playerLayer` / `muteUnmuteButtonNode` are the ones the file already reads. PiP's hook on the same selector chains (both are conditional skips).
- **Jordan — first-line bail** (J3): the TouchHintVideoNode hook is `%orig` when no viewer is up; the tick gates are one static compare. **No process-global per-screen state** (J4): one weak ref to the presented pager, cleared on disappear. **Toggle-off** (J2): nothing is installed or retained. **Comments/tripwires** (J10): every gate carries a comment naming the rotation case and a log line.
- Not applicable: account isolation (J1), in-flight audit (J5), predicate completeness (J6), memory pressure (J7), ownership (J8), restored affordances (J9), description-vs-code (N12) — checked, every bullet above has code behind it.

## Verification

- Synthetic merge on current `apollo-reborn/main` (2427e2b): clean. `git diff --check`: clean. Sibling overlap: #1058/#1059 touch `ApolloSimDebugTap.xm`, but both already conflict with main on their own (5 files) — not introduced here; #1054/#1056 no longer overlap (PiP file untouched).
- `make package` with the pinned iOS 26.0 SDK: OK on the PR head (`com.apollo.reborn_3.7.0-1+debug_iphoneos-arm.deb`).
- Reviewer gate run twice: before opening, and again on the final head after the super-dispatch hardening (rotation + scroll-under-viewer re-checked in the sim on that build).
- Sim launch: `[VideoUnmute] ctor: feed unmute installed (mode=2)`, `ctor: fullscreen exit guard installed`, `ctor: search results playerLayer reclaim installed`, `ctor: hooks initialized`.
- Glass sim (Apollo-Gallery, API-key-free account), "Unmute Videos in Feed" = Always: feed video audible → fullscreen → `rotate landscape` → player stays `muted=0`, session `Playback`, and no protection re-arm (pre-fix: `establishing protection` fired here); `scrollto 3000` under the viewer → no second video unmuted (pre-fix: `Auto-unmute complete` for another player); fullscreen mute button after rotation → dance runs and the player mutes (pre-fix: blocked by protection); dismiss → feed policy re-applies as before.
- Comments header path ("Unmute Videos in Comments" = Always, native mute-button unmute): header → fullscreen → rotate → scroll under the viewer → still audible; dismiss OK.
- Non-glass shell (same device, `vtool` sdk 16.0 downgrade, legacy chrome verified by pixels): same feed matrix; here the recycle path actually fired (`Feed audible cell left the screen … (player stays unmuted: the fullscreen viewer is showing it)`) — the pre-fix code would have muted the fullscreen video at that moment.
- Cancelled interactive dismissal: short pan released → viewer still up, rotate → player still `muted=0`, no protection re-arm.
- **Not reproduced**: the reporter's exact "goes silent on rotate" on an iOS 26.x sim with a v.redd.it post whose cell stayed partially visible in landscape — that cell only gets a rect-change tick there. The paths above fire whenever the audible cell falls off the landscape viewport (lower in the feed, or the iOS 27 layout), which is the reporter's setup (iOS 27, 3.6.0 Liquid Glass). Device pass on iOS 27 still pending — reporter asked to confirm on the next build.
- iPad: not run (code-reading only, per the standing rule).

