### PR TITLE
Prepare 3.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [v3.7.1] - 2026-09-??
+## [v3.7.1] - 2026-09-13
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v3.7.1] - 2026-09-??
+
+### Features
+
+- Add **Hide Header on Scroll** (Interface → Tab Bar) so the Liquid Glass navigation bar follows the tab bar as it hides and reappears, in both Two-Gesture and Classic scroll modes (#1079: @IllIIllIllIllII)
+  - Hide Bars on Scroll, Hide Style, Hide Header on Scroll, and Scroll Behavior are separate controls now, and Hide Style, Scroll Behavior, and Header Style pick from native glass menus that show the current choice in the row
+  - Gallery View honors the selected Header Style while scrolling and after the bars come back, instead of leaving an opaque strip under the navigation controls
+
 ### Fixes
 
-- Keep Liquid Glass builds from crashing when AsyncDisplayKit cannot create a node's bitmap, seen when tapping the Posts tab to return to the top of a long Popular feed; the node is left blank instead (#1097: @icpryde)
+- Fix **swipe navigation** feeling sluggish since 3.7.0 — pages settle with Apollo's original easing again after you lift your finger, on back, forward, and cancelled swipes (#1073: @IllIIllIllIllII)
+- Fix the **comment jump button** stalling on the first parent comment since 3.7.0 — consecutive taps advance again without scrolling past the current comment first, and long-press to jump back uses the corrected position (#1094: @IllIIllIllIllII)
+- Fix posts opened from **Community Highlights**, deep links, Recently Read, Floating Post Tabs, and other `apollo://` routes ignoring the subreddit's suggested sort and your Remember Post Sort and Remember Subreddit Sort choices — they now open on the same comment sort a feed tap would (#1102: @icpryde)
+- Fix several **crashes**: opening 3.7.0 on TrollStore and other ElleKit installs, a profile page still loading when you switch accounts or refresh, expanding or collapsing a multireddit in the subreddit list, and the notification fetcher reading settings that had just been replaced (#1089: @IllIIllIllIllII)
+  - Classic (non-glass) builds running under LiveContainer no longer mistake themselves for Liquid Glass builds, the suspected cause of crashes opening search, settings, posts, and subreddits there
+- Keep **Liquid Glass** builds from crashing when a feed element's bitmap can't be created, seen when tapping the Posts tab to return to the top of a long Popular feed; the element is left blank instead (#1099: @icpryde)
+- Fix **Keep in Floating Tab** and the other Apollo Reborn rows in the legacy ⋯ sheet crashing the app when a third-party menu tweak such as Translomatic is installed (#1076: @icpryde)
+- Fix **videos going quiet** after rotating the phone with the fullscreen viewer open, and stop a second video under the viewer from starting its own audio (#1080: @icpryde)
+- Fix **Add to Multireddit** reporting "Error adding to multireddit" even though the subreddit was added, and the multireddit's subtitle lagging until the next refresh (#1081: @icpryde)
+- Keep the Liquid Glass action pill **expanded by default** again — collapsing it into the ⋯ is now the opt-in **Collapse Navigation Actions** switch (Interface → Display & Navigation), and **Center Title Between Buttons** is back for the expanded layout (#1105: @IllIIllIllIllII)
+  - Titles stay centered unless the expanded actions need the room, the pill no longer flashes when the subreddit picker opens or closes, and a startup recursion on the always-expanded path is fixed
+- Restore **Hidden** as a **Header Style** option on Liquid Glass — it removes the top scroll-edge effect without adding a blur, and existing Hidden preferences and backups work again (#1074: @IllIIllIllIllII)
+- Fix the Liquid Glass tab bar popping open and snapping back on iOS 27 when a **Two-Gesture** reveal starts with the Left or Right hide style (#1078: @IllIIllIllIllII)
+- Show the **+N new-comment count** on Community Highlights again after a refresh (#1098: @IllIIllIllIllII)
 
 ## [v3.7.0] - 2026-09-11
 
@@ -859,6 +880,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v3.7.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.7.0...v1.15.11_3.7.1
 [v3.7.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.6.0...v1.15.11_3.7.0
 [v3.6.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.5.1...v1.15.11_3.6.0
 [v3.5.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.5.0...v1.15.11_3.5.1

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.apollo.reborn
 Name: Apollo-Reborn
-Version: 3.7.0
+Version: 3.7.1
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: Apollo Reborn team

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -12,7 +12,7 @@
   },
   "app": {
     "bundleIdentifier": "com.christianselig.Apollo",
-    "buildVersion": "297",
+    "buildVersion": "298",
     "developerName": "Christian Selig (& Apollo-Reborn contributors)",
     "iconURL": "https://apolloreborn.app/assets/icon.png",
     "tintColor": "#F0542D",

--- a/whats-new/generated/ApolloWhatsNewCatalog.gen.m
+++ b/whats-new/generated/ApolloWhatsNewCatalog.gen.m
@@ -18,6 +18,7 @@ static const ApolloWhatsNewReleaseEntry kWhatsNewReleases[] = {
     { "3.5.1", "What's New in Apollo Reborn" },
     { "3.6.0", "What's New in Apollo Reborn" },
     { "3.7.0", "What's New in Apollo Reborn" },
+    { "3.7.1", "What's New in Apollo Reborn" },
 };
 
 static const ApolloWhatsNewItemEntry kWhatsNewItems[] = {
@@ -48,6 +49,12 @@ static const ApolloWhatsNewItemEntry kWhatsNewItems[] = {
     { "3.7.0", "text.bubble.fill", "Smarter Highlights", "Unread dots, New badges, and +N counts show which Community Highlights you haven't read or that picked up comments." },
     { "3.7.0", "apps.iphone", "Widgets for Any Feed", "Point the Feed and Post widgets at Home, Popular, All, several subreddits, or a multireddit." },
     { "3.7.0", "checkmark.shield.fill", "Stability & Fixes", "Fixes for freezes, GIF memory crashes, launch crashes, duplicate saved items, and translation going quiet." },
+    { "3.7.1", "arrow.left.and.right.circle.fill", "Snappier Swipes", "Swipe navigation settles with Apollo's original easing again after you lift your finger." },
+    { "3.7.1", "arrow.down.circle.fill", "Comments Fixes", "The jump button advances on every tap again, and posts opened from highlights or links respect the subreddit's suggested sort." },
+    { "3.7.1", "checkmark.shield.fill", "Crash Fixes", "Fixes for launch crashes on TrollStore, profile switching, multireddit expansion, LiveContainer, and a Liquid Glass display crash." },
+    { "3.7.1", "ellipsis.circle.fill", "Pill Stays Expanded", "The Liquid Glass action pill stays expanded again; turn on Collapse Navigation Actions if you preferred the collapsing one." },
+    { "3.7.1", "menubar.rectangle", "Hide Header on Scroll", "Let the navigation bar follow the tab bar as it hides, and pick Hidden as a Header Style again." },
+    { "3.7.1", "speaker.wave.2.fill", "Media & Menu Fixes", "Videos stay audible after rotating, adding to a multireddit no longer reports an error, and the \342\213\257 sheet gets along with other tweaks." },
 };
 
 static NSString *S(const char *value) { return [NSString stringWithUTF8String:value]; }

--- a/whats-new/releases/3.7.1.json
+++ b/whats-new/releases/3.7.1.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "version": "3.7.1",
+  "headline": "What's New in Apollo Reborn",
+  "items": [
+    { "icon": "arrow.left.and.right.circle.fill", "title": "Snappier Swipes", "subtitle": "Swipe navigation settles with Apollo's original easing again after you lift your finger." },
+    { "icon": "arrow.down.circle.fill", "title": "Comments Fixes", "subtitle": "The jump button advances on every tap again, and posts opened from highlights or links respect the subreddit's suggested sort." },
+    { "icon": "checkmark.shield.fill", "title": "Crash Fixes", "subtitle": "Fixes for launch crashes on TrollStore, profile switching, multireddit expansion, LiveContainer, and a Liquid Glass display crash." },
+    { "icon": "ellipsis.circle.fill", "title": "Pill Stays Expanded", "subtitle": "The Liquid Glass action pill stays expanded again; turn on Collapse Navigation Actions if you preferred the collapsing one." },
+    { "icon": "menubar.rectangle", "title": "Hide Header on Scroll", "subtitle": "Let the navigation bar follow the tab bar as it hides, and pick Hidden as a Header Style again." },
+    { "icon": "speaker.wave.2.fill", "title": "Media & Menu Fixes", "subtitle": "Videos stay audible after rotating, adding to a multireddit no longer reports an error, and the ⋯ sheet gets along with other tweaks." }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares the Apollo-Reborn 3.7.1 release metadata and user-facing release content.

- bumps the tweak version from 3.7.0 to 3.7.1
- increments the IPA build number from 297 to 298
- moves the 13 user-facing PRs merged since `v1.15.11_3.7.0` into a new 3.7.1 changelog section
- adds a six-highlight What's New sheet and regenerates its catalog
- regenerates the README contributor block (no additions needed)

## Why a patch bump

3.7.0 → 3.7.1 rather than 3.8.0. Fourteen PRs landed since the tag and almost all of them fix 3.7.0 regressions or crashes: sluggish swipe navigation (#1073), the comment jump button stalling (#1094), the launch crash on TrollStore/ElleKit plus the profile, multireddit, notification and LiveContainer crashes (#1089), the Liquid Glass display-burst abort (#1099), the Translomatic action-sheet crash (#1076), the Two-Gesture reveal snap (#1078), the missing +N highlight counts (#1098), the Add to Multireddit error (#1081), the muted-after-rotate video (#1080), the wrong comment sort on URL-scheme opens (#1102), and the action-pill flash and title placement (#1105, which also puts the pill back to always-expanded by default with collapsing as an opt-in). The only new option is Hide Header on Scroll (#1079), a narrowly scoped toggle next to an existing one, and Hidden as a Header Style (#1074) is a restore.

## Release scope

Everything in the 3.7.1 section is already merged into `main` — the boundary is the last published non-prerelease tag, `v1.15.11_3.7.0` (2026-09-11). The branch was cut from `d6da25b` and rebased onto current `main` (`762bbce`), which brought the two PRs merged on 2026-09-13: #1105 and #1102 — both are in the section now. Nothing open was assumed into scope.

Every PR in the window was inspected (body + file list + diff), not just its title. One merged PR is deliberately omitted from the changelog as non-user-facing:

- #1069 (@ryannair05) — drops redundant `copy` calls and switches a few properties to `copy` semantics; no observable change. It is included in the release (it is on `main` below the tag point), just not in the notes.

The `## [Unreleased]` bullet for #1097 that #1099 wrote on main moved into the release section and now cites the PR number instead of the issue.

Eight PRs are still open against `main` — four ready (#1060, #1062, #1075, #1077) and four drafts (#875, #973, #1048, #1053). None are tracked in `## [Unreleased]`, which is left empty; whichever of them land before publishing should be added at that point. Worth re-auditing right before tagging.

## What's New highlights

Curated rather than a mirror of the changelog — six highlights, all regression-facing so people who hit the 3.7.0 problems see them called out once after updating:

- Snappier Swipes
- Comments Fixes (jump button + URL-open sort)
- Crash Fixes
- Pill Stays Expanded (#1105's default change, so nobody thinks the collapsing pill broke)
- Hide Header on Scroll
- Media & Menu Fixes

Every SF Symbol was checked against the system symbol database (`CoreGlyphs.bundle/name_availability.plist`) for availability at the tweak's **iOS 14.0 deployment floor**; all six resolve at iOS 13.0–14.0 (`arrow.left.and.right.circle.fill`, `arrow.down.circle.fill`, `checkmark.shield.fill`, `ellipsis.circle.fill`, `menubar.rectangle`, `speaker.wave.2.fill`).

If a patch release shouldn't interrupt people with a sheet at all, delete `whats-new/releases/3.7.1.json` and regenerate the catalog — a version with no catalog entry intentionally shows nothing.

## Contributors

The GitHub contributors API shows no commit author since 3.7.0 who isn't already in `contributors.json` — @icpryde, @IllIIllIllIllII and @ryannair05 are all credited. The README block was regenerated from the unchanged `contributors.json`.

Maintainers unchanged: JeffreyCA, icpryde, jordanearle, nickclyde, DeltAndy123, IllIIllIllIllII.

## Verification

This PR changes release metadata and generated data tables only — no hooks, no runtime code — so most of the usual gate doesn't apply. What was run:

- Branch rebased onto `apollo-reborn/main` at `762bbce` (clean, the release files don't overlap #1102/#1105); `git diff --check` clean
- `python3 whats-new/scripts/generate_catalog.py whats-new/releases whats-new/generated/ApolloWhatsNewCatalog.gen.h whats-new/generated/ApolloWhatsNewCatalog.gen.m` — "generated 5 what's new releases" (the 3.7.1 entry now has six rows)
- `APOLLO_VERSION=1.15.11 TWEAK_VERSION=3.7.1 python3 scripts/generate_release_notes.py` — prints exactly the 3.7.1 section, no `## [Unreleased]` bleed; the 13 cited PR numbers match the merged set minus #1069
- `python3 -m json.tool contributors.json`; README contributor block regenerated from `contributors.json`
- SF Symbol availability checked against `CoreGlyphs.bundle/name_availability.plist` (see above)
- Simulator build (`make TARGET=simulator:clang:latest:15.0 … APOLLO_SIM_BUILD=1`) compiles the regenerated `ApolloWhatsNewCatalog.gen.m`; the sim launch logs 78 `hook installed` / `hooks initialized` lines under the `tweak v3.7.1` banner
- Device `make package` with the pinned iOS 26.0 SDK on the rebased head: OK, `packages/com.apollo.reborn_3.7.1-3+debug_iphoneos-arm.deb` (the `-3` is theos' local debug revision counter)
- No open PR touches `CHANGELOG.md`, `control`, `distribution/config.json`, `contributors.json`, `README.md`, or `whats-new/`, so this merges cleanly regardless of which of them lands first
- Not run: Hopper checks (no hooked selectors changed), the modes matrix and device scenarios (no behaviour changed), iPad (not requested)

### What's New sheet, rendered

Built and launched on a fresh Liquid Glass shell in the iOS 26.5 simulator (new device `Apollo-Rel371`, empty container), `[WhatsNew] Presented What's New for 3.7.1` confirmed in the `apollofix` log, launch banner reads `tweak v3.7.1` (only this branch can emit it), and the staged dylib's strings are identical to this worktree's build:

- header reads `Version 3.7.1`
- all six SF Symbols resolve — no `[WhatsNew] Symbol '…' unavailable` fallback line was logged for any row (the sheet builds every row into a stack view up front, so the below-the-fold row is covered too)
- three rows wrap in full above the fold, the fourth (Pill Stays Expanded) peeks under the bottom fade, and the last two need a scroll — one row more below the fold than the 3.7.0 sheet had
- re-presented after the #1102/#1105 update by relaunching with `-LastSeenWhatsNewVersion 3.7.0` on the rebuilt dylib: `Presented What's New for 3.7.1`, the two new rows render, no fallback-symbol line
- gating: relaunching with `-LastSeenWhatsNewVersion 3.7.1` produces no `Presented` line, and relaunching with `-LastSeenWhatsNewVersion 3.7.0` presents it again, so the marker short-circuits by version as intended

## Before release

- replace the changelog date placeholder `2026-09-??` with the intended release date
- re-audit open PRs immediately before tagging in case any of #1060, #1062, #1075, #1077 lands first, and add them to the release section
- decide whether a patch release should show the What's New sheet (see above)
