### PR TITLE
Fix app crashes and LiveContainer compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ ApolloReborn_FILES = \
     $(WHATS_NEW_GEN_M) \
     $(SRC_DIR)/Tweak.xm \
     $(SRC_DIR)/ApolloCommon.m \
+    $(SRC_DIR)/ApolloProfilePagination.xm \
     $(SRC_DIR)/ApolloWebTextDecoding.m \
     $(SRC_DIR)/ApolloMemoryDiagnostics.m \
     $(SRC_DIR)/settings/ApolloSettingsTableViewController.m \

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1,4 +1,5 @@
 #import "ApolloCommon.h"
+#import "ApolloExecutableSDK.h"
 #import "ApolloState.h"
 #import "ApolloThemeRuntime.h"
 #import <QuartzCore/QuartzCore.h>
@@ -533,58 +534,60 @@ NSURLSessionDataTask *ApolloStartBoundedDataRequest(NSURLRequest *request,
                                                                 completion:completion];
 }
 
-// Get the SDK version from the main binary's LC_BUILD_VERSION load command
-// Returns 0 if not found, otherwise packed version (major << 16 | minor << 8 | patch)
-static uint32_t GetLinkedSDKVersion(void) {
-    // Find the main executable by filetype instead of assuming image index 0.
-    // In the simulator the injected tweak dylib can occupy index 0, which made
-    // IsLiquidGlass() read the dylib's own SDK (always current) instead of
-    // Apollo's — masking every legacy (non-glass) code path during sim testing.
-    const struct mach_header_64 *header = NULL;
-    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
-        const struct mach_header *h = _dyld_get_image_header(i);
-        if (h && h->filetype == MH_EXECUTE) {
-            header = (const struct mach_header_64 *)h;
-            break;
-        }
+// Identify Apollo by a native class, independently of launch host or image
+// order. LiveContainer normally retains its own MH_EXECUTE and loads Apollo
+// as MH_DYLIB; the sim may put the injected tweak at image index zero. Neither
+// image describes which chrome Apollo's selected IPA variant requested.
+static const char *ApolloNativeExecutableImageName(void) {
+    const char *classNames[] = {
+        "_TtC6Apollo11AppDelegate",
+        "_TtC6Apollo13SceneDelegate",
+        "_TtC6Apollo19PostsViewController",
+    };
+    for (size_t i = 0; i < sizeof(classNames) / sizeof(classNames[0]); i++) {
+        Class cls = objc_lookUpClass(classNames[i]);
+        const char *name = cls ? class_getImageName(cls) : NULL;
+        if (name && name[0]) return name;
     }
-    if (!header) header = (const struct mach_header_64 *)_dyld_get_image_header(0);
-    if (!header) return 0;
+    return NULL;
+}
 
-    uintptr_t cursor = (uintptr_t)header + sizeof(struct mach_header_64);
-    for (uint32_t i = 0; i < header->ncmds; i++) {
-        struct load_command *cmd = (struct load_command *)cursor;
-        if (cmd->cmd == LC_BUILD_VERSION) {
-            struct build_version_command *buildCmd = (struct build_version_command *)cmd;
-            return buildCmd->sdk;
-        }
-        cursor += cmd->cmdsize;
+// Read the guest image's actual load command. LiveContainer's optional SDK
+// spoofing hooks dyld's program-SDK APIs, not this header; the glass patch's
+// intentional SDK bump therefore still works in both hosted and normal apps.
+static uint32_t GetLinkedSDKVersion(void) {
+    const char *executableName = ApolloNativeExecutableImageName();
+    if (!executableName) return 0;
+    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
+        const char *imageName = _dyld_get_image_name(i);
+        if (!imageName || strcmp(imageName, executableName) != 0) continue;
+        const struct mach_header *header = _dyld_get_image_header(i);
+        if (!header || header->magic != MH_MAGIC_64 ||
+            header->sizeofcmds > ApolloMaximumMachOLoadCommandBytes) return 0;
+        // dyld has already validated/mapped this loaded image. The reader
+        // additionally bounds every command within its declared header area.
+        size_t length = sizeof(struct mach_header_64) + header->sizeofcmds;
+        return ApolloSDKVersionFromMachO(header, length);
     }
     return 0;
 }
 
-// Check if Liquid Glass is active by checking if the app binary was linked against iOS 26+ SDK
+// Both the selected Apollo variant and the running OS must support glass.
 BOOL IsLiquidGlass(void) {
     static BOOL checked = NO;
     static BOOL available = NO;
 
     if (!checked) {
         checked = YES;
-        // BOOL isiOS26Runtime = (objc_getClass("_UITabButton") != nil);
-        // if (!isiOS26Runtime) {
-        //     ApolloLog(@"[IsLiquidGlass] iOS 26+ runtime not detected");
-        //     available = NO;
-        //     return available;
-        // }
-
-        // iOS 26 SDK version = 19.0 = 0x00130000 (major 19 in high 16 bits)
-        // SDK version format: major << 16 | minor << 8 | patch
+        BOOL glassRuntime = NO;
+        if (@available(iOS 26.0, *)) {
+            glassRuntime = objc_lookUpClass("UIGlassEffect") != Nil;
+        }
         uint32_t sdkVersion = GetLinkedSDKVersion();
-        uint32_t sdkMajor = (sdkVersion >> 16) & 0xFFFF;
-        available = (sdkMajor >= 19);
+        available = ApolloSDKEnablesLiquidGlass(sdkVersion, glassRuntime);
 
-        ApolloLog(@"[IsLiquidGlass] SDK version: 0x%08X (major: %u), linked for iOS 26+: %@",
-                  sdkVersion, sdkMajor, available ? @"YES" : @"NO");
+        ApolloLog(@"[IsLiquidGlass] Apollo SDK: 0x%08X, glass runtime: %@, enabled: %@",
+                  sdkVersion, glassRuntime ? @"YES" : @"NO", available ? @"YES" : @"NO");
     }
 
     return available;

--- a/src/ApolloExecutableSDK.h
+++ b/src/ApolloExecutableSDK.h
@@ -1,0 +1,66 @@
+#ifndef APOLLO_EXECUTABLE_SDK_H
+#define APOLLO_EXECUTABLE_SDK_H
+
+#include <mach-o/loader.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+// Apollo has only a few KB of load commands. Bound this independently of an
+// image's declared command count before walking its header at startup.
+enum { ApolloMaximumMachOLoadCommandBytes = 1024 * 1024 };
+
+// Reads a mapped Mach-O header and its load-command bytes, not a file's whole
+// contents. The explicit extent also lets host tests exercise truncated or
+// malformed commands without reading past their fixture. Filetype is
+// deliberately irrelevant: LiveContainer loads Apollo as MH_DYLIB.
+static inline uint32_t ApolloSDKVersionFromMachO(const void *bytes, size_t length) {
+    if (!bytes || length < sizeof(struct mach_header_64)) return 0;
+    struct mach_header_64 header;
+    memcpy(&header, bytes, sizeof(header));
+    if (header.magic != MH_MAGIC_64 ||
+        header.sizeofcmds > ApolloMaximumMachOLoadCommandBytes ||
+        header.sizeofcmds > length - sizeof(header) ||
+        header.ncmds > header.sizeofcmds / sizeof(struct load_command)) return 0;
+
+    size_t offset = sizeof(header);
+    size_t end = offset + header.sizeofcmds;
+    uint32_t sdk = 0;
+    uint32_t legacySDK = 0;
+    bool hasBuildVersion = false;
+    for (uint32_t i = 0; i < header.ncmds; i++) {
+        if (end - offset < sizeof(struct load_command)) return 0;
+        struct load_command command;
+        memcpy(&command, (const char *)bytes + offset, sizeof(command));
+        if (command.cmdsize < sizeof(command) || command.cmdsize > end - offset ||
+            (command.cmdsize & 7) != 0) return 0;
+        if (command.cmd == LC_BUILD_VERSION) {
+            if (command.cmdsize < sizeof(struct build_version_command)) return 0;
+            struct build_version_command build;
+            memcpy(&build, (const char *)bytes + offset, sizeof(build));
+            if (build.ntools > (command.cmdsize - sizeof(build)) / sizeof(struct build_tool_version)) return 0;
+            if (build.platform == PLATFORM_IOS || build.platform == PLATFORM_IOSSIMULATOR) {
+                if (hasBuildVersion) return 0;
+                hasBuildVersion = true;
+                sdk = build.sdk;
+            }
+        } else if (command.cmd == LC_VERSION_MIN_IPHONEOS) {
+            if (command.cmdsize < sizeof(struct version_min_command)) return 0;
+            struct version_min_command version;
+            memcpy(&version, (const char *)bytes + offset, sizeof(version));
+            legacySDK = version.sdk;
+        }
+        offset += command.cmdsize;
+    }
+    if (offset != end) return 0;
+    return hasBuildVersion ? sdk : legacySDK;
+}
+
+static inline bool ApolloSDKEnablesLiquidGlass(uint32_t sdk, bool glassRuntime) {
+    // The original iOS 26 SDK encoded its version as 19.0; later toolchains
+    // use 26/27. Keep both forms, but never enable glass on an older runtime.
+    return glassRuntime && (sdk >> 16) >= 19;
+}
+
+#endif

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -290,7 +290,8 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
             %orig(tableView, [NSIndexPath indexPathForRow:apolloRow inSection:indexPath.section]);
             return;
         }
-        %orig; return;
+        %orig;
+        return;
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
@@ -356,7 +357,8 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
             dispatch_async(dispatch_get_main_queue(), ^{ [ws apollo_pfRefreshBlockedToggleCount:wt]; });
             return;
         }
-        %orig; return;
+        %orig;
+        return;
     }
     if (editingStyle != UITableViewCellEditingStyleDelete) return;
     if (indexPath.section >= native + 2) return; // Tag Filters rows are static

--- a/src/ApolloFindInComments.xm
+++ b/src/ApolloFindInComments.xm
@@ -330,11 +330,24 @@ static void FICRunSelection(dispatch_block_t orig) {
 
 // MARK: - hooks: multi-term matching
 
+typedef NSRange (*FICRangeOfStringIMP)(NSString *, SEL, NSString *, NSStringCompareOptions, NSRange);
+static FICRangeOfStringIMP sFICStringBootstrapOriginal = NULL;
+
+%group ApolloFindInCommentsString
+
 // Only answers the exact rangeOfString: call the native match rebuild makes
 // (armed flag + main thread + the needle is the active comma query), so the
-// hot path everywhere else is a single static-BOOL test.
+// ordinary search path needs no additional Objective-C calls.
 %hook NSString
 - (NSRange)rangeOfString:(NSString *)needle options:(NSStringCompareOptions)options range:(NSRange)searchRange {
+    // ElleKit publishes the replacement, logs using Foundation string
+    // operations, then fills Logos's original-IMP slot. That log can reenter
+    // this hook during %init (#1083), before %orig is callable. The bootstrap
+    // IMP was captured before publication; after installation always use the
+    // generator's original so Substrate trampolines and prior hooks stay in
+    // the chain. The same &%orig syntax works with the internal sim generator.
+    FICRangeOfStringIMP original = (FICRangeOfStringIMP)&%orig;
+    if (!original) original = sFICStringBootstrapOriginal;
     if (sFICMultiActive && needle && [NSThread isMainThread] &&
         [needle compare:sFICMultiQuery options:NSCaseInsensitiveSearch] == NSOrderedSame) {
         // Earliest match of ANY term; on a tied start the longer term wins so
@@ -342,7 +355,7 @@ static void FICRunSelection(dispatch_block_t orig) {
         // whatever we return and asks again — all terms, in document order.
         NSRange best = NSMakeRange(NSNotFound, 0);
         for (NSString *term in sFICMultiTerms) {
-            NSRange r = %orig(term, options, searchRange);
+            NSRange r = original(self, _cmd, term, options, searchRange);
             if (r.location == NSNotFound) continue;
             if (best.location == NSNotFound || r.location < best.location ||
                 (r.location == best.location && r.length > best.length)) {
@@ -351,9 +364,21 @@ static void FICRunSelection(dispatch_block_t orig) {
         }
         return best;
     }
-    return %orig;
+    return original(self, _cmd, needle, options, searchRange);
 }
 %end
+%end
+
+static BOOL FICInstallStringHook(Class stringClass) {
+    Method method = class_getInstanceMethod(stringClass, @selector(rangeOfString:options:range:));
+    if (!method) return NO;
+    sFICStringBootstrapOriginal = (FICRangeOfStringIMP)method_getImplementation(method);
+    if (!sFICStringBootstrapOriginal) return NO;
+    // Keep publication after the bootstrap assignment, and keep Foundation
+    // logging outside the hook itself: logging can call this method again.
+    %init(ApolloFindInCommentsString, NSString = stringClass);
+    return YES;
+}
 
 // MARK: - hooks: selection entry points
 //
@@ -365,11 +390,15 @@ static void FICRunSelection(dispatch_block_t orig) {
 %hook _TtC6Apollo22CommentsViewController
 
 - (void)nextResultButtonTappedWithSender:(id)sender {
-    FICRunSelection(^{ %orig; });
+    FICRunSelection(^{
+        %orig;
+    });
 }
 
 - (void)previousResultButtonTappedWithSender:(id)sender {
-    FICRunSelection(^{ %orig; });
+    FICRunSelection(^{
+        %orig;
+    });
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -397,7 +426,9 @@ static void FICRunSelection(dispatch_block_t orig) {
         sFICMultiActive = YES;
         ApolloLog(@"[FindInComments] multi-term search: %lu terms", (unsigned long)terms.count);
     }
-    FICRunSelection(^{ %orig; });
+    FICRunSelection(^{
+        %orig;
+    });
     sFICMultiActive = NO;
     sFICMultiTerms = nil;
     sFICMultiQuery = nil;
@@ -416,5 +447,7 @@ static void FICRunSelection(dispatch_block_t orig) {
 
 %ctor {
     %init;
-    ApolloLog(@"[FindInComments] hooks installed (scroll watchdog + comma multi-term search)");
+    BOOL stringHookInstalled = FICInstallStringHook(objc_getClass("NSString"));
+    ApolloLog(@"[FindInComments] scroll watchdog installed; comma multi-term search %@",
+              stringHookInstalled ? @"installed" : @"unavailable (NSString method missing)");
 }

--- a/src/ApolloFollowingSection.xm
+++ b/src/ApolloFollowingSection.xm
@@ -799,12 +799,18 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
-    if (!map.active) { %orig; return; }
+    if (!map.active) {
+        %orig;
+        return;
+    }
     NSIndexPath *nativePath = ApolloFollowingNativePathForVisible(map, indexPath);
     ApolloLog(@"[FollowingSection] didSelect visible %ld/%ld -> native %ld/%ld",
               (long)indexPath.section, (long)indexPath.row,
               (long)(nativePath ? nativePath.section : -1), (long)(nativePath ? nativePath.row : -1));
-    if (!nativePath) { %orig; return; }
+    if (!nativePath) {
+        %orig;
+        return;
+    }
     %orig(tableView, nativePath);
 }
 
@@ -850,9 +856,15 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(NSInteger)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
-    if (!map.active) { %orig; return; }
+    if (!map.active) {
+        %orig;
+        return;
+    }
     NSIndexPath *nativePath = ApolloFollowingNativePathForVisible(map, indexPath);
-    if (!nativePath) { %orig; return; }
+    if (!nativePath) {
+        %orig;
+        return;
+    }
     // Apollo's commit paths end in reloadData (never row animations), so the
     // translated native path is all that's needed here.
     %orig(tableView, editingStyle, nativePath);
@@ -860,17 +872,29 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 
 - (void)tableView:(UITableView *)tableView willBeginEditingRowAtIndexPath:(NSIndexPath *)indexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
-    if (!map.active) { %orig; return; }
+    if (!map.active) {
+        %orig;
+        return;
+    }
     NSIndexPath *nativePath = ApolloFollowingNativePathForVisible(map, indexPath);
-    if (!nativePath) { %orig; return; }
+    if (!nativePath) {
+        %orig;
+        return;
+    }
     %orig(tableView, nativePath);
 }
 
 - (void)tableView:(UITableView *)tableView didEndEditingRowAtIndexPath:(NSIndexPath *)indexPath {
     ApolloFollowingMap *map = ApolloFollowingMapFor((UIViewController *)self);
-    if (!map.active || !indexPath) { %orig; return; }
+    if (!map.active || !indexPath) {
+        %orig;
+        return;
+    }
     NSIndexPath *nativePath = ApolloFollowingNativePathForVisible(map, indexPath);
-    if (!nativePath) { %orig; return; }
+    if (!nativePath) {
+        %orig;
+        return;
+    }
     %orig(tableView, nativePath);
 }
 
@@ -945,7 +969,10 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
     }
     NSIndexPath *nativeFrom = ApolloFollowingNativePathForVisible(map, fromIndexPath);
     NSIndexPath *nativeTo = ApolloFollowingNativePathForVisible(map, toIndexPath);
-    if (!nativeFrom || !nativeTo) { %orig; return; }
+    if (!nativeFrom || !nativeTo) {
+        %orig;
+        return;
+    }
     %orig(tableView, nativeFrom, nativeTo);
 }
 
@@ -954,7 +981,10 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 - (void)favoriteSubredditButtonTapped:(id)sender {
     UITableView *tableView = ApolloFollowingTableViewOf((UIViewController *)self);
     ApolloFollowingMap *map = tableView ? ApolloFollowingActiveMapForTable(tableView) : nil;
-    if (!map) { %orig; return; }
+    if (!map) {
+        %orig;
+        return;
+    }
     sApolloFollowingWindowDepth++;
     sApolloFollowingWindowTable = tableView;
     sApolloFollowingWindowTappedName = nil;
@@ -972,7 +1002,10 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 - (void)multiredditExpandButtonTapped:(id)sender {
     UITableView *tableView = ApolloFollowingTableViewOf((UIViewController *)self);
     ApolloFollowingMap *map = tableView ? ApolloFollowingActiveMapForTable(tableView) : nil;
-    if (!map) { %orig; return; }
+    if (!map) {
+        %orig;
+        return;
+    }
     sApolloFollowingWindowDepth++;
     sApolloFollowingWindowTable = tableView;
     %orig;
@@ -1072,7 +1105,10 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
     // ApolloSubredditIndexPolish's outer deleteRows hook).
     BOOL windowActive = sApolloFollowingWindowDepth > 0 && (UITableView *)self == sApolloFollowingWindowTable;
     ApolloFollowingMap *map = ApolloFollowingPresentedMapForTable((UITableView *)self);
-    if (!map) { %orig; return; }
+    if (!map) {
+        %orig;
+        return;
+    }
     NSMutableArray<NSIndexPath *> *translated = [NSMutableArray arrayWithCapacity:indexPaths.count];
     for (NSIndexPath *nativePath in indexPaths) {
         NSIndexPath *effectiveNative = nativePath;
@@ -1109,14 +1145,20 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 }
 
 - (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
-    if (!ApolloFollowingTableIsList((UITableView *)self)) { %orig; return; }
+    if (!ApolloFollowingTableIsList((UITableView *)self)) {
+        %orig;
+        return;
+    }
     // Inserts speak the POST-update layout: rebuild from the current model
     // first (Apollo mutates its model before registering the animation), so a
     // newly added u/ profile resolves straight into the FOLLOWING section and
     // collation rows get the compressed row index of the fresh layout.
     ApolloFollowingInvalidateMap((UIViewController *)((UITableView *)self).dataSource);
     ApolloFollowingMap *map = ApolloFollowingActiveMapForTable((UITableView *)self);
-    if (!map) { %orig; return; }
+    if (!map) {
+        %orig;
+        return;
+    }
     NSMutableArray<NSIndexPath *> *translated = [NSMutableArray arrayWithCapacity:indexPaths.count];
     for (NSIndexPath *nativePath in indexPaths) {
         NSIndexPath *visible = ApolloFollowingVisiblePathForNative(map, nativePath);
@@ -1140,9 +1182,15 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
     // only descends into ApolloSwipeUpComments' pass-through. The point
     // windows remain the fallback for Apollo's synchronous star/expand reloads.
     BOOL windowActive = sApolloFollowingWindowDepth > 0 && (UITableView *)self == sApolloFollowingWindowTable;
-    if (!windowActive && !ApolloFollowingCallerIsApolloBinary(__builtin_return_address(0))) { %orig; return; }
+    if (!windowActive && !ApolloFollowingCallerIsApolloBinary(__builtin_return_address(0))) {
+        %orig;
+        return;
+    }
     ApolloFollowingMap *map = ApolloFollowingPresentedMapForTable((UITableView *)self);
-    if (!map) { %orig; return; }
+    if (!map) {
+        %orig;
+        return;
+    }
     NSMutableArray<NSIndexPath *> *translated = [NSMutableArray arrayWithCapacity:indexPaths.count];
     for (NSIndexPath *nativePath in indexPaths) {
         NSIndexPath *visible = ApolloFollowingVisiblePathForNative(map, nativePath);

--- a/src/ApolloFollowingSection.xm
+++ b/src/ApolloFollowingSection.xm
@@ -52,6 +52,10 @@
 //    unfavorite delete we recompute the favorites row from the tapped name the
 //    same way ApolloSubredditIndexPolish's off-by-one correction does, so the
 //    two modules converge on the same answer regardless of hook order.
+//    Multireddit expansion instead defers its row batch and rebuilds the list
+//    once the handler closes its point window. Apollo's name-based expansion
+//    state can affect more models than that batch accounts for; see
+//    ApolloMultiredditExpansion.h for the reproduced invalid-row-count case.
 //
 // Everything else Apollo does to this table is reloadData (unsubscribe commits,
 // model refreshes), which is remap-safe: our mapping is invalidated in a
@@ -80,6 +84,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloFollowingSection.h"
+#import "ApolloMultiredditExpansion.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 
@@ -1002,19 +1007,26 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 - (void)multiredditExpandButtonTapped:(id)sender {
     UITableView *tableView = ApolloFollowingTableViewOf((UIViewController *)self);
     ApolloFollowingMap *map = tableView ? ApolloFollowingActiveMapForTable(tableView) : nil;
-    if (!map) {
-        %orig;
-        return;
-    }
-    sApolloFollowingWindowDepth++;
-    sApolloFollowingWindowTable = tableView;
-    %orig;
-    if (sApolloFollowingWindowDepth > 0) sApolloFollowingWindowDepth--;
-    if (sApolloFollowingWindowDepth == 0) {
-        sApolloFollowingWindowTable = nil;
-        sApolloFollowingWindowTappedName = nil;
-        sApolloFollowingWindowFavorites = nil;
-    }
+    // Native expansion can change more rows than its animation describes.
+    // This also applies to the normal layout, where no Following map exists.
+    ApolloPerformMultiredditExpansion(tableView, ^{
+        if (!map) {
+            %orig;
+            return;
+        }
+        sApolloFollowingWindowDepth++;
+        sApolloFollowingWindowTable = tableView;
+        @try {
+            %orig;
+        } @finally {
+            if (sApolloFollowingWindowDepth > 0) sApolloFollowingWindowDepth--;
+            if (sApolloFollowingWindowDepth == 0) {
+                sApolloFollowingWindowTable = nil;
+                sApolloFollowingWindowTappedName = nil;
+                sApolloFollowingWindowFavorites = nil;
+            }
+        }
+    });
 }
 
 %end
@@ -1028,10 +1040,21 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 %hook UITableView
 
 - (void)reloadData {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
     if (ApolloFollowingTableIsList((UITableView *)self)) {
         // Invalidate BEFORE %orig so the re-query sees a fresh mapping.
         ApolloFollowingInvalidateMap((UIViewController *)((UITableView *)self).dataSource);
     }
+    %orig;
+}
+
+- (void)beginUpdates {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
+    %orig;
+}
+
+- (void)endUpdates {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
     %orig;
 }
 
@@ -1096,6 +1119,7 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 // the same answer ApolloSubredditIndexPolish's off-by-one correction produces,
 // so the two hooks converge in either install order.
 - (void)deleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
     // No caller gate here (unlike the lookup hooks above): row mutations on
     // this table only ever ORIGINATE in Apollo's model-space code — UIKit
     // never self-registers them and the tweak's other modules only rewrite
@@ -1145,6 +1169,7 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 }
 
 - (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
     if (!ApolloFollowingTableIsList((UITableView *)self)) {
         %orig;
         return;
@@ -1173,6 +1198,7 @@ static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(UITableView *tabl
 }
 
 - (void)reloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
+    if (ApolloDeferMultiredditTableUpdate((UITableView *)self)) return;
     // Only Apollo's own reloads carry model-space paths. The tweak's other
     // modules pass visible ones (ApolloSubredditIndexPolish's delayed star
     // refresh reloads the rows it found via indexPathForCell:), so gate the

--- a/src/ApolloInterruptibleNavTransition.xm
+++ b/src/ApolloInterruptibleNavTransition.xm
@@ -297,7 +297,10 @@ static UIViewPropertyAnimator *ApolloNavBuildAnimator(id animatorObject,
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)ctx {
     UIViewPropertyAnimator *animator = (UIViewPropertyAnimator *)
         [(id<UIViewControllerAnimatedTransitioning>)self interruptibleAnimatorForTransition:ctx];
-    if (!animator) { %orig; return; }
+    if (!animator) {
+        %orig;
+        return;
+    }
     [animator startAnimation];
 }
 

--- a/src/ApolloMultiredditExpansion.h
+++ b/src/ApolloMultiredditExpansion.h
@@ -1,0 +1,66 @@
+#ifndef APOLLO_MULTIREDDIT_EXPANSION_H
+#define APOLLO_MULTIREDDIT_EXPANSION_H
+
+// Included only by ApolloFollowingSection.xm, which already owns this list's
+// coordinate translation and UITableView hooks. UITableView and Foundation
+// must be declared by the caller (host tests provide a small table double).
+//
+// Native Apollo stores expansion by account + case-insensitive multi.name,
+// not by path. Its data source expands EVERY matching model, while the tap
+// handler inserts/deletes children for only the tapped model. For two equal
+// names with 2 and 3 children, the count changes 2 -> 7 but it inserts only 2.
+// UIKit rejects the batch at endUpdates. Other stale table snapshots can fail
+// the same way. Let Apollo update its state and chevron, but defer that one
+// table's synchronous row batch and rebuild from the resulting model once.
+
+typedef struct ApolloMultiredditExpansionScope {
+    __unsafe_unretained UITableView *table;
+    struct ApolloMultiredditExpansionScope *parent;
+    BOOL needsReload;
+} ApolloMultiredditExpansionScope;
+
+static ApolloMultiredditExpansionScope *sApolloMultiredditExpansionScope;
+
+static inline ApolloMultiredditExpansionScope *ApolloMultiredditExpansionForTable(UITableView *table) {
+    if (!table || ![NSThread isMainThread]) return NULL;
+    for (ApolloMultiredditExpansionScope *scope = sApolloMultiredditExpansionScope;
+         scope; scope = scope->parent) {
+        if (scope->table == table) return scope;
+    }
+    return NULL;
+}
+
+static inline BOOL ApolloDeferMultiredditTableUpdate(UITableView *table) {
+    ApolloMultiredditExpansionScope *scope = ApolloMultiredditExpansionForTable(table);
+    if (!scope) return NO;
+    scope->needsReload = YES;
+    return YES;
+}
+
+static inline void ApolloPerformMultiredditExpansion(UITableView *table, dispatch_block_t original) {
+    if (!table || ![NSThread isMainThread]) {
+        original();
+        return;
+    }
+    ApolloMultiredditExpansionScope scope = { table, sApolloMultiredditExpansionScope, NO };
+    ApolloMultiredditExpansionScope *outer = NULL;
+    sApolloMultiredditExpansionScope = &scope;
+    @try {
+        original();
+    } @finally {
+        // Never swallow an exception or leave another table's calls deferred.
+        sApolloMultiredditExpansionScope = scope.parent;
+        outer = ApolloMultiredditExpansionForTable(table);
+        // If a nested caller catches an exception, its enclosing successful
+        // expansion must still reconcile any model changes already made.
+        if (outer && scope.needsReload) outer->needsReload = YES;
+    }
+    if (scope.needsReload && !outer) {
+        // Runs after the handler has closed FollowingSection's point window.
+        // Its reloadData hook invalidates the section map before UIKit asks
+        // for the final counts/cells. No partially applied batch exists.
+        [table reloadData];
+    }
+}
+
+#endif

--- a/src/ApolloNotificationBackend.h
+++ b/src/ApolloNotificationBackend.h
@@ -10,8 +10,8 @@ extern "C" {
 BOOL ApolloIsNotificationBackendConfigured(void);
 
 // Parsed base URL of the user's self-hosted backend, or nil. Trailing slash is
-// trimmed when saved by the settings UI. Cached and invalidated on
-// NSUserDefaultsDidChangeNotification.
+// trimmed when saved by the settings UI. Each call reads current defaults;
+// the returned value stays valid across later settings changes.
 NSURL *ApolloNotificationBackendBaseURL(void);
 
 // The trimmed X-Registration-Token value, or nil when unset. For requests the

--- a/src/ApolloNotificationBackend.m
+++ b/src/ApolloNotificationBackend.m
@@ -1,6 +1,12 @@
 #import "ApolloNotificationBackend.h"
 #import "ApolloBarkNotifications.h"
+#if defined(APOLLO_NOTIFICATION_BACKEND_TESTING)
+// The request/configuration code is Foundation-only. Host tests provide the
+// account/Bark dependencies and do not emit request URLs or credentials.
+#define ApolloLog(...) do {} while (0)
+#else
 #import "ApolloCommon.h"
+#endif
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "ApolloAccountCredentials.h"
@@ -23,17 +29,17 @@ static NSSet<NSString *> *ApolloLegacyBackendHosts(void) {
     return hosts;
 }
 
-// Cached config. NSURL/NSString are immutable so reads on the URLSession queue
-// are safe; writes happen via the defaults-did-change observer below.
-static NSURL *sCachedBaseURL = nil;
-static NSString *sCachedRegistrationToken = nil;
-static BOOL sCacheValid = NO;
+// Do not cache these objects in mutable globals. Defaults changes can be posted
+// from any thread while URLSession workers rewrite requests. The old cache's
+// unsynchronized load/store/release let invalidation free a backend URL while
+// Foundation bridged it into NSURLComponents (crash #980). NSUserDefaults owns
+// synchronization; each caller now owns its values for the duration of use.
+static NSURL *ApolloParseBackendBaseURL(id raw) {
+    if (![raw isKindOfClass:[NSString class]]) return nil;
+    NSString *value = [raw copy];
+    if (value.length == 0) return nil;
 
-static NSURL *ApolloParseBackendBaseURLFromDefaults(void) {
-    NSString *raw = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyNotificationBackendURL];
-    if (![raw isKindOfClass:[NSString class]] || raw.length == 0) return nil;
-
-    NSString *trimmed = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *trimmed = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     while ([trimmed hasSuffix:@"/"]) {
         trimmed = [trimmed substringToIndex:trimmed.length - 1];
     }
@@ -47,49 +53,23 @@ static NSURL *ApolloParseBackendBaseURLFromDefaults(void) {
     return url;
 }
 
-static NSString *ApolloParseRegistrationTokenFromDefaults(void) {
-    NSString *raw = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyNotificationBackendRegistrationToken];
+static NSString *ApolloParseRegistrationToken(id raw) {
     if (![raw isKindOfClass:[NSString class]]) return nil;
-    NSString *trimmed = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *value = [raw copy];
+    NSString *trimmed = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     return trimmed.length > 0 ? trimmed : nil;
 }
 
-static void ApolloInvalidateBackendCache(void) {
-    sCacheValid = NO;
-    sCachedBaseURL = nil;
-    sCachedRegistrationToken = nil;
-}
-
-static void ApolloEnsureBackendCacheValid(void) {
-    if (sCacheValid) return;
-    sCachedBaseURL = ApolloParseBackendBaseURLFromDefaults();
-    sCachedRegistrationToken = ApolloParseRegistrationTokenFromDefaults();
-    sCacheValid = YES;
-}
-
-__attribute__((constructor))
-static void ApolloNotificationBackendInit(void) {
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification
-                                                      object:nil
-                                                       queue:nil
-                                                  usingBlock:^(NSNotification * _Nonnull __unused note) {
-        ApolloInvalidateBackendCache();
-    }];
-}
-
 BOOL ApolloIsNotificationBackendConfigured(void) {
-    ApolloEnsureBackendCacheValid();
-    return sCachedBaseURL != nil;
+    return ApolloNotificationBackendBaseURL() != nil;
 }
 
 NSURL *ApolloNotificationBackendBaseURL(void) {
-    ApolloEnsureBackendCacheValid();
-    return sCachedBaseURL;
+    return ApolloParseBackendBaseURL([[NSUserDefaults standardUserDefaults] objectForKey:UDKeyNotificationBackendURL]);
 }
 
 NSString *ApolloNotificationBackendRegistrationToken(void) {
-    ApolloEnsureBackendCacheValid();
-    return sCachedRegistrationToken;
+    return ApolloParseRegistrationToken([[NSUserDefaults standardUserDefaults] objectForKey:UDKeyNotificationBackendRegistrationToken]);
 }
 
 // MARK: - Path classification
@@ -265,8 +245,12 @@ NSURLRequest *ApolloRewriteRequestForNotificationBackend(NSURLRequest *request) 
     if (host.length == 0) return nil;
     if (![ApolloLegacyBackendHosts() containsObject:host]) return nil;
 
-    NSURL *base = ApolloNotificationBackendBaseURL();
+    // Capture URL and token from one defaults snapshot. A configuration update
+    // during rewriting must not swap in another backend's registration token.
+    NSDictionary *configuration = [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
+    NSURL *base = ApolloParseBackendBaseURL(configuration[UDKeyNotificationBackendURL]);
     if (!base) return nil;
+    NSString *registrationToken = ApolloParseRegistrationToken(configuration[UDKeyNotificationBackendRegistrationToken]);
 
     NSURLComponents *components = [NSURLComponents componentsWithURL:requestURL resolvingAgainstBaseURL:NO];
     if (!components) return nil;
@@ -291,8 +275,8 @@ NSURLRequest *ApolloRewriteRequestForNotificationBackend(NSURLRequest *request) 
 
     // Header gate: only POSTs hit the gated handlers, but be defensive.
     if ([method isEqualToString:@"POST"] && ApolloPathRequiresRegistrationToken(path)) {
-        if (sCachedRegistrationToken.length > 0) {
-            [mutable setValue:sCachedRegistrationToken forHTTPHeaderField:@"X-Registration-Token"];
+        if (registrationToken.length > 0) {
+            [mutable setValue:registrationToken forHTTPHeaderField:@"X-Registration-Token"];
         }
     }
 

--- a/src/ApolloProfilePagination.xm
+++ b/src/ApolloProfilePagination.xm
@@ -1,0 +1,228 @@
+// A profile response belongs to the pagination object that requested it.
+//
+// Apollo 1.15.11's ProfileViewController refresh clears `overview` and replaces
+// `pagination`, including when the profile tab changes accounts. Its native
+// fetchNextPage completion does not check either state: it stores the returned
+// pagination, appends to the current overview and starts a ListAdapter batch.
+// Issue #1064 crashed in that batch, inside ASMutableElementMap insertion.
+// Reject the obsolete response BEFORE that Swift completion mutates the model.
+//
+// Requests can start on ASDK's batch-fetch queue. UI/Swift ivar access remains
+// on main; a locked, weak-key identity map connects background requests to the
+// profile and generation recorded on main. No usernames or credentials are
+// retained, and other RDKClient overview consumers pass through unchanged.
+
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+typedef void (^ApolloProfileOverviewCompletion)(NSArray *items, id pagination, NSError *error);
+
+@interface ApolloProfilePageState : NSObject
+@property (nonatomic) NSUInteger generation;
+@property (nonatomic, strong) id pagination;
+@end
+@implementation ApolloProfilePageState
+@end
+
+@interface ApolloProfilePageBinding : NSObject
+@property (nonatomic, weak) UIViewController *owner;
+@property (nonatomic) NSUInteger generation;
+@end
+@implementation ApolloProfilePageBinding
+@end
+
+static char kApolloProfilePageStateKey;
+static NSHashTable<UIViewController *> *sApolloProfilePageOwners;
+static NSMapTable<id, ApolloProfilePageBinding *> *sApolloProfilePageBindings;
+
+static id ApolloProfilePageObjectIvar(id object, const char *name) {
+    Ivar ivar = object ? class_getInstanceVariable(object_getClass(object), name) : NULL;
+    return ivar ? object_getIvar(object, ivar) : nil;
+}
+
+static id ApolloProfileCurrentPagination(UIViewController *owner) {
+    return ApolloProfilePageObjectIvar(owner, "pagination");
+}
+
+static ApolloProfilePageState *ApolloProfilePageStateForOwner(UIViewController *owner) {
+    ApolloProfilePageState *state = objc_getAssociatedObject(owner, &kApolloProfilePageStateKey);
+    if (!state && owner) {
+        state = [ApolloProfilePageState new];
+        state.generation = 1;
+        objc_setAssociatedObject(owner, &kApolloProfilePageStateKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return state;
+}
+
+static void ApolloProfilePageCompleteOldBatch(UIViewController *owner) {
+    // This is the same ASBatchContext completed by Apollo's captured Swift
+    // fetchNextPage completion. Complete it AT RESET, never when an old response
+    // arrives: by then the same context may belong to a new account's fetch.
+    // ASDK's completeBatchFetching:NO leaves the context fetching; YES frees it
+    // for future pages. No table mutation or synthetic native response is needed.
+    id node = ApolloProfilePageObjectIvar(owner, "tableNode");
+    if (![node respondsToSelector:@selector(isNodeLoaded)] ||
+        !((BOOL (*)(id, SEL))objc_msgSend)(node, @selector(isNodeLoaded))) return;
+    if (![node respondsToSelector:@selector(view)]) return;
+    id table = ((id (*)(id, SEL))objc_msgSend)(node, @selector(view));
+    SEL contextSelector = NSSelectorFromString(@"batchContext");
+    if (![table respondsToSelector:contextSelector]) return;
+    id context = ((id (*)(id, SEL))objc_msgSend)(table, contextSelector);
+    SEL fetchingSelector = NSSelectorFromString(@"isFetching");
+    SEL completeSelector = NSSelectorFromString(@"completeBatchFetching:");
+    if ([context respondsToSelector:fetchingSelector] &&
+        [context respondsToSelector:completeSelector] &&
+        ((BOOL (*)(id, SEL))objc_msgSend)(context, fetchingSelector)) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(context, completeSelector, YES);
+    }
+}
+
+static void ApolloProfilePageBeginReset(UIViewController *owner) {
+    ApolloProfilePageState *state = ApolloProfilePageStateForOwner(owner);
+    state.generation++;
+    state.pagination = nil;
+    ApolloProfilePageCompleteOldBatch(owner);
+}
+
+static ApolloProfilePageBinding *ApolloProfilePageBindCurrent(UIViewController *owner) {
+    id pagination = ApolloProfileCurrentPagination(owner);
+    if (!pagination) return nil;
+    ApolloProfilePageState *state = ApolloProfilePageStateForOwner(owner);
+    if (state.pagination && state.pagination != pagination) {
+        // Covers a native reset reached without the refresh-control selector,
+        // e.g. a pushed profile becoming the active account. Accepted responses
+        // update state.pagination explicitly below, so a normal next page does
+        // not enter this reset path.
+        ApolloProfilePageBeginReset(owner);
+    }
+    state.pagination = pagination;
+    ApolloProfilePageBinding *binding = [ApolloProfilePageBinding new];
+    binding.owner = owner;
+    binding.generation = state.generation;
+    @synchronized (sApolloProfilePageBindings) {
+        [sApolloProfilePageBindings setObject:binding forKey:pagination];
+    }
+    return binding;
+}
+
+static ApolloProfilePageBinding *ApolloProfilePageBindingForRequest(id pagination) {
+    if (!pagination) return nil;
+    if ([NSThread isMainThread]) {
+        UIViewController *match = nil;
+        for (UIViewController *owner in sApolloProfilePageOwners) {
+            if (ApolloProfileCurrentPagination(owner) != pagination) continue;
+            // Native profiles allocate their own pagination; do not guess an
+            // owner if another implementation shares one between controllers.
+            if (match) return nil;
+            match = owner;
+        }
+        return match ? ApolloProfilePageBindCurrent(match) : nil;
+    }
+    @synchronized (sApolloProfilePageBindings) {
+        return [sApolloProfilePageBindings objectForKey:pagination];
+    }
+}
+
+static ApolloProfileOverviewCompletion ApolloProfilePageWrapCompletion(
+    id pagination, ApolloProfileOverviewCompletion completion) {
+    if (!completion) return nil;
+    ApolloProfilePageBinding *binding = ApolloProfilePageBindingForRequest(pagination);
+    if (!binding) return completion;
+    __block BOOL delivered = NO;
+    return ^(NSArray *items, id nextPagination, NSError *error) {
+        dispatch_block_t deliver = ^{
+            if (delivered) return;
+            delivered = YES;
+            UIViewController *owner = binding.owner;
+            ApolloProfilePageState *state = ApolloProfilePageStateForOwner(owner);
+            if (!owner || state.generation != binding.generation ||
+                state.pagination != pagination || ApolloProfileCurrentPagination(owner) != pagination) {
+                ApolloLog(@"[ProfilePagination] Discarded a response from an obsolete profile load");
+                return;
+            }
+            // Completing ASBatchContext can schedule the next fetch on its
+            // background queue before this call returns. Publish the proposed
+            // page first; delivery still checks the actual native ivar on main,
+            // so a rejected/error result cannot make this provisional page valid.
+            if (nextPagination) {
+                @synchronized (sApolloProfilePageBindings) {
+                    [sApolloProfilePageBindings setObject:binding forKey:nextPagination];
+                }
+            }
+            completion(items, nextPagination, error);
+            if (state.generation == binding.generation) {
+                // Native completion synchronously replaces the pagination and
+                // completes its ASBatchContext. Publish the new object for the
+                // next request, which ASDK may start on a background queue.
+                state.pagination = ApolloProfileCurrentPagination(owner);
+                ApolloProfilePageBindCurrent(owner);
+            }
+        };
+        if ([NSThread isMainThread]) deliver();
+        else dispatch_async(dispatch_get_main_queue(), deliver);
+    };
+}
+
+static BOOL ApolloProfilePageIsAccountTab(UIViewController *owner) {
+    UINavigationController *navigation = owner.navigationController;
+    return navigation && navigation.viewControllers.firstObject == owner &&
+        [owner.tabBarController.viewControllers containsObject:navigation];
+}
+
+@interface ApolloProfilePaginationController : UIViewController
+@end
+
+%group ApolloProfilePaginationHooks
+
+%hook ApolloProfilePaginationController
+
+- (void)viewDidLoad {
+    [sApolloProfilePageOwners addObject:self];
+    ApolloProfilePageBindCurrent(self);
+    %orig;
+    ApolloProfilePageBindCurrent(self);
+}
+
+- (void)refreshControlActivatedWithSender:(id)sender {
+    id oldPagination = ApolloProfileCurrentPagination(self);
+    ApolloProfilePageBeginReset(self);
+    %orig;
+    if (ApolloProfileCurrentPagination(self) != oldPagination) ApolloProfilePageBindCurrent(self);
+}
+
+- (void)redditAccountChangedWithNotification:(id)notification {
+    id oldPagination = ApolloProfileCurrentPagination(self);
+    // The persistent account tab also resets when signing out; that native
+    // path may leave the old pagination object in place. Invalidate its epoch
+    // before calling Apollo, without decoding the Swift ProfileType enum.
+    if (ApolloProfilePageIsAccountTab(self)) ApolloProfilePageBeginReset(self);
+    %orig;
+    if (ApolloProfileCurrentPagination(self) != oldPagination) ApolloProfilePageBindCurrent(self);
+}
+
+%end
+
+%hook RDKClient
+
+- (id)overviewOfUserWithUsername:(id)username pagination:(id)pagination completion:(ApolloProfileOverviewCompletion)completion {
+    return %orig(username, pagination, ApolloProfilePageWrapCompletion(pagination, completion));
+}
+
+%end
+
+%end
+
+%ctor {
+    Class profileClass = NSClassFromString(@"Apollo.ProfileViewController");
+    if (!profileClass) profileClass = NSClassFromString(@"_TtC6Apollo21ProfileViewController");
+    if (!profileClass || !class_getInstanceVariable(profileClass, "pagination") ||
+        !class_getInstanceMethod(NSClassFromString(@"RDKClient"),
+            @selector(overviewOfUserWithUsername:pagination:completion:))) return;
+    sApolloProfilePageOwners = [NSHashTable weakObjectsHashTable];
+    sApolloProfilePageBindings = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality
+                                                    valueOptions:NSPointerFunctionsStrongMemory];
+    %init(ApolloProfilePaginationHooks, ApolloProfilePaginationController = profileClass);
+    ApolloLog(@"[ProfilePagination] Profile response ownership guard installed");
+}

--- a/src/ApolloSubredditListLaunchSettle.xm
+++ b/src/ApolloSubredditListLaunchSettle.xm
@@ -467,7 +467,9 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
             CGFloat before = self.contentOffset.y;
             [CATransaction begin];
             [CATransaction setDisableActions:YES];
-            [UIView performWithoutAnimation:^{ %orig; }];
+            [UIView performWithoutAnimation:^{
+                %orig;
+            }];
             [CATransaction commit];
             sSuppressedPasses++;
             // One line per launch is enough to tell a fixed launch from an
@@ -496,7 +498,10 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 }
 
 - (void)setContentOffset:(CGPoint)offset {
-    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    if (!sWindowOpen || self != sTrackedTable) {
+        %orig;
+        return;
+    }
     CGPoint before = self.contentOffset;
     %orig;
     if (fabs(before.y - offset.y) < 0.5) return;
@@ -507,7 +512,10 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 }
 
 - (void)setContentInset:(UIEdgeInsets)inset {
-    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    if (!sWindowOpen || self != sTrackedTable) {
+        %orig;
+        return;
+    }
     UIEdgeInsets before = self.contentInset;
     %orig;
     if (UIEdgeInsetsEqualToEdgeInsets(before, inset)) return;
@@ -521,7 +529,10 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 // Apollo parks several of its tables through -setBounds: rather than
 // -setContentOffset:, so the offset move can bypass the setter above.
 - (void)setBounds:(CGRect)bounds {
-    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    if (!sWindowOpen || self != sTrackedTable) {
+        %orig;
+        return;
+    }
     CGRect before = self.bounds;
     %orig;
     if (fabs(before.origin.y - bounds.origin.y) < 0.5) return;
@@ -532,7 +543,10 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 }
 
 - (void)safeAreaInsetsDidChange {
-    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    if (!sWindowOpen || self != sTrackedTable) {
+        %orig;
+        return;
+    }
     UIEdgeInsets before = self.safeAreaInsets;
     %orig;
     ApolloSLDLog(@"+%.0fms safeAreaInsetsDidChange %@ -> %@ anim(%@) via %@",
@@ -541,7 +555,10 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 }
 
 - (void)reloadData {
-    if (!sWindowOpen || self != sTrackedTable) { %orig; return; }
+    if (!sWindowOpen || self != sTrackedTable) {
+        %orig;
+        return;
+    }
     CGFloat before = self.contentSize.height;
     %orig;
     ApolloSLDLog(@"+%.0fms reloadData contentHeight %.0f -> %.0f anim(%@) via %@",
@@ -557,11 +574,16 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 %hook UITableViewHeaderFooterView
 
 - (void)layoutSubviews {
-    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) { %orig; return; }
+    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) {
+        %orig;
+        return;
+    }
     ApolloSLDNoteHeaderSuppressed((UIView *)self);
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [UIView performWithoutAnimation:^{ %orig; }];
+    [UIView performWithoutAnimation:^{
+        %orig;
+    }];
     [CATransaction commit];
 }
 
@@ -570,11 +592,16 @@ static void ApolloSLDNoteHeaderSuppressed(UIView *header) {
 %hook _TtC6Apollo31RecreatedTableSectionHeaderView
 
 - (void)layoutSubviews {
-    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) { %orig; return; }
+    if (!ApolloSLDShouldSuppressHeaderLayout((UIView *)self)) {
+        %orig;
+        return;
+    }
     ApolloSLDNoteHeaderSuppressed((UIView *)self);
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [UIView performWithoutAnimation:^{ %orig; }];
+    [UIView performWithoutAnimation:^{
+        %orig;
+    }];
     [CATransaction commit];
 }
 

--- a/src/ApolloThemeIntegrations.xm
+++ b/src/ApolloThemeIntegrations.xm
@@ -212,11 +212,13 @@ static void ApplyAccentImageView(id cell) {
     ColorListCell((UITableViewCell *)self);
 }
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
-    %orig; ApplyAccentImageView(self);
+    %orig;
+    ApplyAccentImageView(self);
     if (ApolloThemeRuntimeIsActive()) [(UITableViewCell *)self setNeedsLayout];
 }
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    %orig; ApplyAccentImageView(self);
+    %orig;
+    ApplyAccentImageView(self);
     if (ApolloThemeRuntimeIsActive()) [(UITableViewCell *)self setNeedsLayout];
 }
 %end

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -2058,11 +2058,13 @@ void ApolloThemeRuntimeInvalidate(void) {
 %hook UIButton
 
 - (CGSize)intrinsicContentSize {
-    return ApolloNavigationTitleFittingSize(self, %orig);
+    CGSize nativeSize = %orig;
+    return ApolloNavigationTitleFittingSize(self, nativeSize);
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
-    return ApolloNavigationTitleFittingSize(self, %orig(size));
+    CGSize nativeSize = %orig(size);
+    return ApolloNavigationTitleFittingSize(self, nativeSize);
 }
 
 - (void)setTitleColor:(UIColor *)color forState:(UIControlState)state {

--- a/tests/executable_sdk_tests.m
+++ b/tests/executable_sdk_tests.m
@@ -1,0 +1,218 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import "ApolloExecutableSDK.h"
+
+typedef struct {
+    struct mach_header_64 header;
+    struct build_version_command build;
+    struct version_min_command legacy;
+} SDKFixture;
+
+typedef struct {
+    const char *path;
+    const struct mach_header *header;
+} LoadedImage;
+
+static LoadedImage images[4];
+static uint32_t imageCount;
+static const char *nativeImageName;
+static unsigned availableNativeClasses = 1;
+static unsigned checks;
+
+static void Check(BOOL condition, NSString *message) {
+    checks++;
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+        exit(1);
+    }
+}
+
+static SDKFixture Fixture(uint32_t sdk, uint32_t platform, uint32_t filetype) {
+    SDKFixture fixture = {0};
+    fixture.header.magic = MH_MAGIC_64;
+    fixture.header.filetype = filetype;
+    fixture.header.ncmds = 1;
+    fixture.header.sizeofcmds = sizeof(fixture.build);
+    fixture.build.cmd = LC_BUILD_VERSION;
+    fixture.build.cmdsize = sizeof(fixture.build);
+    fixture.build.platform = platform;
+    fixture.build.sdk = sdk;
+    return fixture;
+}
+
+static Class QAClassLookup(const char *name) {
+    if ((availableNativeClasses & 1) && strcmp(name, "_TtC6Apollo11AppDelegate") == 0) return NSObject.class;
+    if ((availableNativeClasses & 2) && strcmp(name, "_TtC6Apollo13SceneDelegate") == 0) return NSObject.class;
+    if ((availableNativeClasses & 4) && strcmp(name, "_TtC6Apollo19PostsViewController") == 0) return NSObject.class;
+    return Nil;
+}
+static const char *QAClassImageName(__unused Class cls) { return nativeImageName; }
+static uint32_t QAImageCount(void) { return imageCount; }
+static const char *QAImageName(uint32_t index) { return images[index].path; }
+static const struct mach_header *QAImageHeader(uint32_t index) { return images[index].header; }
+
+// Exercise the actual production class/image selection, with only the loader
+// and class registry substituted. This tests image order and class fallback,
+// rather than reimplementing the new selection algorithm in the harness.
+#define objc_lookUpClass QAClassLookup
+#define class_getImageName QAClassImageName
+#define _dyld_image_count QAImageCount
+#define _dyld_get_image_name QAImageName
+#define _dyld_get_image_header QAImageHeader
+#include "ExecutableSDKSelection.inc"
+#undef objc_lookUpClass
+#undef class_getImageName
+#undef _dyld_image_count
+#undef _dyld_get_image_name
+#undef _dyld_get_image_header
+
+static uint32_t OldFirstExecutableSDK(void) {
+    const struct mach_header_64 *header = NULL;
+    for (uint32_t i = 0; i < imageCount; i++) {
+        if (images[i].header && images[i].header->filetype == MH_EXECUTE) {
+            header = (const struct mach_header_64 *)images[i].header;
+            break;
+        }
+    }
+    if (!header && imageCount) header = (const struct mach_header_64 *)images[0].header;
+    return header ? ApolloSDKVersionFromMachO(header, sizeof(*header) + header->sizeofcmds) : 0;
+}
+
+static void TestImageSelection(void) {
+    SDKFixture host = Fixture(0x001A0000, PLATFORM_IOS, MH_EXECUTE);
+    SDKFixture guest = Fixture(0x00100000, PLATFORM_IOS, MH_DYLIB);
+    SDKFixture tweak = Fixture(0x001B0000, PLATFORM_IOS, MH_DYLIB);
+    nativeImageName = "/guest/Apollo.app/Apollo";
+    images[0] = (LoadedImage){"/host/LiveContainer.app/LiveContainer", (const struct mach_header *)&host};
+    images[1] = (LoadedImage){nativeImageName, (const struct mach_header *)&guest};
+    images[2] = (LoadedImage){"/guest/Apollo.app/Frameworks/ApolloReborn.dylib", (const struct mach_header *)&tweak};
+    imageCount = 3;
+    Check(ApolloSDKEnablesLiquidGlass(OldFirstExecutableSDK(), true),
+          @"old first-executable detector reproduces false glass for a classic hosted guest");
+    Check(GetLinkedSDKVersion() == guest.build.sdk, @"hosted guest is selected despite MH_DYLIB filetype");
+    Check(!ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), true),
+          @"standard, noext and glass-icons guests retain classic chrome under a glass-linked host");
+    Check(!ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), false), @"classic guest stays classic on iOS 18");
+
+    LoadedImage swap = images[0];
+    images[0] = images[2];
+    images[2] = swap;
+    Check(GetLinkedSDKVersion() == guest.build.sdk, @"injected tweak at image zero is ignored");
+    guest.header.filetype = MH_EXECUTE;
+    guest.build.platform = PLATFORM_IOSSIMULATOR;
+    Check(GetLinkedSDKVersion() == guest.build.sdk, @"standalone simulator executable is selected by native class");
+    guest.build.sdk = 0x00130000;
+    Check(ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), true), @"SDK 19 encoding preserves glass-patched simulator");
+    Check(!ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), false), @"glass-patched guest cannot enable glass on iOS 18");
+    guest.build.platform = PLATFORM_IOS;
+    guest.header.filetype = MH_DYLIB;
+    guest.build.sdk = 0x001A0000;
+    Check(ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), true), @"glass guest works on iOS 26");
+    guest.build.sdk = 0x001B0000;
+    Check(ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), true), @"glass guest works on iOS 27");
+    Check(!ApolloSDKEnablesLiquidGlass(GetLinkedSDKVersion(), false), @"future-linked guest still requires glass runtime");
+    availableNativeClasses = 2;
+    Check(GetLinkedSDKVersion() == guest.build.sdk, @"SceneDelegate identifies the native image when AppDelegate is absent");
+    availableNativeClasses = 4;
+    Check(GetLinkedSDKVersion() == guest.build.sdk, @"PostsViewController identifies the native image when delegate classes are absent");
+    availableNativeClasses = 0;
+    Check(GetLinkedSDKVersion() == 0, @"missing native classes never fall back to the host");
+    availableNativeClasses = 1;
+    nativeImageName = "/other/Apollo.app/Apollo";
+    Check(GetLinkedSDKVersion() == 0, @"similar basename cannot select the wrong image");
+    nativeImageName = "";
+    Check(GetLinkedSDKVersion() == 0, @"empty native image path disables glass");
+    nativeImageName = NULL;
+    Check(GetLinkedSDKVersion() == 0, @"missing native image path disables glass");
+    nativeImageName = "/guest/Apollo.app/Apollo";
+    guest.header.sizeofcmds = UINT32_MAX;
+    Check(GetLinkedSDKVersion() == 0, @"malformed guest metadata cannot fall back to the host SDK");
+    images[1].header = NULL;
+    Check(GetLinkedSDKVersion() == 0, @"unavailable guest header never falls back to host or tweak");
+    imageCount = 0;
+    Check(GetLinkedSDKVersion() == 0, @"empty image list disables glass");
+}
+
+static void TestLoadCommands(void) {
+    SDKFixture good = Fixture(0x001A0000, PLATFORM_IOS, MH_DYLIB);
+    Check(ApolloSDKVersionFromMachO(&good, sizeof(good)) == good.build.sdk, @"valid iOS build version parses");
+    Check(ApolloSDKVersionFromMachO(NULL, sizeof(good)) == 0, @"null header is rejected");
+    Check(ApolloSDKVersionFromMachO(&good, sizeof(good.header) - 1) == 0, @"truncated header is rejected");
+    Check(ApolloSDKVersionFromMachO(&good, sizeof(good.header) + sizeof(good.build) - 1) == 0,
+          @"truncated load commands are rejected");
+    SDKFixture bad = good;
+    bad.header.magic = MH_CIGAM_64;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"unsupported byte order is rejected");
+    bad = good;
+    bad.header.sizeofcmds = UINT32_MAX;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"oversized load-command area is rejected");
+    bad = good;
+    bad.header.ncmds = UINT32_MAX;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"impossible command count is rejected");
+    bad = good;
+    bad.build.cmdsize = 0;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"zero-sized command cannot loop forever");
+    bad = good;
+    bad.build.cmdsize = UINT32_MAX;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"command overrun is rejected");
+    bad = good;
+    bad.build.cmdsize = 23;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"unaligned command is rejected");
+    bad = good;
+    bad.build.cmdsize = sizeof(struct load_command);
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"short build-version payload is rejected");
+    bad = good;
+    bad.build.ntools = 1;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"truncated build-tool table is rejected");
+    bad = good;
+    bad.build.platform = PLATFORM_MACOS;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"macOS SDK cannot enable iOS glass");
+    bad = good;
+    bad.header.ncmds = 2;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"command count exceeding area is rejected");
+    bad = good;
+    bad.header.sizeofcmds += 8;
+    Check(ApolloSDKVersionFromMachO(&bad, sizeof(bad)) == 0, @"unaccounted command bytes are rejected");
+    SDKFixture legacy = good;
+    struct version_min_command minimum = {LC_VERSION_MIN_IPHONEOS, sizeof(minimum), 0x000E0000, 0x00100000};
+    memcpy(&legacy.build, &minimum, sizeof(minimum));
+    legacy.header.sizeofcmds = sizeof(minimum);
+    Check(ApolloSDKVersionFromMachO(&legacy, sizeof(legacy)) == 0x00100000, @"legacy iPhoneOS SDK command parses");
+    good.header.ncmds = 2;
+    good.header.sizeofcmds += sizeof(good.legacy);
+    good.legacy = minimum;
+    Check(ApolloSDKVersionFromMachO(&good, sizeof(good)) == good.build.sdk,
+          @"build-version SDK takes precedence over legacy SDK metadata");
+
+    struct {
+        struct mach_header_64 header;
+        struct uuid_command uuid;
+        struct build_version_command build;
+    } preceded = {0};
+    preceded.header = good.header;
+    preceded.header.sizeofcmds = sizeof(preceded.uuid) + sizeof(preceded.build);
+    preceded.uuid.cmd = LC_UUID;
+    preceded.uuid.cmdsize = sizeof(preceded.uuid);
+    preceded.build = good.build;
+    Check(ApolloSDKVersionFromMachO(&preceded, sizeof(preceded)) == good.build.sdk,
+          @"unrelated load commands before the SDK are skipped safely");
+    struct {
+        struct mach_header_64 header;
+        struct build_version_command builds[2];
+    } duplicate = {0};
+    duplicate.header = good.header;
+    duplicate.header.sizeofcmds = sizeof(duplicate.builds);
+    duplicate.builds[0] = good.build;
+    duplicate.builds[1] = good.build;
+    Check(ApolloSDKVersionFromMachO(&duplicate, sizeof(duplicate)) == 0,
+          @"ambiguous duplicate iOS build-version commands are rejected");
+}
+
+int main(void) {
+    @autoreleasepool {
+        TestImageSelection();
+        TestLoadCommands();
+        printf("PASS: %u executable SDK and Liquid Glass checks\n", checks);
+    }
+    return 0;
+}

--- a/tests/find_in_comments_hook_tests.m
+++ b/tests/find_in_comments_hook_tests.m
@@ -1,0 +1,163 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+// The runner places the production string hook and its installer immediately
+// before this file, after processing them with the selected Logos generator.
+// A private probe class keeps the test from replacing Foundation globally.
+@interface FICStringProbe : NSObject
+@property (nonatomic, copy) NSString *text;
+- (NSRange)rangeOfString:(NSString *)needle options:(NSStringCompareOptions)options range:(NSRange)range;
+@end
+@implementation FICStringProbe
+- (NSRange)rangeOfString:(NSString *)needle options:(NSStringCompareOptions)options range:(NSRange)range {
+    return [self.text rangeOfString:needle options:options range:range];
+}
+@end
+
+@interface FICInheritedStringProbe : FICStringProbe
+@end
+@implementation FICInheritedStringProbe
+@end
+
+static NSUInteger checks;
+static NSUInteger priorCalls;
+static NSUInteger trampolineCalls;
+static NSUInteger laterCalls;
+static NSUInteger installerReentries;
+static FICStringProbe *installationProbe;
+static FICRangeOfStringIMP nativeOriginal;
+static FICRangeOfStringIMP trampolineOriginal;
+static FICRangeOfStringIMP laterOriginal;
+
+static void Check(BOOL condition, NSString *message) {
+    checks++;
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+        exit(1);
+    }
+}
+
+static NSRange PriorHook(NSString *receiver, SEL selector, NSString *needle,
+                         NSStringCompareOptions options, NSRange range) {
+    priorCalls++;
+    return nativeOriginal(receiver, selector, needle, options, range);
+}
+
+static NSRange InstallerTrampoline(NSString *receiver, SEL selector, NSString *needle,
+                                  NSStringCompareOptions options, NSRange range) {
+    trampolineCalls++;
+    return trampolineOriginal(receiver, selector, needle, options, range);
+}
+
+static NSRange LaterHook(NSString *receiver, SEL selector, NSString *needle,
+                         NSStringCompareOptions options, NSRange range) {
+    laterCalls++;
+    return laterOriginal(receiver, selector, needle, options, range);
+}
+
+void MSHookMessageEx(Class cls, SEL selector, IMP replacement, IMP *original) {
+    Method method = class_getInstanceMethod(cls, selector);
+    trampolineOriginal = (FICRangeOfStringIMP)method_getImplementation(method);
+    Check(*original == NULL, @"Logos original is uninitialized before publication");
+    class_replaceMethod(cls, selector, replacement, method_getTypeEncoding(method));
+
+    // Reproduce the reported ElleKit order exactly: publish, synchronously use
+    // the replaced method while formatting its log, then fill the orig slot.
+    // Calling through this slot directly here used to jump to address zero.
+    Check(*original == NULL, @"installer has not filled the original during reentry");
+    NSRange result = [installationProbe rangeOfString:@"cats" options:0
+                                               range:NSMakeRange(0, installationProbe.text.length)];
+    installerReentries++;
+    Check(NSEqualRanges(result, NSMakeRange(0, 4)), @"installation reentry reaches the seeded original");
+    Check(priorCalls == 1, @"installation reentry preserves the preexisting hook");
+    Check(trampolineCalls == 0, @"trampoline is not used before installer returns it");
+
+    // A hook engine may supply a callable trampoline distinct from the IMP
+    // captured before installation. Steady-state calls must use that result.
+    *original = (IMP)InstallerTrampoline;
+}
+
+static NSRange Find(FICStringProbe *probe, NSString *needle, NSRange range) {
+    return [probe rangeOfString:needle options:NSCaseInsensitiveSearch range:range];
+}
+
+int main(void) {
+    @autoreleasepool {
+        SEL selector = @selector(rangeOfString:options:range:);
+        Method method = class_getInstanceMethod(FICStringProbe.class, selector);
+        nativeOriginal = (FICRangeOfStringIMP)method_setImplementation(method, (IMP)PriorHook);
+        installationProbe = [FICInheritedStringProbe new];
+        installationProbe.text = @"cats and DOGS; cat";
+        NSRange fullRange = NSMakeRange(0, installationProbe.text.length);
+
+        Check(!FICInstallStringHook(NSObject.class), @"missing method is never hooked");
+        Check(FICInstallStringHook(FICInheritedStringProbe.class), @"inherited method installs");
+#if FIC_TEST_SUBSTRATE
+        Check(installerReentries == 1, @"fake ElleKit reentered during installation");
+#else
+        Check(installerReentries == 0, @"internal generator needs no Substrate dependency");
+#endif
+        Check(class_getMethodImplementation(FICStringProbe.class, selector) == (IMP)PriorHook,
+              @"hooking an inherited method does not replace the superclass method");
+        Check(NSEqualRanges(Find(installationProbe, @"dogs", fullRange), NSMakeRange(9, 4)),
+              @"ordinary search preserves comparison options");
+        Check(NSEqualRanges(Find(installationProbe, @"cat", NSMakeRange(4, fullRange.length - 4)),
+                            NSMakeRange(15, 3)), @"ordinary search preserves the search range");
+        Check(Find(installationProbe, @"cat, cats", fullRange).location == NSNotFound,
+              @"comma query remains literal outside the native rebuild");
+
+        sFICMultiTerms = @[@"cat", @"cats"];
+        sFICMultiQuery = @"cat, cats";
+        sFICMultiActive = YES;
+        Check(NSEqualRanges(Find(installationProbe, @"cat, cats", fullRange), NSMakeRange(0, 4)),
+              @"multi-term ties choose the longer match");
+        Check(NSEqualRanges(Find(installationProbe, @"CAT, CATS", NSMakeRange(4, fullRange.length - 4)),
+                            NSMakeRange(15, 3)), @"subsequent multi-term match preserves query comparison");
+        Check(NSEqualRanges(Find(installationProbe, @"dogs", fullRange), NSMakeRange(9, 4)),
+              @"unrelated searches remain literal while multi-term search is armed");
+        __block NSRange backgroundResult;
+        dispatch_semaphore_t backgroundDone = dispatch_semaphore_create(0);
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+            backgroundResult = Find(installationProbe, @"cat, cats", fullRange);
+            dispatch_semaphore_signal(backgroundDone);
+        });
+        Check(dispatch_semaphore_wait(backgroundDone, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)) == 0,
+              @"background search completed");
+        Check(backgroundResult.location == NSNotFound, @"background searches never use the main-thread query");
+
+        sFICMultiTerms = @[@"dogs", @"cat"];
+        sFICMultiQuery = @"dogs, cat";
+        Check(NSEqualRanges(Find(installationProbe, @"dogs, cat", fullRange), NSMakeRange(0, 3)),
+              @"earliest match wins regardless of term order");
+        sFICMultiTerms = @[@"absent", @"missing"];
+        sFICMultiQuery = @"absent, missing";
+        Check(Find(installationProbe, sFICMultiQuery, fullRange).location == NSNotFound,
+              @"unmatched multi-term query returns not found");
+#if FIC_TEST_SUBSTRATE
+        Check(trampolineCalls > 0, @"completed installation uses the hook engine trampoline");
+#endif
+
+        method = class_getInstanceMethod(FICInheritedStringProbe.class, selector);
+        laterOriginal = (FICRangeOfStringIMP)method_setImplementation(method, (IMP)LaterHook);
+        sFICMultiTerms = @[@"dogs", @"cat"];
+        sFICMultiQuery = @"dogs, cat";
+        Check(NSEqualRanges(Find(installationProbe, sFICMultiQuery, fullRange), NSMakeRange(0, 3)),
+              @"a later hook can chain through multi-term matching");
+        Check(laterCalls == 1, @"later hook executes exactly once");
+        sFICMultiActive = NO;
+        sFICMultiTerms = nil;
+        sFICMultiQuery = nil;
+        Check(NSEqualRanges(Find(installationProbe, @"cat", fullRange), NSMakeRange(0, 3)),
+              @"normal searches resume after the native rebuild ends");
+        BOOL threwRangeException = NO;
+        @try {
+            (void)Find(installationProbe, @"cat", NSMakeRange(fullRange.length + 1, 1));
+        } @catch (NSException *exception) {
+            threwRangeException = [exception.name isEqualToString:NSRangeException];
+        }
+        Check(threwRangeException, @"underlying Foundation exception behavior is preserved");
+        printf("PASS: %lu Find in Comments hook checks (%s)\n", (unsigned long)checks,
+               FIC_TEST_SUBSTRATE ? "Substrate with synchronous reentry" : "internal generator");
+    }
+    return 0;
+}

--- a/tests/multireddit_expansion_tests.m
+++ b/tests/multireddit_expansion_tests.m
@@ -1,0 +1,273 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <dispatch/dispatch.h>
+#define ApolloLog(...) do {} while (0)
+
+typedef NSInteger UITableViewRowAnimation;
+
+@interface NSIndexPath (TableCoordinates)
+@property (nonatomic, readonly) NSInteger row;
+@property (nonatomic, readonly) NSInteger section;
++ (instancetype)indexPathForRow:(NSInteger)row inSection:(NSInteger)section;
+@end
+@implementation NSIndexPath (TableCoordinates)
+- (NSInteger)row { return (NSInteger)[self indexAtPosition:1]; }
+- (NSInteger)section { return (NSInteger)[self indexAtPosition:0]; }
++ (instancetype)indexPathForRow:(NSInteger)row inSection:(NSInteger)section {
+    NSUInteger indexes[] = { (NSUInteger)section, (NSUInteger)row };
+    return [self indexPathWithIndexes:indexes length:2];
+}
+@end
+
+@interface UIViewController : NSObject
+@property (nonatomic) NSUInteger mapInvalidations;
+@end
+@implementation UIViewController
+@end
+
+// This double enforces UIKit's row-count invariant, rather than implementing
+// the production deferral. The real Logos hooks below decide what reaches it.
+@interface UITableView : NSObject
+@property (nonatomic, strong) UIViewController *dataSource;
+@property (nonatomic) NSInteger modelRows;
+@property (nonatomic) NSInteger presentedRows;
+@property (nonatomic) NSInteger pendingDelta;
+@property (nonatomic) NSUInteger batchDepth;
+@property (nonatomic) NSUInteger begins;
+@property (nonatomic) NSUInteger ends;
+@property (nonatomic) NSUInteger inserts;
+@property (nonatomic) NSUInteger deletes;
+@property (nonatomic) NSUInteger rowReloads;
+@property (nonatomic) NSUInteger reloads;
+- (void)reloadData;
+- (void)beginUpdates;
+- (void)endUpdates;
+- (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)paths withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)deleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)paths withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)reloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)paths withRowAnimation:(UITableViewRowAnimation)animation;
+@end
+@implementation UITableView
+- (void)reloadData {
+    self.reloads++;
+    self.presentedRows = self.modelRows;
+}
+- (void)beginUpdates {
+    self.begins++;
+    self.batchDepth++;
+}
+- (void)endUpdates {
+    self.ends++;
+    if (self.batchDepth == 0) {
+        [NSException raise:NSInternalInconsistencyException format:@"Unbalanced table batch"];
+    }
+    self.batchDepth--;
+    if (self.batchDepth > 0) return;
+    if (self.presentedRows + self.pendingDelta != self.modelRows) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Before %ld + changes %ld != after %ld", self.presentedRows,
+                           self.pendingDelta, self.modelRows];
+    }
+    self.presentedRows = self.modelRows;
+    self.pendingDelta = 0;
+}
+- (void)insertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)paths withRowAnimation:(__unused UITableViewRowAnimation)animation {
+    self.inserts++;
+    self.pendingDelta += (NSInteger)paths.count;
+}
+- (void)deleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)paths withRowAnimation:(__unused UITableViewRowAnimation)animation {
+    self.deletes++;
+    self.pendingDelta -= (NSInteger)paths.count;
+}
+- (void)reloadRowsAtIndexPaths:(__unused NSArray<NSIndexPath *> *)paths withRowAnimation:(__unused UITableViewRowAnimation)animation {
+    self.rowReloads++;
+}
+@end
+
+// The captured crash took the normal-layout path, with no active Following
+// map. The table identity and map invalidation remain observable in this test.
+typedef NSObject ApolloFollowingMap;
+static NSInteger sApolloFollowingWindowDepth;
+static UITableView *sApolloFollowingWindowTable;
+static NSString *sApolloFollowingWindowTappedName;
+static NSArray<NSString *> *sApolloFollowingWindowFavorites;
+static const NSInteger kApolloNativeSectionFavorites = 1;
+static BOOL ApolloFollowingTableIsList(UITableView *table) { return table.dataSource != nil; }
+static void ApolloFollowingInvalidateMap(UIViewController *controller) { controller.mapInvalidations++; }
+static ApolloFollowingMap *ApolloFollowingPresentedMapForTable(__unused UITableView *table) { return nil; }
+static ApolloFollowingMap *ApolloFollowingActiveMapForTable(__unused UITableView *table) { return nil; }
+static NSIndexPath *ApolloFollowingVisiblePathForNative(__unused ApolloFollowingMap *map, NSIndexPath *path) { return path; }
+static BOOL ApolloFollowingCallerIsApolloBinary(__unused void *address) { return NO; }
+
+#include "ApolloMultiredditExpansion.h"
+
+// INCLUDE_PRODUCTION_TABLE_HOOKS
+
+static NSUInteger checks;
+static void Check(BOOL condition, NSString *message) {
+    checks++;
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+        exit(1);
+    }
+}
+static UITableView *Table(NSInteger rows) {
+    UITableView *table = [UITableView new];
+    table.dataSource = [UIViewController new];
+    table.modelRows = rows;
+    table.presentedRows = rows;
+    return table;
+}
+static NSArray<NSIndexPath *> *ChildPaths(NSUInteger count) {
+    NSMutableArray *paths = [NSMutableArray array];
+    for (NSUInteger i = 0; i < count; i++) {
+        [paths addObject:[NSIndexPath indexPathForRow:(NSInteger)i + 1 inSection:2]];
+    }
+    return paths;
+}
+
+// Native Apollo's shared name key can expand both parents, while the tapped
+// model provides only its own two child paths to the table animation.
+static void NativeToggle(UITableView *table, NSInteger resultingRows,
+                         NSUInteger tappedChildren, BOOL expand) {
+    [table beginUpdates];
+    table.modelRows = resultingRows;
+    if (expand) [table insertRowsAtIndexPaths:ChildPaths(tappedChildren) withRowAnimation:0];
+    else [table deleteRowsAtIndexPaths:ChildPaths(tappedChildren) withRowAnimation:0];
+    [table endUpdates];
+}
+
+int main(void) {
+    @autoreleasepool {
+        UITableView *broken = Table(2);
+        BOOL caught = NO;
+        @try { NativeToggle(broken, 7, 2, YES); }
+        @catch (NSException *exception) { caught = [exception.name isEqualToString:NSInternalInconsistencyException]; }
+        Check(caught, @"negative control: duplicate-name expansion fails the native row-count invariant");
+
+        UITableView *duplicate = Table(2);
+        __block NSUInteger originals = 0;
+        ApolloPerformMultiredditExpansion(duplicate, ^{
+            originals++;
+            NativeToggle(duplicate, 7, 2, YES);
+        });
+        Check(originals == 1 && duplicate.modelRows == 7, @"original state mutation still runs exactly once");
+        Check(duplicate.presentedRows == 7 && duplicate.reloads == 1, @"duplicate-name expansion displays every resulting child");
+        Check(duplicate.begins == 0 && duplicate.ends == 0 && duplicate.inserts == 0,
+              @"no part of the invalid expansion batch reaches UIKit");
+        Check(duplicate.dataSource.mapInvalidations == 1, @"final reload invalidates the Following map once");
+        ApolloPerformMultiredditExpansion(duplicate, ^{ NativeToggle(duplicate, 2, 2, NO); });
+        Check(duplicate.presentedRows == 2 && duplicate.reloads == 2 && duplicate.deletes == 0,
+              @"shared-name collapse also reconciles every removed child");
+
+        UITableView *ordinary = Table(1);
+        ApolloPerformMultiredditExpansion(ordinary, ^{ NativeToggle(ordinary, 4, 3, YES); });
+        Check(ordinary.presentedRows == 4 && ordinary.reloads == 1, @"ordinary multireddit expansion still works");
+        ApolloPerformMultiredditExpansion(ordinary, ^{ originals++; });
+        Check(originals == 2 && ordinary.reloads == 1, @"a no-op handler is preserved without an unnecessary reload");
+
+        // Cover each shipping hook independently, including a native reload
+        // and a row refresh without a begin/end pair.
+        NSArray<dispatch_block_t> *mutations = @[
+            ^{ [ordinary reloadData]; },
+            ^{ [ordinary beginUpdates]; },
+            ^{ [ordinary endUpdates]; },
+            ^{ [ordinary insertRowsAtIndexPaths:ChildPaths(1) withRowAnimation:0]; },
+            ^{ [ordinary deleteRowsAtIndexPaths:ChildPaths(1) withRowAnimation:0]; },
+            ^{ [ordinary reloadRowsAtIndexPaths:ChildPaths(1) withRowAnimation:0]; }
+        ];
+        for (dispatch_block_t mutation in mutations) {
+            NSUInteger beforeReloads = ordinary.reloads;
+            ApolloPerformMultiredditExpansion(ordinary, mutation);
+            Check(ordinary.reloads == beforeReloads + 1, @"every deferred table API triggers one completed reload");
+        }
+        Check(ordinary.begins == 0 && ordinary.ends == 0 && ordinary.inserts == 0 &&
+              ordinary.deletes == 0 && ordinary.rowReloads == 0,
+              @"all six production hooks defer their scoped native work");
+
+        UITableView *other = Table(1);
+        NSUInteger beforeReloads = ordinary.reloads;
+        ApolloPerformMultiredditExpansion(ordinary, ^{
+            NativeToggle(other, 3, 2, YES);
+            [other reloadRowsAtIndexPaths:ChildPaths(1) withRowAnimation:0];
+            [ordinary reloadData];
+            [ordinary reloadData];
+            [ordinary reloadRowsAtIndexPaths:ChildPaths(1) withRowAnimation:0];
+        });
+        Check(other.begins == 1 && other.ends == 1 && other.inserts == 1 && other.rowReloads == 1 && other.reloads == 0,
+              @"another table retains ordinary batch and row refresh behavior");
+        Check(ordinary.reloads == beforeReloads + 1, @"multiple scoped reload requests coalesce");
+
+        beforeReloads = ordinary.reloads;
+        ApolloPerformMultiredditExpansion(ordinary, ^{
+            ApolloPerformMultiredditExpansion(ordinary, ^{ [ordinary reloadData]; });
+            Check(ordinary.reloads == beforeReloads, @"nested same-table expansion does not reload early");
+            [ordinary reloadData];
+        });
+        Check(ordinary.reloads == beforeReloads + 1, @"nested same-table expansion reloads once at its outer boundary");
+
+        NSUInteger otherReloads = other.reloads;
+        beforeReloads = ordinary.reloads;
+        ApolloPerformMultiredditExpansion(ordinary, ^{
+            ApolloPerformMultiredditExpansion(other, ^{
+                [ordinary reloadData];
+                [other reloadData];
+                ApolloPerformMultiredditExpansion(ordinary, ^{ [ordinary reloadData]; });
+            });
+            Check(other.reloads == otherReloads + 1 && ordinary.reloads == beforeReloads,
+                  @"nested different tables complete at their own outer boundaries");
+        });
+        Check(ordinary.reloads == beforeReloads + 1, @"a nested table does not hide its parent's scope");
+
+        NSException *sentinel = [NSException exceptionWithName:@"TestOriginalFailure" reason:nil userInfo:nil];
+        beforeReloads = ordinary.reloads;
+        caught = NO;
+        @try {
+            ApolloPerformMultiredditExpansion(ordinary, ^{
+                [ordinary reloadData];
+                @throw sentinel;
+            });
+        } @catch (NSException *exception) { caught = exception == sentinel; }
+        Check(caught && ordinary.reloads == beforeReloads, @"original exceptions propagate without a successful-completion reload");
+        Check(!ApolloDeferMultiredditTableUpdate(ordinary), @"throwing original cannot leak its scope");
+        [ordinary reloadData];
+        Check(ordinary.reloads == beforeReloads + 1, @"table reloads work normally after exception cleanup");
+
+        beforeReloads = ordinary.reloads;
+        ApolloPerformMultiredditExpansion(ordinary, ^{
+            @try {
+                ApolloPerformMultiredditExpansion(ordinary, ^{
+                    [ordinary reloadData];
+                    @throw sentinel;
+                });
+            } @catch (NSException *exception) {
+                Check(exception == sentinel, @"a caller can catch its nested original exception");
+            }
+        });
+        Check(ordinary.reloads == beforeReloads + 1, @"successful outer caller reconciles mutations from its caught nested failure");
+
+        __block BOOL nilOriginalRan = NO;
+        ApolloPerformMultiredditExpansion(nil, ^{ nilOriginalRan = YES; });
+        Check(nilOriginalRan && !ApolloDeferMultiredditTableUpdate(nil), @"missing table still runs original without deferral");
+
+        UITableView *background = Table(1);
+        dispatch_semaphore_t completed = dispatch_semaphore_create(0);
+        __block BOOL backgroundDeferred = YES;
+        ApolloPerformMultiredditExpansion(ordinary, ^{
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+                @autoreleasepool {
+                    backgroundDeferred = ApolloDeferMultiredditTableUpdate(ordinary);
+                    ApolloPerformMultiredditExpansion(background, ^{ [background reloadData]; });
+                    dispatch_semaphore_signal(completed);
+                }
+            });
+            Check(dispatch_semaphore_wait(completed, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)) == 0,
+                  @"background passthrough does not block on the main scope");
+        });
+        Check(!backgroundDeferred && background.reloads == 1,
+              @"background calls neither join nor replace a main-thread expansion scope");
+        Check(!ApolloDeferMultiredditTableUpdate(ordinary) && !ApolloDeferMultiredditTableUpdate(other),
+              @"all successful scopes are removed before returning");
+        printf("PASS: %lu multireddit expansion checks (production scope and six table hooks)\n", (unsigned long)checks);
+    }
+    return 0;
+}

--- a/tests/notification_backend_tests.m
+++ b/tests/notification_backend_tests.m
@@ -1,0 +1,141 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <unistd.h>
+
+#import "ApolloNotificationBackend.h"
+#import "ApolloAccountCredentials.h"
+#import "UserDefaultConstants.h"
+
+// Only the unrelated account/Bark inputs are stubbed. The executable compiles
+// the real configuration getters and request rewrite from the feature module.
+NSString *sRedditClientId = @"";
+NSString *sRedditClientSecret = @"";
+NSString *sRedirectURI = @"";
+NSString *sUserAgent = @"";
+BOOL ApolloBarkModeActive(void) { return NO; }
+NSURL *ApolloBarkEffectivePushURL(void) { return nil; }
+ApolloAccountCredentialEntry *ApolloAccountCredentialsFor(__unused NSString *username) { return nil; }
+
+static NSUserDefaults *sTestDefaults;
+static NSString *sTestDomain;
+
+static id TestStandardUserDefaults(__unused id self, __unused SEL selector) {
+    return sTestDefaults;
+}
+
+static void Require(BOOL condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "notification_backend_tests: %s\n", message);
+        abort();
+    }
+}
+
+static NSDictionary *Configuration(NSUInteger generation) {
+    return @{
+        UDKeyNotificationBackendURL: [NSString stringWithFormat:@" https://backend-%lu.example:8443/// \n", (unsigned long)generation],
+        UDKeyNotificationBackendRegistrationToken: [NSString stringWithFormat:@" token-%lu \n", (unsigned long)generation],
+    };
+}
+
+static void SetConfiguration(NSDictionary *configuration) {
+    [sTestDefaults setPersistentDomain:configuration forName:sTestDomain];
+    // Exercise the old invalidation trigger even on hosts that coalesce their
+    // defaults notifications. This may run alongside every request worker.
+    [[NSNotificationCenter defaultCenter] postNotificationName:NSUserDefaultsDidChangeNotification object:sTestDefaults];
+}
+
+static NSMutableURLRequest *RegistrationRequest(void) {
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://apollonotifications.com/v1/live_activities?existing=1"]];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = [@"original body" dataUsingEncoding:NSUTF8StringEncoding];
+    [request setValue:@"preserved" forHTTPHeaderField:@"X-Existing"];
+    return request;
+}
+
+static void CheckRewrittenRequest(NSURLRequest *rewritten, NSURLRequest *original) {
+    Require(rewritten != nil, "a configured legacy backend must be rewritten");
+    NSString *host = rewritten.URL.host;
+    Require([host hasPrefix:@"backend-"] && [host hasSuffix:@".example"], "unexpected rewritten host");
+    NSString *generation = [[host componentsSeparatedByString:@"."][0] substringFromIndex:@"backend-".length];
+    NSString *expectedToken = [@"token-" stringByAppendingString:generation];
+    Require([[rewritten valueForHTTPHeaderField:@"X-Registration-Token"] isEqualToString:expectedToken], "backend and token must come from the same defaults snapshot");
+    Require([rewritten.URL.scheme isEqualToString:@"https"] && rewritten.URL.port.integerValue == 8443, "backend scheme and port must be applied");
+    Require([rewritten.URL.path isEqualToString:original.URL.path] && [rewritten.URL.query isEqualToString:original.URL.query], "rewrite must preserve path and query");
+    Require([rewritten.HTTPMethod isEqualToString:original.HTTPMethod] && [rewritten.HTTPBody isEqualToData:original.HTTPBody], "rewrite must preserve method and body");
+    Require([[rewritten valueForHTTPHeaderField:@"X-Existing"] isEqualToString:@"preserved"], "rewrite must preserve unrelated headers");
+}
+
+static void TestSettingsChangesAndRetainedValues(void) {
+    SetConfiguration(Configuration(1));
+    NSURL *heldURL = ApolloNotificationBackendBaseURL();
+    NSString *heldToken = ApolloNotificationBackendRegistrationToken();
+    Require(ApolloIsNotificationBackendConfigured(), "valid backend should be configured");
+    Require([heldURL.absoluteString isEqualToString:@"https://backend-1.example:8443"], "base URL whitespace and trailing slashes must be trimmed");
+    Require([heldToken isEqualToString:@"token-1"], "token whitespace must be trimmed");
+
+    SetConfiguration(Configuration(2));
+    NSMutableURLRequest *request = RegistrationRequest();
+    CheckRewrittenRequest(ApolloRewriteRequestForNotificationBackend(request), request);
+    Require([ApolloNotificationBackendBaseURL().host isEqualToString:@"backend-2.example"], "getters must see settings changes immediately");
+    Require([ApolloNotificationBackendRegistrationToken() isEqualToString:@"token-2"], "token getter must see settings changes immediately");
+    Require([[NSURLComponents componentsWithURL:heldURL resolvingAgainstBaseURL:NO].host isEqualToString:@"backend-1.example"] && [heldToken isEqualToString:@"token-1"], "previously returned values must survive later settings changes");
+    Require([request.URL.host isEqualToString:@"apollonotifications.com"] && [request valueForHTTPHeaderField:@"X-Registration-Token"] == nil, "rewrite must leave the original request unchanged");
+
+    SetConfiguration(@{});
+    Require(!ApolloIsNotificationBackendConfigured() && ApolloNotificationBackendBaseURL() == nil, "removed backend must disable rewriting immediately");
+    Require(ApolloRewriteRequestForNotificationBackend(request) == nil && ApolloNotificationBackendRegistrationToken() == nil, "removed configuration must not leave stale values");
+
+    for (id invalid in @[@"file:///tmp/backend", @"https://", @"   /  ", @[@"https://invalid.example"]]) {
+        SetConfiguration(@{UDKeyNotificationBackendURL: invalid});
+        Require(!ApolloIsNotificationBackendConfigured(), "invalid backend should be rejected");
+    }
+}
+
+static void TestConcurrentSettingsAndRewrites(void) {
+    SetConfiguration(Configuration(1));
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_semaphore_t start = dispatch_semaphore_create(0);
+    // A writer replaces URL and token together while six request workers read,
+    // retain, and bridge their values. Tests both lifetime and paired snapshots.
+    dispatch_group_async(group, queue, ^{
+        dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+        for (NSUInteger iteration = 0; iteration < 3000; iteration++) {
+            @autoreleasepool {
+                SetConfiguration(Configuration(iteration + 2));
+            }
+        }
+    });
+    for (NSUInteger worker = 0; worker < 6; worker++) {
+        dispatch_group_async(group, queue, ^{
+            dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+            for (NSUInteger iteration = 0; iteration < 2000; iteration++) {
+                @autoreleasepool {
+                    NSURL *heldURL = ApolloNotificationBackendBaseURL();
+                    NSString *heldToken = ApolloNotificationBackendRegistrationToken();
+                    NSMutableURLRequest *request = RegistrationRequest();
+                    CheckRewrittenRequest(ApolloRewriteRequestForNotificationBackend(request), request);
+                    if (iteration % 100 == 0) usleep(100);
+                    Require([NSURLComponents componentsWithURL:heldURL resolvingAgainstBaseURL:NO].host.length > 0 && heldToken.length > 0, "retained values must remain usable across concurrent replacement");
+                }
+            }
+        });
+    }
+    for (NSUInteger worker = 0; worker < 7; worker++) dispatch_semaphore_signal(start);
+    Require(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC)) == 0, "concurrent configuration stress timed out");
+}
+
+int main(void) {
+    @autoreleasepool {
+        sTestDomain = [@"app.apolloreborn.notification-backend-tests." stringByAppendingString:NSUUID.UUID.UUIDString];
+        sTestDefaults = [[NSUserDefaults alloc] initWithSuiteName:sTestDomain];
+        Method standardDefaults = class_getClassMethod(NSUserDefaults.class, @selector(standardUserDefaults));
+        IMP originalDefaults = method_setImplementation(standardDefaults, (IMP)TestStandardUserDefaults);
+        TestSettingsChangesAndRetainedValues();
+        TestConcurrentSettingsAndRewrites();
+        method_setImplementation(standardDefaults, originalDefaults);
+        [sTestDefaults removePersistentDomainForName:sTestDomain];
+        puts("notification_backend_tests: settings/lifetime checks and 12,000 concurrent rewrites passed");
+    }
+    return 0;
+}

--- a/tests/profile_pagination_tests.m
+++ b/tests/profile_pagination_tests.m
@@ -1,0 +1,282 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <dispatch/dispatch.h>
+#define ApolloLog(...) do {} while (0)
+
+@class UINavigationController, UITabBarController;
+@interface UIViewController : NSObject
+@property (nonatomic, weak) UINavigationController *navigationController;
+@property (nonatomic, weak) UITabBarController *tabBarController;
+@end
+@implementation UIViewController
+@end
+@interface UINavigationController : UIViewController
+@property (nonatomic, copy) NSArray *viewControllers;
+@end
+@implementation UINavigationController
+@end
+@interface UITabBarController : UIViewController
+@property (nonatomic, copy) NSArray *viewControllers;
+@end
+@implementation UITabBarController
+@end
+
+@interface TestBatchContext : NSObject
+@property (nonatomic) BOOL fetching;
+@property (nonatomic) NSUInteger completions;
+- (BOOL)isFetching;
+- (void)completeBatchFetching:(BOOL)complete;
+@end
+@implementation TestBatchContext
+- (BOOL)isFetching { return self.fetching; }
+- (void)completeBatchFetching:(BOOL)complete {
+    if (complete) { self.fetching = NO; self.completions++; }
+}
+@end
+@interface TestTable : NSObject
+@property (nonatomic, strong) TestBatchContext *batchContext;
+@end
+@implementation TestTable
+@end
+@interface TestNode : NSObject
+@property (nonatomic) BOOL loaded;
+@property (nonatomic, strong) TestTable *view;
+- (BOOL)isNodeLoaded;
+@end
+@implementation TestNode
+- (BOOL)isNodeLoaded { return self.loaded; }
+@end
+
+typedef void (^TestOverviewCompletion)(NSArray *, id, NSError *);
+@interface RDKClient : NSObject
+@property (nonatomic, copy) TestOverviewCompletion lastCompletion;
+@property (nonatomic, strong) id returnTask;
+- (id)overviewOfUserWithUsername:(id)username pagination:(id)pagination completion:(TestOverviewCompletion)completion;
+@end
+@implementation RDKClient
+- (id)overviewOfUserWithUsername:(__unused id)username pagination:(__unused id)pagination completion:(TestOverviewCompletion)completion {
+    self.lastCompletion = completion;
+    return self.returnTask;
+}
+@end
+
+@interface _TtC6Apollo21ProfileViewController : UIViewController {
+    id pagination;
+    TestNode *tableNode;
+}
+@property (nonatomic, strong) id pagination;
+@property (nonatomic, strong) TestNode *tableNode;
+@property (nonatomic) BOOL accountChangeReplacesPagination;
+- (void)viewDidLoad;
+- (void)refreshControlActivatedWithSender:(id)sender;
+- (void)redditAccountChangedWithNotification:(id)notification;
+@end
+@implementation _TtC6Apollo21ProfileViewController
+@synthesize pagination, tableNode;
+- (void)viewDidLoad {}
+- (void)refreshControlActivatedWithSender:(__unused id)sender { self.pagination = [NSObject new]; }
+- (void)redditAccountChangedWithNotification:(__unused id)notification {
+    if (self.accountChangeReplacesPagination) self.pagination = [NSObject new];
+}
+@end
+
+// INCLUDE_PRODUCTION_GUARD
+
+static NSUInteger checks;
+static void Check(BOOL condition, NSString *message) {
+    checks++;
+    if (!condition) { fprintf(stderr, "FAIL: %s\n", message.UTF8String); exit(1); }
+}
+static void DrainMainQueue(void) {
+    __block BOOL done = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{ done = YES; });
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
+    while (!done && deadline.timeIntervalSinceNow > 0) {
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.001]];
+    }
+    Check(done, @"main-queue callback delivery drains");
+}
+static void OnBackground(dispatch_block_t block) {
+    dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        block();
+        dispatch_semaphore_signal(finished);
+    });
+    Check(dispatch_semaphore_wait(finished, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)) == 0,
+          @"background request lookup never waits for main");
+}
+static _TtC6Apollo21ProfileViewController *Profile(void) {
+    _TtC6Apollo21ProfileViewController *profile = [_TtC6Apollo21ProfileViewController new];
+    profile.pagination = [NSObject new];
+    profile.tableNode = [TestNode new];
+    profile.tableNode.loaded = YES;
+    profile.tableNode.view = [TestTable new];
+    profile.tableNode.view.batchContext = [TestBatchContext new];
+    [profile viewDidLoad];
+    return profile;
+}
+
+int main(void) {
+    @autoreleasepool {
+        RDKClient *client = [RDKClient new];
+        client.returnTask = [NSObject new];
+        _TtC6Apollo21ProfileViewController *profile = Profile();
+        TestBatchContext *batch = profile.tableNode.view.batchContext;
+        __block NSUInteger writes = 0;
+        __block id receivedItems, receivedError;
+        TestOverviewCompletion native = ^(NSArray *items, id next, NSError *error) {
+            Check([NSThread isMainThread], @"native profile callback is on main");
+            writes++;
+            receivedItems = items;
+            receivedError = error;
+            if (!error) profile.pagination = next;
+            [batch completeBatchFetching:YES];
+        };
+
+        // Real #1064 ordering: an ASDK background page starts, switching
+        // accounts resets the persistent profile, then the old page arrives.
+        id firstPage = profile.pagination;
+        batch.fetching = YES;
+        OnBackground(^{
+            id task = [client overviewOfUserWithUsername:@"unused" pagination:firstPage completion:native];
+            Check(task == client.returnTask, @"RDK task return value is preserved");
+        });
+        TestOverviewCompletion obsolete = client.lastCompletion;
+        UINavigationController *navigation = [UINavigationController new];
+        UITabBarController *tabs = [UITabBarController new];
+        navigation.viewControllers = @[profile];
+        tabs.viewControllers = @[navigation];
+        profile.navigationController = navigation;
+        profile.tabBarController = tabs;
+        profile.accountChangeReplacesPagination = YES;
+        [profile redditAccountChangedWithNotification:nil];
+        Check(!batch.fetching && batch.completions == 1, @"reset releases the old batch before its response");
+        id newAccountPage = profile.pagination;
+        batch.fetching = YES;
+        [client overviewOfUserWithUsername:nil pagination:newAccountPage completion:native];
+        TestOverviewCompletion current = client.lastCompletion;
+        obsolete(@[@"old account"], [NSObject new], nil);
+        Check(writes == 0 && profile.pagination == newAccountPage, @"old account cannot replace pagination or mutate the native model");
+        Check(batch.fetching && batch.completions == 1, @"late old response cannot finish the new account's batch");
+        id nextPage = [NSObject new];
+        NSArray *items = @[@"new account"];
+        current(items, nextPage, nil);
+        Check(writes == 1 && receivedItems == items && profile.pagination == nextPage, @"current account response passes through exactly");
+        current(items, nextPage, nil);
+        Check(writes == 1, @"a duplicate transport callback cannot mutate twice");
+
+        // The accepted next-page object is published for the next background
+        // ASDK request, and background completions serialize with UI resets.
+        OnBackground(^{
+            [client overviewOfUserWithUsername:nil pagination:nextPage completion:native];
+            client.lastCompletion(@[], [NSObject new], nil);
+        });
+        Check(writes == 1, @"background delivery waits for main");
+        DrainMainQueue();
+        Check(writes == 2, @"normal pagination continues after account replacement");
+
+        batch.fetching = YES;
+        [client overviewOfUserWithUsername:nil pagination:profile.pagination completion:native];
+        obsolete = client.lastCompletion;
+        [profile refreshControlActivatedWithSender:nil];
+        obsolete(@[@"pre-refresh"], [NSObject new], nil);
+        Check(writes == 2 && !batch.fetching, @"pull to refresh retires old pages and releases fetching");
+
+        // Error payloads and an empty end-of-list result retain their native
+        // semantics. The guard does not turn errors into synthetic successes.
+        [client overviewOfUserWithUsername:nil pagination:profile.pagination completion:native];
+        NSError *error = [NSError errorWithDomain:@"Test" code:1 userInfo:nil];
+        client.lastCompletion(nil, nil, error);
+        Check(writes == 3 && receivedError == error, @"current native error is preserved");
+        [client overviewOfUserWithUsername:nil pagination:profile.pagination completion:native];
+        client.lastCompletion(nil, nil, nil);
+        Check(writes == 4 && receivedItems == nil && profile.pagination == nil, @"end-of-list nil result is preserved");
+
+        // Sign out can leave the old RDKPagination ivar unchanged. Epoch
+        // invalidation still prevents an outstanding success from resurfacing.
+        [profile refreshControlActivatedWithSender:nil];
+        [client overviewOfUserWithUsername:nil pagination:profile.pagination completion:native];
+        obsolete = client.lastCompletion;
+        profile.accountChangeReplacesPagination = NO;
+        [profile redditAccountChangedWithNotification:nil];
+        obsolete(@[@"signed out"], [NSObject new], nil);
+        Check(writes == 4, @"sign out rejects the old generation even when pagination is unchanged");
+
+        // A pushed other-user profile does not reload for every account-change
+        // notification; leave its request and ASDK context running in that case.
+        _TtC6Apollo21ProfileViewController *other = Profile();
+        __block NSUInteger otherCalls = 0;
+        [client overviewOfUserWithUsername:nil pagination:other.pagination completion:^(NSArray *a, id p, NSError *e) {
+            (void)a; (void)p; (void)e; otherCalls++;
+        }];
+        current = client.lastCompletion;
+        [other redditAccountChangedWithNotification:nil];
+        current(@[], nil, nil);
+        Check(otherCalls == 1, @"unaffected pushed profiles retain their request");
+
+        // Completing the native batch may start a background request before
+        // the outer native completion returns. The next object must already be
+        // discoverable, not merely published after the completion finishes.
+        _TtC6Apollo21ProfileViewController *racing = Profile();
+        __block TestOverviewCompletion following;
+        __block NSUInteger followingCalls = 0;
+        id proposed = [NSObject new];
+        [client overviewOfUserWithUsername:nil pagination:racing.pagination completion:^(NSArray *a, id p, NSError *e) {
+            (void)a; (void)e;
+            racing.pagination = p;
+            OnBackground(^{
+                [client overviewOfUserWithUsername:nil pagination:p completion:^(NSArray *a2, id p2, NSError *e2) {
+                    (void)a2; (void)p2; (void)e2; followingCalls++;
+                }];
+                following = client.lastCompletion;
+            });
+        }];
+        client.lastCompletion(@[], proposed, nil);
+        [racing refreshControlActivatedWithSender:nil];
+        following(@[@"stale immediately scheduled page"], nil, nil);
+        Check(followingCalls == 0, @"page scheduled during native completion was guarded before refresh");
+
+        // A reentrant refresh inside a valid native completion owns the new
+        // generation. Post-callback publication must not resurrect the old one.
+        __block TestOverviewCompletion afterNestedReset;
+        [client overviewOfUserWithUsername:nil pagination:racing.pagination completion:^(NSArray *a, id p, NSError *e) {
+            (void)a; (void)e;
+            racing.pagination = p;
+            [racing refreshControlActivatedWithSender:nil];
+            [client overviewOfUserWithUsername:nil pagination:racing.pagination completion:^(NSArray *a2, id p2, NSError *e2) {
+                (void)a2; (void)p2; (void)e2; followingCalls++;
+            }];
+            afterNestedReset = client.lastCompletion;
+        }];
+        client.lastCompletion(@[], [NSObject new], nil);
+        afterNestedReset(@[], nil, nil);
+        Check(followingCalls == 1, @"nested reset remains current after its outer callback returns");
+
+        // Some native reloads do not traverse the refresh-control selector.
+        // A new pagination object at the next first-page request is still a
+        // reset boundary, and cannot leave an old batch fetching indefinitely.
+        racing.tableNode.view.batchContext.fetching = YES;
+        [client overviewOfUserWithUsername:nil pagination:racing.pagination completion:^(NSArray *a, id p, NSError *e) {
+            (void)a; (void)p; (void)e; followingCalls++;
+        }];
+        obsolete = client.lastCompletion;
+        racing.pagination = [NSObject new];
+        [client overviewOfUserWithUsername:nil pagination:racing.pagination completion:^(NSArray *a, id p, NSError *e) {
+            (void)a; (void)p; (void)e; followingCalls++;
+        }];
+        Check(!racing.tableNode.view.batchContext.fetching, @"native first-page replacement releases the prior batch");
+        obsolete(@[], nil, nil);
+        Check(followingCalls == 1, @"implicit native reset rejects the preceding load");
+        client.lastCompletion(@[], nil, nil);
+        Check(followingCalls == 2, @"implicit native reset accepts its replacement load");
+
+        // Unknown pagination belongs to some other RDK consumer, so even the
+        // completion block identity and execution queue are preserved.
+        TestOverviewCompletion unrelated = ^(NSArray *a, id p, NSError *e) { (void)a; (void)p; (void)e; };
+        [client overviewOfUserWithUsername:nil pagination:[NSObject new] completion:unrelated];
+        Check(client.lastCompletion == unrelated, @"non-profile overview consumers pass through unchanged");
+        printf("PASS: %lu profile pagination checks\n", (unsigned long)checks);
+    }
+    return 0;
+}

--- a/tests/run_executable_sdk_tests.sh
+++ b/tests/run_executable_sdk_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-executable-sdk.XXXXXX")
+trap 'rm -rf -- "$test_build_dir"' EXIT HUP INT TERM
+
+python3 - "$test_repo_root/src/ApolloCommon.m" "$test_build_dir/ExecutableSDKSelection.inc" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text()
+begin = source.index('static const char *ApolloNativeExecutableImageName(void)')
+end = source.index('// Both the selected Apollo variant', begin)
+Path(sys.argv[2]).write_text(source[begin:end])
+PY
+
+xcrun --sdk macosx clang -fobjc-arc -fblocks -Wall -Wextra -Werror \
+    -fsanitize=address,undefined -framework Foundation \
+    -I "$test_repo_root/src" -I "$test_build_dir" \
+    "$test_repo_root/tests/executable_sdk_tests.m" -o "$test_build_dir/executable_sdk_tests"
+"$test_build_dir/executable_sdk_tests"

--- a/tests/run_find_in_comments_hook_tests.sh
+++ b/tests/run_find_in_comments_hook_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_logos=${LOGOS:-${THEOS:-$HOME/theos}/bin/logos.pl}
+if [ ! -f "$test_logos" ]; then
+    printf 'Logos not found at %s; set THEOS or LOGOS.\n' "$test_logos" >&2
+    exit 1
+fi
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-find-in-comments.XXXXXX")
+trap 'rm -rf -- "$test_build_dir"' EXIT HUP INT TERM
+
+# Compile the actual production installer and hook with both generators. Only
+# their UIKit-independent section is extracted; no hand-maintained hook copy.
+python3 - "$test_repo_root" "$test_build_dir" <<'PY'
+from pathlib import Path
+import sys
+
+root, output = map(Path, sys.argv[1:])
+source = (root / 'src/ApolloFindInComments.xm').read_text()
+state_start = source.index('static BOOL sFICMultiActive')
+state_end = source.index('// MARK: - helpers', state_start)
+hook_start = source.index('// MARK: - hooks: multi-term matching')
+hook_end = source.index('// MARK: - hooks: selection entry points', hook_start)
+prefix = '#import <Foundation/Foundation.h>\n#import <objc/runtime.h>\n#import <objc/message.h>\n'
+test_source = prefix + source[state_start:state_end] + source[hook_start:hook_end]
+test_source += '\n' + (root / 'tests/find_in_comments_hook_tests.m').read_text()
+(output / 'FindInCommentsHook.xm').write_text(test_source)
+(output / 'substrate.h').write_text(
+    '#import <objc/runtime.h>\n'
+    'void MSHookMessageEx(Class, SEL, IMP, IMP *);\n')
+PY
+
+for test_generator in MobileSubstrate internal; do
+    test_substrate=0
+    if [ "$test_generator" = MobileSubstrate ]; then test_substrate=1; fi
+    perl "$test_logos" -c "generator=$test_generator" \
+        "$test_build_dir/FindInCommentsHook.xm" > "$test_build_dir/FindInCommentsHook.mm"
+    xcrun --sdk macosx clang++ -fobjc-arc -fblocks -Wall -Wextra -Werror \
+        -DFIC_TEST_SUBSTRATE="$test_substrate" -framework Foundation \
+        -I "$test_build_dir" "$test_build_dir/FindInCommentsHook.mm" \
+        -o "$test_build_dir/find_in_comments_hook_tests"
+    "$test_build_dir/find_in_comments_hook_tests"
+done

--- a/tests/run_multireddit_expansion_tests.sh
+++ b/tests/run_multireddit_expansion_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_logos=${LOGOS:-${THEOS:-$HOME/theos}/bin/logos.pl}
+if [ ! -f "$test_logos" ]; then
+    printf 'Logos not found at %s; set THEOS or LOGOS.\n' "$test_logos" >&2
+    exit 1
+fi
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-multireddit-expansion.XXXXXX")
+trap 'rm -rf -- "$test_build_dir"' EXIT HUP INT TERM
+
+# Execute the shipping scope helper AND the complete six UITableView hook
+# bodies. Only the unrelated Following-map helpers and UIKit are doubled.
+python3 - "$test_repo_root" "$test_build_dir" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root, output = map(Path, sys.argv[1:])
+source = (root / 'src/ApolloFollowingSection.xm').read_text()
+group = source.split('%group ApolloFollowingTable', 1)[1].split('%end // group ApolloFollowingTable', 1)[0]
+names = ('reloadData', 'beginUpdates', 'endUpdates', 'insertRowsAtIndexPaths',
+         'deleteRowsAtIndexPaths', 'reloadRowsAtIndexPaths')
+methods = []
+for name in names:
+    start = re.search(r'^- \(void\)' + name + r'(?=[: {])', group, re.M)
+    if start is None:
+        raise SystemExit(f'Missing production table hook: {name}')
+    # Every method's closing brace is at column zero; nested blocks are indented.
+    end = group.index('\n}', start.start()) + 2
+    methods.append(group[start.start():end])
+hooks = '%group ExpansionTableTests\n%hook UITableView\n' + '\n\n'.join(methods)
+hooks += '\n%end\n%end\n%ctor { %init(ExpansionTableTests); }\n'
+test = (root / 'tests/multireddit_expansion_tests.m').read_text()
+(output / 'MultiredditExpansion.xm').write_text(test.replace('// INCLUDE_PRODUCTION_TABLE_HOOKS', hooks))
+PY
+
+perl "$test_logos" -c generator=internal "$test_build_dir/MultiredditExpansion.xm" > "$test_build_dir/MultiredditExpansion.mm"
+xcrun --sdk macosx clang++ -fobjc-arc -fblocks -Wall -Wextra -Werror \
+    -fsanitize=address,undefined -framework Foundation \
+    -I "$test_repo_root/src" "$test_build_dir/MultiredditExpansion.mm" \
+    -o "$test_build_dir/multireddit_expansion_tests"
+"$test_build_dir/multireddit_expansion_tests"

--- a/tests/run_notification_backend_tests.sh
+++ b/tests/run_notification_backend_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-notification-backend-tests.XXXXXX")
+test_binary="$test_build_dir/notification_backend_tests"
+trap 'rm -f -- "$test_binary"; rmdir -- "$test_build_dir"' EXIT HUP INT TERM
+
+xcrun --sdk macosx clang -fobjc-arc -fblocks -Wall -Wextra -Werror -O2 \
+    -framework Foundation -DAPOLLO_NOTIFICATION_BACKEND_TESTING \
+    -I "$test_repo_root/src" \
+    "$test_repo_root/src/ApolloNotificationBackend.m" \
+    "$test_repo_root/tests/notification_backend_tests.m" \
+    -o "$test_binary"
+"$test_binary"

--- a/tests/run_profile_pagination_tests.sh
+++ b/tests/run_profile_pagination_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+test_repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_logos=${LOGOS:-${THEOS:-$HOME/theos}/bin/logos.pl}
+if [ ! -f "$test_logos" ]; then
+    printf 'Logos not found at %s; set THEOS or LOGOS.\n' "$test_logos" >&2
+    exit 1
+fi
+test_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/apollo-profile-pagination.XXXXXX")
+trap 'rm -rf -- "$test_build_dir"' EXIT HUP INT TERM
+
+# Exercise the shipping hooks and completion guard with Foundation-only UIKit,
+# RDK and ASBatchContext doubles. No copied implementation of the guard.
+python3 - "$test_repo_root" "$test_build_dir" <<'PY'
+from pathlib import Path
+import sys
+root, output = map(Path, sys.argv[1:])
+source = (root / 'src/ApolloProfilePagination.xm').read_text()
+test = (root / 'tests/profile_pagination_tests.m').read_text()
+source = source[source.index('typedef void (^ApolloProfileOverviewCompletion)'):]
+(output / 'ProfilePagination.xm').write_text(test.replace('// INCLUDE_PRODUCTION_GUARD', source))
+PY
+
+perl "$test_logos" -c generator=internal "$test_build_dir/ProfilePagination.xm" > "$test_build_dir/ProfilePagination.mm"
+xcrun --sdk macosx clang++ -fobjc-arc -fblocks -Wall -Wextra -Werror \
+    -framework Foundation "$test_build_dir/ProfilePagination.mm" -o "$test_build_dir/profile_pagination_tests"
+"$test_build_dir/profile_pagination_tests"


### PR DESCRIPTION
## Summary 

This PR addresses several crash risks found in the recent reports:

* #1083 — Startup: prevent a crash while Find in Comments starts on TrollStore/ElleKit installations.
* #980 — Notifications: keep background requests from using settings that have already been replaced.
* #1064 — Profile loading: ignore outdated responses after an account switch or refresh, preventing them from disrupting the profile list.
* #1084, #1085, #1086, #1088 — LiveContainer: prevent classic Apollo builds from accidentally enabling Liquid Glass features. This compatibility bug is fixed, but its connection to these crashes still needs confirmation.
* #1091 - Multireddit expansion: prevent a crash when expanding or collapsing a multireddit changes more rows than Apollo expects. Refresh the list after the change, including when sections have been reordered.

For #1031, the menu changes already included in 3.7.0 passed repeated opening and closing tests. This PR adds no further menu changes.

Validation passed: 108 automated checks, 12,000 simulated notification requests, simulator and device builds, and navigation checks in the simulator.

The affected TrollStore and LiveContainer setups still need testing before all eight reports can be closed.