### PR TITLE
Liquid Glass: keep a failed node bitmap from terminating the app during a display burst (fixes #1097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+- Keep Liquid Glass builds from crashing when AsyncDisplayKit cannot create a node's bitmap, seen when tapping the Posts tab to return to the top of a long Popular feed; the node is left blank instead (#1097: @icpryde)
+
 ## [v3.7.0] - 2026-09-11
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloShareLinks.xm \
     $(SRC_DIR)/ApolloSafariDarkLoading.xm \
     $(SRC_DIR)/ApolloMedia.xm \
+    $(SRC_DIR)/ApolloAsyncDisplayGuard.xm \
     $(SRC_DIR)/ApolloFeedGalleryCarousel.xm \
     $(SRC_DIR)/ApolloSwipeUpComments.xm \
     $(SRC_DIR)/ApolloMediaMetadata.m \

--- a/src/ApolloAsyncDisplayGuard.h
+++ b/src/ApolloAsyncDisplayGuard.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+// Pixel budget above which ApolloAsyncDisplayGuard refuses to start a node
+// display (see ApolloAsyncDisplayGuard.xm). Test seam for the simulator debug
+// bridge: pass 0 to restore the default.
+void ApolloAsyncDisplayGuardSetMaxPixelsForTesting(double maxPixels);
+double ApolloAsyncDisplayGuardMaxPixels(void);

--- a/src/ApolloAsyncDisplayGuard.xm
+++ b/src/ApolloAsyncDisplayGuard.xm
@@ -1,0 +1,117 @@
+// Keeps AsyncDisplayKit's background display pass from taking the process down
+// when a node's bitmap cannot be created (#1097).
+//
+// Every drawRect-based node (ASTextNode, Apollo's own nodes) and every
+// ASImageNode renders through ASGraphicsCreateImage, which in Apollo's Texture
+// build still goes through the legacy UIGraphicsBeginImageContextWithOptions.
+// When CGBitmapContextCreate fails in there, UIKit's reaction depends on the
+// SDK the executable was linked against (UIGraphics.m:410, gated on
+// dyld_program_sdk_at_least): older link targets get no context and a blank
+// node, newer ones hit an NSAssert that raises NSInternalInconsistencyException
+// ("UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size=...
+// Use UIGraphicsImageRenderer to avoid this assert."). The Liquid Glass IPA
+// relinks Apollo against the iOS 26 SDK, so on glass builds that assert fires,
+// on a display-queue thread where nothing catches it, and the process is
+// terminated.
+//
+// The tweak already catches this for ASImageNode contents
+// (+[ASImageNode createContentsForkey:...] in ApolloMedia.xm). This module
+// extends the same protection to the display block every other node kind runs,
+// and additionally refuses to start a display whose bitmap would be absurdly
+// large. #1097 (3.6.0 glass, iOS 26.6.1) died with the assert on one display
+// thread while the main thread aborted inside CA::Render::Encoder::grow while
+// encoding a layer's image contents: both are what a node whose bounds have
+// blown up to a gigabyte-class bitmap looks like, and a bitmap that size can
+// never be shown anyway. Skipping it costs one blank node instead of the app.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <math.h>
+
+#import "ApolloAsyncDisplayGuard.h"
+#import "ApolloCommon.h"
+#import "ApolloTextureDecls.h"
+
+@interface ASDisplayNode (ApolloAsyncDisplayGuard)
+- (CGRect)bounds;
+- (CGFloat)contentsScaleForDisplay;
+@end
+
+// 64 million pixels is about 256 MB of RGBA: an 8000 x 8000 px square, or on
+// a 3x phone a column about 17,000 pt tall (Reddit's 40,000 character selftext
+// limit lays out to roughly 10,000 pt). Nothing Apollo shows comes close.
+static const double kApolloDisplayGuardDefaultMaxPixels = 64.0 * 1000.0 * 1000.0;
+static double sApolloDisplayGuardMaxPixels = kApolloDisplayGuardDefaultMaxPixels;
+
+double ApolloAsyncDisplayGuardMaxPixels(void) {
+    return sApolloDisplayGuardMaxPixels;
+}
+
+void ApolloAsyncDisplayGuardSetMaxPixelsForTesting(double maxPixels) {
+    sApolloDisplayGuardMaxPixels = maxPixels > 0 ? maxPixels : kApolloDisplayGuardDefaultMaxPixels;
+    ApolloLog(@"[AsyncDisplayGuard] max pixels now %.0f", sApolloDisplayGuardMaxPixels);
+}
+
+typedef id (^ApolloAsyncDisplayBlock)(void);
+
+// One log line per node class and reason per launch: a runaway layout re-runs
+// display for the same node on every frame, and the display queue is hot.
+static BOOL ApolloDisplayGuardShouldLog(NSString *key) {
+    static NSMutableSet<NSString *> *logged;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ logged = [NSMutableSet set]; });
+    @synchronized (logged) {
+        if ([logged containsObject:key]) return NO;
+        [logged addObject:key];
+        return YES;
+    }
+}
+
+%hook ASDisplayNode
+
+// Called on the main thread once per display pass; the returned block runs on
+// a display-queue thread (or inline for synchronous display).
+- (id)_displayBlockWithAsynchronous:(BOOL)asynchronous isCancelledBlock:(id)isCancelledBlock rasterizing:(BOOL)rasterizing {
+    ApolloAsyncDisplayBlock block = %orig;
+    if (!block) return nil;
+
+    // The same bounds and scale ASDK just captured for the block.
+    CGRect bounds = [self bounds];
+    CGFloat scale = [self respondsToSelector:@selector(contentsScaleForDisplay)] ? [self contentsScaleForDisplay] : 0;
+    if (!(scale > 0) || !isfinite(scale)) scale = UIScreen.mainScreen.scale;
+    double width = bounds.size.width;
+    double height = bounds.size.height;
+    double pixels = width * scale * height * scale;
+    BOOL finite = isfinite(width) && isfinite(height) && isfinite(pixels);
+    Class nodeClass = [self class];
+
+    if (!finite || pixels > sApolloDisplayGuardMaxPixels) {
+        NSString *className = NSStringFromClass(nodeClass) ?: @"(unknown)";
+        if (ApolloDisplayGuardShouldLog([@"skip:" stringByAppendingString:className])) {
+            ApolloLog(@"[AsyncDisplayGuard] skipped display of %@ bounds=%@ scale=%.1f (%.0f MP%@)",
+                      className, NSStringFromCGRect(bounds), scale, pixels / 1e6,
+                      finite ? @"" : @", non-finite");
+        }
+        return ^id{ return nil; };
+    }
+
+    return ^id{
+        @try {
+            return block();
+        } @catch (NSException *exception) {
+            NSString *className = NSStringFromClass(nodeClass) ?: @"(unknown)";
+            if (ApolloDisplayGuardShouldLog([@"throw:" stringByAppendingString:className])) {
+                ApolloLog(@"[AsyncDisplayGuard] display of %@ raised %@: %@ (node left blank)",
+                          className, exception.name ?: @"(nil)", exception.reason ?: @"(nil)");
+            }
+            return nil;
+        }
+    };
+}
+
+%end
+
+%ctor {
+    %init;
+    ApolloLog(@"[AsyncDisplayGuard] module loaded (max %.0f MP)", sApolloDisplayGuardMaxPixels / 1e6);
+}

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -16,6 +16,7 @@
 #if APOLLO_SIM_BUILD
 
 #import "ApolloAccountCredentials.h"
+#import "ApolloAsyncDisplayGuard.h"
 #import "ApolloChatRoomDirectory.h"
 #import "ApolloCommentVoteInsights.h"
 #import "ApolloCommon.h"
@@ -25,6 +26,7 @@
 #import "ApolloGalleryImageLoader.h"
 #import "ApolloWebTextDecoding.h"
 #import "ApolloState.h"
+#import "ApolloTextureDecls.h"
 #import "UserDefaultConstants.h"
 #import "UIWindow+Apollo.h"
 
@@ -650,11 +652,74 @@ static void ApolloSimInstallLowPowerModeOverride(void) {
     ApolloLog(@"[SimDebugTap] lpm override installed on %@", NSStringFromClass(cls));
 }
 
+@interface ASDisplayNode (ApolloSimDebugDisplayGuard)
+- (void)setBounds:(CGRect)bounds;
+- (CALayer *)layer;
+- (void)displayImmediately;
+@end
+
+// "bitmapassert" command: push UIKit's legacy image context with a size
+// CGBitmapContextCreate rejects, so the SDK-gated assert behind #1097 can be
+// observed directly. A glass shell (Apollo relinked against the iOS 26 SDK)
+// raises NSInternalInconsistencyException; a classic shell pushes no context
+// and raises nothing.
+static void ApolloSimDebugBitmapAssert(void) {
+    @try {
+        UIGraphicsBeginImageContextWithOptions(CGSizeZero, NO, 0);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        ApolloLog(@"[SimDebugTap] bitmapassert: no exception, context %@", context ? @"pushed" : @"absent");
+        if (context) UIGraphicsEndImageContext();
+    } @catch (NSException *exception) {
+        ApolloLog(@"[SimDebugTap] bitmapassert: raised %@: %@", exception.name, exception.reason);
+    }
+}
+
+// "displayguard W H [capMP]" command: synchronously display a throwaway
+// ASTextNode with W x H pt bounds through the same
+// _displayBlockWithAsynchronous: path the display queue uses, optionally
+// lowering ApolloAsyncDisplayGuard's pixel budget to capMP megapixels first
+// (restored afterwards), and log whether the guard skipped the display, caught
+// UIKit's assert, or the node rendered.
+static void ApolloSimDebugDisplayGuardTest(NSString *payload) {
+    NSMutableArray<NSString *> *numbers = [NSMutableArray array];
+    for (NSString *part in [payload componentsSeparatedByCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet]) {
+        if (part.length > 0) [numbers addObject:part];
+    }
+    if (numbers.count < 2) { ApolloLog(@"[SimDebugTap] malformed displayguard: %@", payload); return; }
+    double width = numbers[0].doubleValue;
+    double height = numbers[1].doubleValue;
+    double capPixels = numbers.count >= 3 ? numbers[2].doubleValue * 1e6 : 0;
+    ApolloAsyncDisplayGuardSetMaxPixelsForTesting(capPixels);
+
+    ASTextNode *node = [[objc_getClass("ASTextNode") alloc] init];
+    node.attributedText = [[NSAttributedString alloc] initWithString:@"display guard test"
+                                                          attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:17]}];
+    [node setBounds:CGRectMake(0, 0, width, height)];
+    CALayer *layer = [node layer];
+    ApolloLog(@"[SimDebugTap] displayguard: displaying ASTextNode %.0fx%.0f pt (cap %.0f MP)",
+              width, height, ApolloAsyncDisplayGuardMaxPixels() / 1e6);
+    @try {
+        [node displayImmediately];
+        ApolloLog(@"[SimDebugTap] displayguard: returned, contents %@", layer.contents ? @"set" : @"nil");
+    } @catch (NSException *exception) {
+        ApolloLog(@"[SimDebugTap] displayguard: exception ESCAPED the guard, %@: %@", exception.name, exception.reason);
+    }
+    ApolloAsyncDisplayGuardSetMaxPixelsForTesting(0);
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *contents = [NSString stringWithContentsOfFile:ApolloSimTapFile()
                                                        encoding:NSUTF8StringEncoding error:nil];
+        if ([contents hasPrefix:@"bitmapassert"]) {
+            ApolloSimDebugBitmapAssert();
+            return;
+        }
+        if ([contents hasPrefix:@"displayguard "]) {
+            ApolloSimDebugDisplayGuardTest([contents substringFromIndex:13]);
+            return;
+        }
         if ([contents hasPrefix:@"insetbottom "]) {
             ApolloSimDebugForceBottomInset([[contents substringFromIndex:12] doubleValue]);
             return;


### PR DESCRIPTION
Fixes #1097

## What happened

Reporter (3.6.0 **Liquid Glass**, iOS 26.6.1, iPhone Air) tapped the Posts tab to scroll a long Popular feed back to the top and the app died a moment into the animation. The `apollo-reborn-crash.json` has two threads going down at once, and neither has an ApolloReborn frame on its path:

- **Thread 0 (the reported crash, `EXC_CRASH` / abort):** `CA::Transaction::commit` → `CA::Context::commit_transaction` → `CA::Layer::commit_if_needed` ×22 → `CA::Render::encode_set_object` → `CA::Render::Layer::encode` → `CA::Render::Image::encode` → `CA::Render::Encoder::encode_data_async` → **`CA::Render::Encoder::grow` + 423 → `abort()`**. Symbolicated against the iOS 26.6.1 (23G83, iPhone18,4) shared cache; `grow`'s only two `abort` paths are "Encoder size overflow" and a failed `mmap` of the doubled buffer. So the main thread was copying a layer's image contents to the render server and the image was gigabyte-class.
- **Thread 28 (a display-queue thread, mid-terminate):** `-[ASDisplayNode(AsyncDisplay) _displayBlockWithAsynchronous:isCancelledBlock:rasterizing:]_block_invoke.5` → `ASGraphicsCreateImage` → **`_UIGraphicsBeginImageContextWithOptions` + 579** → `-[NSAssertionHandler handleFailureInFunction:…]` → `objc_exception_throw` → `__cxa_throw` → `failed_throw` (no handler on that thread) → `std::terminate` → KSCrash's terminate hook → `_objc_terminate` → `__handleUncaughtException`, still formatting the "First throw call stack" when thread 0 aborted. That is UIKit's `UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size=…` assert (UIGraphics.m:410) from `CGBitmapContextCreate` returning NULL.

Two things make this a glass-only, tweak-side problem rather than a stock one:

1. In the iOS 26.1 UIKitCore decompile, `_UIGraphicsBeginImageContextWithOptions` only raises when **`dyld_program_sdk_at_least`** says the executable was linked against a new enough SDK; older link targets push no context and draw nothing. The Liquid Glass patch relinks Apollo against the iOS 26 SDK, so the whole process flips to the throwing behaviour. Confirmed in the sim with a new `bitmapassert` bridge probe: glass shell (sdk 19.0) → `raised NSInternalInconsistencyException: UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 0}, scale=3.000000, bitmapInfo=0x2002…`; the same probe on the vtool-downgraded non-glass shell (sdk 16.0) → `no exception, context absent`.
2. Apollo's Texture build (`AsyncDisplayKit` UUID `99E7085F…`, same as the report) doesn't enable the `UIGraphicsImageRenderer` path in `ASGraphicsCreateImage` (the `ASExperimentalDrawingGlobal` once-token), so every drawRect node (ASTextNode and Apollo's own nodes) and every ASImageNode goes through the legacy API. The tweak already wraps the ASImageNode side (`+[ASImageNode createContentsForkey:…]` in `ApolloMedia.xm`, from dankrichtofen's glass tweak); the generic display block that all the other node kinds run had no guard, and that is the frame thread 28 threw from. The block only reaches the assert with a non-empty size: `_displayBlockWithAsynchronous:` returns nil for `CGRectIsEmpty(bounds)` (checked in the binary at `+0x49708`), so the failing bitmap was huge or non-finite, which also fits the encoder abort on thread 0.

## The fix

`src/ApolloAsyncDisplayGuard.xm` hooks `-[ASDisplayNode _displayBlockWithAsynchronous:isCancelledBlock:rasterizing:]` (main-thread, once per display pass) and returns a wrapper around ASDK's block:

- **Refuses to start a display whose bitmap would be absurd:** non-finite bounds, or more than 64 million pixels (about 256 MB RGBA; an 8000×8000 px square, or on a 3x phone a column about 17,000 pt tall, well past what a 40,000-character selftext lays out to). The node is left blank and one line is logged per class: `[AsyncDisplayGuard] skipped display of <class> bounds=… scale=… (N MP)`. A bitmap that size could not have been shown anyway, and it is what took the main-thread encoder down in #1097.
- **Catches anything the block raises** and returns nil (contents cleared, same outcome as the existing ASImageNode guard): `[AsyncDisplayGuard] display of <class> raised <name>: <reason> (node left blank)`, once per class.
- Everything under the cap runs ASDK's block unchanged; the hook itself only reads `bounds` and `contentsScaleForDisplay` (both lock-protected getters) and does one multiplication. No toggle: it is a crash guard.

`ApolloSimDebugTap.xm` (sim-only) gains `bitmapassert` (observe the SDK-gated assert directly) and `displayguard W H [capMP]` (display a throwaway ASTextNode with the given bounds through the real `_displayBlockWithAsynchronous:` path, optionally lowering or lifting the pixel budget for the call). `ApolloAsyncDisplayGuard.h` exposes the budget setter that command uses.

## Verification

- **Glass sim** (Apollo-Sim, iOS 26.5, shell sdk 19.0, API-key account), same dylib throughout:
  - `displayguard 60000 60000` → `skipped display of ASTextNode bounds={{0, 0}, {60000, 60000}} scale=3.0 (32400 MP)` → `contents nil`, process alive.
  - `displayguard 1000000000000 300 1000000000000` (budget lifted so the block runs) → `display of ASTextNode raised NSInternalInconsistencyException: UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={1000000000000, 300}, scale=3.000000, bitmapInfo=0x2002… (node left blank)` → `contents nil`, process alive. That is UIKit's real assert, thrown from the same `ASGraphicsCreateImage` frame as the report, caught by the wrapper.
  - `displayguard 300 100` → `contents set` (normal render unchanged).
  - Reporter's scenario: r/popular, `scrollto` to the bottom repeatedly until the table held 185k pt, then 276k pt of posts (load-more each time), tap the Posts tab (`hit=_UITabButton`) → Apollo's animated scroll-to-top, feed at the top, same PID, zero `[AsyncDisplayGuard]` lines from real content. The giant node itself does not reproduce here (nor for me on device), so the guard is the protection; the natural path is untouched.
- **Non-glass sim** (same device, shell vtool-downgraded to sdk 16.0): `bitmapassert` → `no exception, context absent` (proves the SDK gate); r/popular scrolled to 182k pt, Posts tab (`hit=UITabBarButton`) → top of feed, same PID, no guard lines.
- **Modes:** API-key account throughout. Keyless not separately run: the change is inside Texture's display pass and never touches networking or session state. Cancelled swipe-back: n/a, no navigation or per-controller state is added. iPad: code-reading only; per-node, no window or trait assumptions.
- **Launch log lines:** `[AsyncDisplayGuard] module loaded (max 64 MP)`; verified the running process mapped this build (`lsof`), not a stale staged copy.
- **Hooked selector verified** against the AsyncDisplayKit Mach-O the report was running (UUID `99E7085F-15A8-3644-8CE0-B54F3395E506`): `-[ASDisplayNode(AsyncDisplay) _displayBlockWithAsynchronous:isCancelledBlock:rasterizing:]` at `0x495c4`; `ASGraphicsCreateImage` at `0x5e970` calls `_UIGraphicsBeginImageContextWithOptions` at `+0xd4` (return `+0xd8`, the report's frame). No other module hooks that selector. System frames symbolicated with `ipsw` against the 23G83 iPhone18,4 cache; ApolloReborn frames with the 3.6.0 rootful dSYM (UUID `CF1C1D66…`).
- `make package` (device, pinned iOS 26.0 SDK) → `packages/com.apollo.reborn_3.7.0-1+debug_iphoneos-arm.deb`; sim build with the internal Logos generator; `git diff --check` clean. Branch is on current `apollo-reborn/main` (2427e2b) and merges cleanly with the open PRs that touch `Makefile` or `ApolloSimDebugTap.xm` (#1089, #1080, #1079, #1060; #1062's conflict is with main itself in `CustomAPIViewController.m`, not this branch).
- **Not run:** a device pass. Worth doing before merge since memory is involved: a long Popular session on a glass build with lots of image posts, Posts tab from deep in the feed a few times, and a memory-warning (`simulate memory warning` isn't available on device, so just a long session). If the reporter can grab the matching `.ips` from Settings → Privacy & Security → Analytics Data, the exception reason there carries the bitmap `size={…}` our sanitizer strips, which would name the node that blew up.
