### PR TITLE
Fix comment jump button in 3.7.0

### DIFF
--- a/src/ApolloSearchNativeBar.xm
+++ b/src/ApolloSearchNativeBar.xm
@@ -1347,6 +1347,76 @@ static void NSBViewWillDisappear(UIViewController *vc) {
 
 %end
 
+// MARK: - Comment jump lookup (#1092 / #1093)
+//
+// Apollo 1.15.11's current-comment helper (0x10070ec10) probes its table at
+// (0, bounds.origin.y + contentInset.top + 1). Both the tap handler
+// (0x100726594) and long-press handler (0x10070f1b0) call it synchronously.
+// Native search moves the chrome into adjustedContentInset, so that probe
+// lands ABOVE the visible parent and repeatedly selects the same destination.
+// Correct only that probe, keeping Apollo's tree traversal and animation.
+// Never alter the table's actual insets or offset to influence the lookup.
+// Thread-local, save/restored scope prevents unrelated tables, nested actions,
+// and Texture background work from inheriting the correction.
+static __thread void *sNSBCommentJumpTable;
+
+static void *NSBCommentJumpTableForController(UIViewController *vc) {
+    if (!NSThread.isMainThread || !ApolloNativeFeedSearchEnabled() ||
+        !NSBIsNativeSearchCommentsVC(vc)) return NULL;
+    UIScrollView *table = NSBTableForVC(vc);
+    if (!table || objc_getAssociatedObject(table, kNSBFeedTableKey) == nil) return NULL;
+    return (__bridge void *)table;
+}
+
+// MARK: - Comment jump handlers
+%hook _TtC6Apollo22CommentsViewController
+
+- (void)commentJumpButtonTappedWithSender:(id)sender {
+    void *previous = sNSBCommentJumpTable;
+    sNSBCommentJumpTable = NSBCommentJumpTableForController((UIViewController *)self);
+    @try {
+        %orig(sender);
+    } @finally {
+        sNSBCommentJumpTable = previous;
+    }
+}
+
+- (void)commentJumpButtonLongPressedWithSender:(id)sender {
+    void *previous = sNSBCommentJumpTable;
+    sNSBCommentJumpTable = NSBCommentJumpTableForController((UIViewController *)self);
+    @try {
+        %orig(sender);
+    } @finally {
+        sNSBCommentJumpTable = previous;
+    }
+}
+
+%end
+
+// MARK: - Comment jump probe
+%hook ASTableView
+
+- (NSIndexPath *)indexPathForRowAtPoint:(CGPoint)point {
+    if (sNSBCommentJumpTable == (__bridge void *)self) {
+        UIScrollView *table = (UIScrollView *)self;
+        CGFloat nativeY = table.bounds.origin.y + table.contentInset.top + 1.0;
+        if (point.x == 0.0 && fabs(point.y - nativeY) < 0.01) {
+            CGFloat correctedY = table.bounds.origin.y + table.adjustedContentInset.top + 1.0;
+            // Consume the probe before entering UIKit/Texture: any reentrant
+            // geometry lookup must see the real point it was passed.
+            sNSBCommentJumpTable = NULL;
+            if (NSBTraceEnabled()) {
+                ApolloLog(@"[NativeSearch] comment jump probe %.1f -> %.1f", point.y, correctedY);
+            }
+            point.y = correctedY;
+        }
+    }
+    return %orig(point);
+}
+
+%end
+// MARK: - End comment jump lookup
+
 // CommentsViewController does not implement viewWillDisappear: itself and
 // other modules hook it on the subclass. With the runtime's own dispatch a
 // subclass hook of an inherited method captures the superclass IMP at install

--- a/tests/comment_jump_tests.m
+++ b/tests/comment_jump_tests.m
@@ -1,0 +1,173 @@
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <objc/runtime.h>
+#import <math.h>
+
+typedef struct { CGFloat top, left, bottom, right; } UIEdgeInsets;
+@interface UIScrollView : NSObject
+@property CGRect bounds;
+@property UIEdgeInsets contentInset;
+@property UIEdgeInsets adjustedContentInset;
+@end
+@implementation UIScrollView
+@end
+@interface ASTableView : UIScrollView
+@property CGFloat rowHeight;
+@property CGPoint lastProbe;
+- (NSIndexPath *)indexPathForRowAtPoint:(CGPoint)point;
+@end
+@implementation ASTableView
+- (NSIndexPath *)indexPathForRowAtPoint:(CGPoint)point {
+    self.lastProbe = point;
+    if (point.y < 0) return nil;
+    return [NSIndexPath indexPathWithIndex:(NSUInteger)floor(point.y / self.rowHeight)];
+}
+@end
+@interface UIViewController : NSObject
+@property ASTableView *table;
+@property BOOL eligible;
+@end
+@implementation UIViewController
+@end
+@interface _TtC6Apollo22CommentsViewController : UIViewController
+@property void (^duringJump)(void);
+@property BOOL failJump;
+@property NSInteger destination;
+- (void)commentJumpButtonTappedWithSender:(id)sender;
+- (void)commentJumpButtonLongPressedWithSender:(id)sender;
+@end
+@implementation _TtC6Apollo22CommentsViewController
+- (void)jump:(NSInteger)direction {
+    if (self.duringJump) self.duringJump();
+    if (self.failJump) [NSException raise:@"JumpTest" format:@"test cleanup"];
+    // Model the recovered native probe and UIKit's adjusted-inset landing.
+    CGPoint probe = CGPointMake(0, self.table.bounds.origin.y + self.table.contentInset.top + 1);
+    NSIndexPath *path = [self.table indexPathForRowAtPoint:probe];
+    NSInteger current = path ? (NSInteger)[path indexAtPosition:0] : 0;
+    self.destination = MAX(1, current + direction);
+    CGRect bounds = self.table.bounds;
+    bounds.origin.y = self.destination * self.table.rowHeight - self.table.adjustedContentInset.top;
+    self.table.bounds = bounds;
+}
+- (void)commentJumpButtonTappedWithSender:(id)sender { (void)sender; [self jump:1]; }
+- (void)commentJumpButtonLongPressedWithSender:(id)sender { (void)sender; [self jump:-1]; }
+@end
+static BOOL enabled = YES;
+static char managedKey;
+static const void *kNSBFeedTableKey = &managedKey;
+static BOOL ApolloNativeFeedSearchEnabled(void) { return enabled; }
+static BOOL NSBIsNativeSearchCommentsVC(UIViewController *vc) { return vc.eligible; }
+static UIScrollView *NSBTableForVC(UIViewController *vc) { return vc.table; }
+static BOOL NSBTraceEnabled(void) { return NO; }
+#define ApolloLog(...) do {} while (0)
+
+// PRODUCTION_HOOKS
+
+void MSHookMessageEx(Class cls, SEL selector, IMP replacement, IMP *original) {
+    Method method = class_getInstanceMethod(cls, selector);
+    *original = method_getImplementation(method);
+    class_replaceMethod(cls, selector, replacement, method_getTypeEncoding(method));
+}
+static int checks;
+static void Check(BOOL result, NSString *message) {
+    checks++;
+    if (!result) { fprintf(stderr, "FAIL: %s\n", message.UTF8String); exit(1); }
+}
+static _TtC6Apollo22CommentsViewController *Fixture(CGFloat height, CGFloat inset) {
+    _TtC6Apollo22CommentsViewController *vc = [_TtC6Apollo22CommentsViewController new];
+    vc.eligible = YES;
+    vc.table = [ASTableView new];
+    vc.table.rowHeight = height;
+    vc.table.bounds = CGRectMake(0, -inset, 400, 800);
+    vc.table.adjustedContentInset = (UIEdgeInsets){inset, 0, 34, 0};
+    objc_setAssociatedObject(vc.table, kNSBFeedTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return vc;
+}
+int main(void) {
+    @autoreleasepool {
+        InstallJumpHooks();
+        for (NSNumber *height in @[@32, @80, @300]) {
+            for (NSNumber *inset in @[@0, @62, @106, @176]) {
+                _TtC6Apollo22CommentsViewController *vc = Fixture(height.doubleValue, inset.doubleValue);
+                for (NSInteger parent = 1; parent <= 8; parent++) {
+                    [vc commentJumpButtonTappedWithSender:nil];
+                    Check(vc.destination == parent, @"repeated taps advance without manual scrolling");
+                    Check(vc.table.contentInset.top == 0, @"raw insets remain untouched");
+                }
+                for (NSInteger parent = 7; parent >= 1; parent--) {
+                    [vc commentJumpButtonLongPressedWithSender:nil];
+                    Check(vc.destination == parent, @"long press returns to previous parent");
+                }
+                CGPoint point = CGPointMake(0, vc.table.bounds.origin.y + 1);
+                [vc.table indexPathForRowAtPoint:point];
+                Check(CGPointEqualToPoint(vc.table.lastProbe, point), @"ordinary lookup outside handler is untouched");
+            }
+        }
+        _TtC6Apollo22CommentsViewController *vc = Fixture(80, 106);
+        enabled = NO;
+        [vc commentJumpButtonTappedWithSender:nil];
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.destination == 1, @"unpatched calculation reproduces stuck first jump");
+        enabled = YES;
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.destination == 2, @"correction advances from reproduced failure");
+        vc.table.adjustedContentInset = (UIEdgeInsets){176, 0, 34, 0};
+        vc.table.bounds = CGRectMake(0, 160 - 176, 400, 800);
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.destination == 3, @"uses current inset after search bar expands");
+        ASTableView *other = Fixture(80, 106).table;
+        vc.duringJump = ^{
+            CGPoint unrelated = CGPointMake(0, other.bounds.origin.y + 1);
+            [other indexPathForRowAtPoint:unrelated];
+            Check(CGPointEqualToPoint(other.lastProbe, unrelated), @"other table inside handler is untouched");
+        };
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.destination == 4, @"other-table lookup does not consume scope");
+        vc.duringJump = nil;
+        vc.failJump = YES;
+        @try { [vc commentJumpButtonTappedWithSender:nil]; } @catch (NSException *exception) { (void)exception; }
+        Check(sNSBCommentJumpTable == NULL, @"exception restores scope");
+        vc.failJump = NO;
+        _TtC6Apollo22CommentsViewController *nested = Fixture(32, 176);
+        vc.duringJump = ^{ [nested commentJumpButtonTappedWithSender:nil]; };
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.destination == 5 && nested.destination == 1, @"nested jump restores outer table scope");
+        vc.duringJump = nil;
+        vc.eligible = NO;
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.table.lastProbe.y == 5 * 80 - 176 + 1, @"pane/preview eligibility bypasses correction");
+        vc.eligible = YES;
+        objc_setAssociatedObject(vc.table, kNSBFeedTableKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        CGFloat before = vc.table.bounds.origin.y + 1;
+        [vc commentJumpButtonTappedWithSender:nil];
+        Check(vc.table.lastProbe.y == before, @"unmanaged table bypasses correction");
+        _TtC6Apollo22CommentsViewController *residual = Fixture(80, 140);
+        residual.table.contentInset = (UIEdgeInsets){24, 0, 0, 0};
+        for (NSInteger parent = 1; parent <= 3; parent++) {
+            [residual commentJumpButtonTappedWithSender:nil];
+            Check(residual.destination == parent, @"nonzero raw inset is replaced, not added twice");
+        }
+        ASTableView *sameTable = residual.table;
+        residual.duringJump = ^{
+            CGPoint p = CGPointMake(12, sameTable.bounds.origin.y + sameTable.contentInset.top + 1);
+            [sameTable indexPathForRowAtPoint:p];
+            Check(CGPointEqualToPoint(sameTable.lastProbe, p), @"other x coordinate is untouched");
+            p = CGPointMake(0, p.y + 20);
+            [sameTable indexPathForRowAtPoint:p];
+            Check(CGPointEqualToPoint(sameTable.lastProbe, p), @"other y coordinate is untouched");
+        };
+        [residual commentJumpButtonTappedWithSender:nil];
+        Check(residual.destination == 4, @"unrelated lookups do not consume current-comment probe");
+        residual.duringJump = nil;
+        dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+        __block BOOL backgroundScoped = YES;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+            backgroundScoped = NSBCommentJumpTableForController(residual) != NULL;
+            dispatch_semaphore_signal(finished);
+        });
+        dispatch_semaphore_wait(finished, DISPATCH_TIME_FOREVER);
+        Check(!backgroundScoped, @"background work never enters jump scope");
+        printf("PASS: %d comment jump checks\n", checks);
+    }
+    return 0;
+}

--- a/tests/run_comment_jump_tests.sh
+++ b/tests/run_comment_jump_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+jump_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+jump_logos=${LOGOS:-${THEOS:-$HOME/theos}/bin/logos.pl}
+jump_build=$(mktemp -d "${TMPDIR:-/tmp}/apollo-comment-jump.XXXXXX")
+trap 'rm -rf "$jump_build"' EXIT HUP INT TERM
+python3 - "$jump_root" "$jump_build" <<'PY'
+from pathlib import Path
+import sys
+root, build = map(Path, sys.argv[1:])
+source = (root / 'src/ApolloSearchNativeBar.xm').read_text()
+start = source.index('// MARK: - Comment jump lookup')
+end = source.index('// MARK: - End comment jump lookup', start)
+hooks = source[start:end] + '\nstatic void InstallJumpHooks(void) {\n%init;\n}\n'
+fixture = (root / 'tests/comment_jump_tests.m').read_text()
+(build / 'Jump.xm').write_text(fixture.replace('// PRODUCTION_HOOKS', hooks))
+(build / 'substrate.h').write_text('#import <objc/runtime.h>\nvoid MSHookMessageEx(Class, SEL, IMP, IMP *);\n')
+PY
+for jump_generator in internal MobileSubstrate; do
+    perl "$jump_logos" -c "generator=$jump_generator" "$jump_build/Jump.xm" > "$jump_build/Jump.mm"
+    xcrun --sdk macosx clang++ -fobjc-arc -fblocks -Wall -Wextra -Werror \
+        -framework Foundation -framework CoreGraphics -I "$jump_build" \
+        "$jump_build/Jump.mm" -o "$jump_build/jump-tests"
+    "$jump_build/jump-tests"
+done


### PR DESCRIPTION
## Summary

In 3.7.0, the comment jump button could jump to the first parent comment and then stop advancing. Users had to manually scroll past the current comment before the button would work again. This was especially noticeable with short comments.

The button now advances on consecutive taps without requiring manual scrolling. Long-pressing to jump backward also uses the corrected position.

## Cause and fix

The new native Find in Comments search bar changed how the space above the comment list is calculated. Apollo’s jump-button logic still used the old calculation, causing it to look above the visible comment and repeatedly select the same destination.

This change accounts for the full top inset when identifying the current comment. Apollo continues to handle parent-comment selection and scrolling animations.

## Validation

- Reproduced the first-jump stall in unpatched 3.7.0 on an iOS 27 simulator.
- Verified consecutive jumps through short parent comments and backward jumps with the fix.
- Passed 304 regression checks with each of the two hook generators.
- Device-target compilation succeeded; full device packaging was blocked by unrelated Translation and FoundationModels linking errors.

Fixes #1092.
Fixes #1093.
Fixes #1096.