### PR TITLE
Multireddits: fix "Error adding to multireddit" on every successful add

### DIFF
--- a/src/ApolloMultiredditEdit.xm
+++ b/src/ApolloMultiredditEdit.xm
@@ -439,11 +439,37 @@ static NSString *ApolloMultiEditNormalizedPath(id path) {
         : (NSString *)path;
 }
 
+// api/multi/user/<user>/m/<name>/r/<subreddit> is Reddit's subreddit-
+// membership endpoint. RedditKit PUTs it from
+// -addSubredditWithName:toMultiredditWithName:completion: (the "Add to
+// multireddit" action) and DELETEs it from -removeSubredditWithName:…. Reddit
+// answers the PUT with {"name": "<subreddit>"} — no LabeledMulti envelope —
+// and RedditKit's completion never parses that body (it forwards only the
+// error), so treating it as a model response rejected every successful add
+// and Apollo showed "Error adding to multireddit." (issue #982).
+static BOOL ApolloMultiEditIsSubredditMembershipPath(NSString *normalizedPath) {
+    // Every RDKClient task passes through here; only api/multi paths pay for
+    // the split.
+    if (![normalizedPath hasPrefix:@"api/multi/"]) return NO;
+    NSMutableArray<NSString *> *components = [NSMutableArray array];
+    for (NSString *component in [normalizedPath componentsSeparatedByString:@"/"]) {
+        // Reddit's multireddit paths carry a trailing slash, so a path built
+        // by string concatenation can contain "//" — ignore empty segments.
+        if (component.length > 0) [components addObject:component];
+    }
+    return components.count == 8
+        && [components[0] isEqualToString:@"api"]
+        && [components[1] isEqualToString:@"multi"]
+        && [components[2] isEqualToString:@"user"]
+        && [components[4] isEqualToString:@"m"]
+        && [components[6] isEqualToString:@"r"];
+}
+
 // Every direct RDKObjectBuilder use in RedditKit's multireddit methods was
 // traced in Apollo 1.15.11. Collection reads return an array of LabeledMulti
 // envelopes. Individual reads and create/update/description writes return a
-// single envelope. DELETE and api/multi/copy use non-model completion shapes,
-// so deliberately leave those untouched.
+// single envelope. DELETE, api/multi/copy and the subreddit-membership PUT
+// use non-model completion shapes, so deliberately leave those untouched.
 static ApolloMultiEditResponseShape ApolloMultiEditResponseShapeForRequest(id method, id path) {
     NSString *normalizedMethod = [method isKindOfClass:[NSString class]]
         ? [(NSString *)method uppercaseString] : nil;
@@ -452,7 +478,8 @@ static ApolloMultiEditResponseShape ApolloMultiEditResponseShapeForRequest(id me
         return ApolloMultiEditResponseShapeNone;
     }
     if ([normalizedMethod isEqualToString:@"DELETE"] ||
-        [normalizedPath isEqualToString:@"api/multi/copy"]) {
+        [normalizedPath isEqualToString:@"api/multi/copy"] ||
+        ApolloMultiEditIsSubredditMembershipPath(normalizedPath)) {
         return ApolloMultiEditResponseShapeNone;
     }
     if ([normalizedMethod isEqualToString:@"GET"] &&


### PR DESCRIPTION
Fixes #982 ("Adding subreddit to multireddit shows erroneous fail message", also reported on iOS 18 and reproduced on my own device tonight).

## What was wrong

#864 added a guard that validates every `api/multi/…` response as a `LabeledMulti` envelope before Apollo's private RedditKit parser sees it. The subreddit-membership endpoint doesn't return one: `PUT api/multi/user/<u>/m/<name>/r/<sub>` (what **Add to Multireddit** sends) answers `201 {"name": "<sub>"}`. The guard rejected that as malformed and handed RedditKit an error, so every successful add showed "Error adding to multireddit." even though Reddit had already applied it (the multireddit's row subtitle then stayed stale until the next refresh, the secondary symptom in the issue).

Log from my device, the exact rejection:

```
[MultiEdit] Rejected malformed api/multi/user/iChopPryde/m/apolloreborn/r/mildlyinfuriating response (kind:not-string, top-level=__NSSingleEntryDictionaryI)
```

## Fix

`ApolloMultiEditResponseShapeForRequest` now classifies the membership path (`api/multi/user/<u>/m/<name>/r/<sub>`, any method) as "no model shape", the same bucket DELETE and `api/multi/copy` were already in, so the response passes through untouched. RedditKit's completion for that PUT forwards only the error and never reads the body (Hopper: `-[RDKClient addSubredditWithName:toMultiredditWithName:completion:]` at `0x100020814` builds `api/multi%@/r/%@` and its block at `0x100020a6c` is just `if (completion) completion(error)`), so there is nothing to validate there. Empty path segments are ignored so a multipath with its trailing slash (`…/m/name//r/sub`) still matches.

Nothing else in the guard changes: `mine.json` / `api/multi/user/<u>` stay array-validated, single reads, create/update, `description` and `rename` stay envelope-validated.

## Verification

- Clean on current `apollo-reborn/main` (branch is on top of `2427e2b`, one file touched, no sibling PR touches `ApolloMultiredditEdit.xm`). `git diff --check` clean. `make package` (device, pinned iOS 26.0 SDK) builds.
- Hopper-verified: the RedditKit PUT path format and that its completion ignores `responseObject` (addresses above); Apollo only calls the network add when the subreddit isn't already in the multireddit locally (`sub_1005a5f6c`, otherwise it shows "That subreddit is already in the multireddit!" without a request).
- Classifier table-tested on the host (the two static functions compiled into a Foundation harness, 18 method/path cases): membership PUT/GET/DELETE with and without a leading slash or doubled slash → none; `mine.json` and `user/<u>` → array; `m/<name>`, `/description`, `rename` → object; `copy` → none; a multireddit literally named `r` still resolves correctly.
- Simulator (glass, API-key account u/iChopPryde, `hook installed` lines present, `lsof` confirms the worktree dylib): removed r/MildlyInfuriating from the "apollo subreddits" multireddit via Edit Multireddit (DELETE, 200), then re-added it from the subreddit's ••• menu, four remove/add cycles in total (the last one on this exact commit). Each add returned HTTP 201, the blue "Subreddit added to multireddit!" toast showed, Edit Multireddit listed the subreddit again, and the log has zero `[MultiEdit] Rejected` / `Filtered` lines since launch. The multireddit list capture (`captured 4 multireddits … (active)`) still fires at launch, so the array path is unaffected.
- Modes: the classifier runs inside the one `taskWithMethod:path:parameters:completion:` wrapper every `RDKClient` shares, before any keyless/API-key routing, so the exclusion is identical in both modes (keyless routes `/api/*` writes to www with cookie auth; the PUT body is the same `{"name"}` shape). I did not exercise keyless end-to-end: the keyless test account isn't on the sim I used tonight. Non-glass: no UI code in the diff. No cancelled swipe-back / iPad relevance (no view or navigation code).
- Cost: the new path check runs inside the wrapper every `RDKClient` task goes through, so it bails on the `api/multi/` prefix before splitting the path; non-multireddit requests pay one `hasPrefix:`.
- Device: pending (CI IPA). The bug itself was reproduced on device with the current build (log above).
