### PR TITLE
Comments: respect suggested, per-subreddit and per-post sort on URL-scheme post opens (Community Highlights, deep links)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloSettingsGeneralTable.xm \
     $(SRC_DIR)/settings/ApolloSettingsNativeInjections.xm \
     $(SRC_DIR)/ApolloPerPostCommentSort.xm \
+    $(SRC_DIR)/ApolloURLOpenCommentSort.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
     $(SRC_DIR)/ApolloNavigationActions.xm \
     $(SRC_DIR)/ApolloNavigationTitlePresentation.xm \

--- a/src/ApolloPerPostCommentSort.h
+++ b/src/ApolloPerPostCommentSort.h
@@ -1,0 +1,24 @@
+// Runtime helpers exported by ApolloPerPostCommentSort.xm.
+//
+// ApolloURLOpenCommentSort.xm applies Apollo's comment-sort chain (per-post memory on top)
+// to URL-scheme opens, where CommentsViewController's `link` is nil until the first fetch
+// returns. The ivar layout knowledge stays in ApolloPerPostCommentSort.xm; these are the
+// only entry points other modules use.
+
+#import <Foundation/Foundation.h>
+
+// `currentSort` on _TtC6Apollo22CommentsViewController (Optional<RDKCommentSortingMethod>:
+// Int64 raw at +0, is-nil byte at +8). Read returns NO for .none / unknown layout; write is
+// bounds-checked and returns NO instead of touching memory it cannot vouch for.
+BOOL ApolloCommentsVCReadCurrentSort(id vc, int64_t *outRaw);
+BOOL ApolloCommentsVCWriteCurrentSort(id vc, int64_t raw);
+
+// The `link` ivar (RDKLink *). nil on URL-scheme / inbox opens until the first fetch lands.
+id ApolloCommentsVCLink(id vc);
+
+// "Top" / "Best" / ... / "Live Update" for an RDKCommentSortingMethod raw; "?" otherwise.
+NSString *ApolloCommentSortName(int64_t raw);
+
+// Saved "Remember Post Sort" raw (1-7) for a bare post id, 0 when nothing is saved. Does
+// not consult the feature toggle; callers check sPerPostCommentSort themselves.
+int64_t ApolloPerPostCommentSortSavedSort(NSString *postID);

--- a/src/ApolloPerPostCommentSort.xm
+++ b/src/ApolloPerPostCommentSort.xm
@@ -41,9 +41,10 @@
 //   kicks the first fetch, which uses a non-nil currentSort AS-IS — so writing the ivar
 //   before %orig in viewDidLoad both overrides the init-time chain and feeds the first
 //   fetch AND the sort-button icon setup. On URL-scheme/inbox opens (init(linkID:...))
-//   the `link` ivar is nil until the first fetch returns; those opens keep native
-//   behavior (no id to look up yet), while recording still works because the user can
-//   only change sort after the load populates `link`.
+//   the `link` ivar is nil until the first fetch returns, so this write cannot look the
+//   post up; ApolloURLOpenCommentSort.xm covers those opens (it evaluates the same chain,
+//   per-post memory first, once the first response carries the link). Recording works
+//   either way because the user can only change sort after the load populates `link`.
 // - Every user sort pick funnels through sortBarButtonItemTappedWithSender: -> option
 //   closure -> currentSort ivar write -> reload via -[RDKClient
 //   linkAndCommentsForLinkWithIdentifier:commentSort:pagination:completion:] (bare post
@@ -71,6 +72,7 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "ApolloThemeRuntime.h"
+#import "ApolloPerPostCommentSort.h"
 #import "UserDefaultConstants.h"
 #import "settings/ApolloSettingsGeneralTable.h"
 
@@ -285,6 +287,17 @@ static void PPCSDisarm(void) {
 }
 
 %end
+
+// MARK: - exports (ApolloPerPostCommentSort.h)
+//
+// Thin wrappers so ApolloURLOpenCommentSort.xm can reuse the ivar-layout knowledge above
+// without a second copy of it.
+
+BOOL ApolloCommentsVCReadCurrentSort(id vc, int64_t *outRaw) { return PPCSReadCurrentSort(vc, outRaw); }
+BOOL ApolloCommentsVCWriteCurrentSort(id vc, int64_t raw) { return PPCSWriteCurrentSort(vc, raw); }
+id ApolloCommentsVCLink(id vc) { return PPCSObjectIvar(vc, "link"); }
+NSString *ApolloCommentSortName(int64_t raw) { return PPCSSortName(raw); }
+int64_t ApolloPerPostCommentSortSavedSort(NSString *postID) { return postID.length ? PPCSSavedSortForPost(postID) : 0; }
 
 // MARK: - Settings row (registered with ApolloSettingsGeneralTable)
 //

--- a/src/ApolloURLOpenCommentSort.xm
+++ b/src/ApolloURLOpenCommentSort.xm
@@ -1,0 +1,367 @@
+// Comment sort on URL-scheme post opens
+//
+// Report: "Subreddit default post sort not being respected" — a post whose subreddit sets its
+// suggested sort to New opens on New from the subreddit feed but on the user's Default Sort
+// from a Community Highlights card. (r/ApolloReborn, 1wd7fhf.)
+//
+// WHAT BREAKS (RE'd from the binary)
+// Apollo builds CommentsViewController two ways. A feed tap uses init(link:), which computes
+// the initial comment sort from the RDKLink it is handed:
+//     link.suggestedSort   (unless Settings > General > Comments > Ignore Suggested Sort)
+//       -> Remember Subreddit Sort's per-subreddit memory
+//       -> Default Sort
+// Every apollo:// open uses init(linkID:commentID:subreddit:context:...) instead — that is how
+// the Highlights carousel, Recently Read, Floating Tabs, AI-summary links, inbox/notification
+// taps and deep links from other apps all open posts. There is no RDKLink yet, so that init can
+// only choose the per-subreddit memory (when the URL carried a subreddit) or Default Sort, and
+// nothing revisits the choice once the post arrives: in the whole binary `suggestedSort` is
+// read by init(link:) and the sort menu only, never by loadComments() or its completion.
+// "Remember Post Sort" (ApolloPerPostCommentSort.xm) has the matching gap — its viewDidLoad
+// write needs `link` to look the post up — so it never applied to URL opens either.
+//
+// THE FIX
+// The first comments fetch of a link-less CommentsViewController is
+// -[RDKClient linkAndCommentsForLinkWithIdentifier:commentSort:pagination:completion:] with
+// the bare post id, issued synchronously from viewDidLoad. We wrap that completion. When the
+// response's link asks for a different sort than the one Apollo fetched with — evaluated with
+// the same chain init(link:) uses, per-post memory on top — we write currentSort, re-issue the
+// identical fetch with the corrected sort, and hand THAT response to Apollo's completion.
+// Apollo renders once, already on the right sort; the second round-trip only happens when the
+// two sorts differ. viewDidLoad already drew the nav-bar sort icon from the pre-fetch sort, so
+// we redraw it the way Apollo's own updater does (option-sort-<name> asset + "Sort by <name>"
+// accessibility label). If the corrected fetch fails, the first response is delivered as-is
+// and the sort is put back so the icon never disagrees with the list.
+//
+// Out of scope on purpose: comment-permalink opens (a specific comment with context) go
+// through -linkAndContext:forCommentWithIdentifier:linkIdentifier:commentSort:... and keep
+// Apollo's behavior — that screen is about one comment, not the thread's ordering.
+//
+// RE notes (Apollo 1.15.11):
+// - init(link:) = sub_100725044, init(linkID:...) = sub_100722458, loadComments = sub_100722d24
+//   (its "No sort set, setting to top" fallback runs BEFORE the fetch, so currentSort is always
+//   set by the time the RDKClient call is made), sort-icon updater = sub_1006feeb4.
+// - The RDKClient method wraps the caller's completion in a 2-argument block and calls it on
+//   the main queue: completion(@{ @"link": RDKLink, ... }, nil) on success, completion(nil,
+//   error) on failure (sub_100039680 / sub_100039788).
+// - RDKCommentSortingMethod raws: 1 Top, 2 Best, 3 New, 4 Q&A, 5 Controversial, 6 Old,
+//   7 Random, 8 Live Update; 9 is RDKLink.suggestedSort's "none". Live goes to the network
+//   as New, exactly as loadComments sends it.
+// - DefaultCommentsSort is a string ("top"/"best"/"new"/"qa"/"controversial"/"old"/"random",
+//   anything else = Top); RedditCommentsSortMapping is { lowercased subreddit: raw }.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+#import "ApolloPerPostCommentSort.h"
+#import "ApolloState.h"
+#import "ApolloSwiftRuntime.h"
+#import "UserDefaultConstants.h"
+
+@interface _TtC6Apollo22CommentsViewController : UIViewController
+@end
+
+@interface RDKClient : NSObject
+- (id)linkAndCommentsForLinkWithIdentifier:(id)identifier commentSort:(long long)sort pagination:(id)pagination completion:(id)completion;
+@end
+
+// Apollo's own Settings > General > Comments keys. Read here, never written.
+static NSString *const kUCSKeyIgnoreSuggestedSort = @"IgnoreSuggestedSort";
+static NSString *const kUCSKeyDefaultCommentsSort = @"DefaultCommentsSort";
+static NSString *const kUCSKeySubredditSortMapping = @"RedditCommentsSortMapping";
+
+enum : int64_t {
+    UCSSortTop = 1, UCSSortBest = 2, UCSSortNew = 3, UCSSortQA = 4, UCSSortControversial = 5,
+    UCSSortOld = 6, UCSSortRandom = 7, UCSSortLive = 8, UCSSortNone = 9,
+};
+
+static BOOL UCSIsRealSort(int64_t raw) { return raw >= UCSSortTop && raw <= UCSSortLive; }
+
+// MARK: - Apollo's sort chain, evaluated from the fetched link
+
+// Default Sort, the same way sub_100441058 reads it: a lowercase string, unknown/missing = Top.
+static int64_t UCSDefaultSortRaw(void) {
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kUCSKeyDefaultCommentsSort];
+    NSString *name = [value isKindOfClass:[NSString class]] ? value : nil;
+    if ([name isEqualToString:@"best"]) return UCSSortBest;
+    if ([name isEqualToString:@"new"]) return UCSSortNew;
+    if ([name isEqualToString:@"qa"]) return UCSSortQA;
+    if ([name isEqualToString:@"controversial"]) return UCSSortControversial;
+    if ([name isEqualToString:@"old"]) return UCSSortOld;
+    if ([name isEqualToString:@"random"]) return UCSSortRandom;
+    return UCSSortTop;
+}
+
+// Remember Subreddit Sort's memory for a subreddit (sub_10044395c): 0 when nothing is stored.
+static int64_t UCSRememberedSubredditSort(NSString *subreddit) {
+    if (subreddit.length == 0) return 0;
+    NSDictionary *map = [[NSUserDefaults standardUserDefaults] dictionaryForKey:kUCSKeySubredditSortMapping];
+    NSNumber *raw = [map isKindOfClass:[NSDictionary class]] ? map[subreddit.lowercaseString] : nil;
+    return [raw isKindOfClass:[NSNumber class]] ? raw.longLongValue : 0;
+}
+
+static NSString *UCSStringProperty(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) return nil;
+    id value = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
+// The sort init(link:) would have picked for this link, with "Remember Post Sort" on top the
+// way its pre-viewDidLoad write beats the chain on feed opens. `reason` names the winning rule.
+static int64_t UCSDesiredSort(id link, NSString *postID, NSString **reason) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (sPerPostCommentSort) {
+        int64_t saved = ApolloPerPostCommentSortSavedSort(postID);
+        if (saved >= UCSSortTop && saved <= UCSSortRandom) {   // Live is never stored
+            *reason = @"Remember Post Sort";
+            return saved;
+        }
+    }
+    if ([link respondsToSelector:@selector(suggestedSort)]) {
+        int64_t suggested = ((int64_t (*)(id, SEL))objc_msgSend)(link, @selector(suggestedSort));
+        if (UCSIsRealSort(suggested) && ![defaults boolForKey:kUCSKeyIgnoreSuggestedSort]) {
+            *reason = @"suggested sort";
+            return suggested;
+        }
+    }
+    if ([defaults boolForKey:UDKeyApolloRememberSubredditCommentsSort]) {
+        int64_t remembered = UCSRememberedSubredditSort(UCSStringProperty(link, @selector(subreddit)));
+        if (UCSIsRealSort(remembered)) {
+            *reason = @"Remember Subreddit Sort";
+            return remembered;
+        }
+    }
+    *reason = @"Default Sort";
+    return UCSDefaultSortRaw();
+}
+
+// MARK: - nav-bar sort icon (mirrors sub_1006feeb4)
+
+static NSString *UCSSortAssetName(int64_t raw) {
+    switch (raw) {
+        case UCSSortTop: return @"option-sort-top";
+        case UCSSortBest: return @"option-sort-best";
+        case UCSSortNew: return @"option-sort-new";
+        case UCSSortQA: return @"option-sort-qa";
+        case UCSSortControversial: return @"option-sort-controversial";
+        case UCSSortOld: return @"option-sort-old";
+        case UCSSortRandom: return @"option-sort-random";
+        case UCSSortLive: return @"option-sort-live";
+        default: return nil;
+    }
+}
+
+static NSString *UCSSortAccessibilityLabel(int64_t raw) {
+    switch (raw) {
+        case UCSSortTop: return @"Sort by top";
+        case UCSSortBest: return @"Sort by best";
+        case UCSSortNew: return @"Sort by new";
+        case UCSSortQA: return @"Sort by Q and A";
+        case UCSSortControversial: return @"Sort by controversial";
+        case UCSSortOld: return @"Sort by old";
+        case UCSSortRandom: return @"Sort by random";
+        case UCSSortLive: return @"Sort by live update";
+        default: return @"Sort by none";
+    }
+}
+
+// Apollo's updater sets the image + accessibility label and resets the alpha/transform/
+// animations its Live pulse leaves behind. We never start the pulse (a Live suggested sort is
+// as rare as it gets and the live timer only runs from the menu anyway), so a plain reset is
+// the whole job. Goes through UIButton's setter so the Liquid Glass item strip's re-templating
+// hook sees the change like it sees Apollo's own.
+static void UCSRedrawSortButton(id vc, int64_t raw) {
+    Ivar ivar = class_getInstanceVariable(object_getClass(vc), "sortBarButtonItem");
+    UIButton *button = ivar ? object_getIvar(vc, ivar) : nil;
+    if (![button isKindOfClass:[UIButton class]]) return;
+    NSString *asset = UCSSortAssetName(raw);
+    UIImage *image = asset ? [UIImage imageNamed:asset] : nil;
+    if (asset && !image) {
+        ApolloLog(@"[URLOpenSort] sort icon asset %@ missing; leaving the icon alone", asset);
+        return;
+    }
+    [button setImage:image forState:UIControlStateNormal];
+    button.accessibilityLabel = UCSSortAccessibilityLabel(raw);
+    button.alpha = 1.0;
+    button.transform = CGAffineTransformIdentity;
+    [button.layer removeAllAnimations];
+}
+
+// MARK: - completion plumbing
+
+// The RDKClient completion is a Swift closure bridged to an ObjC block. Read its signature
+// off the block descriptor so a shape we did not RE (a future 3-argument completion) makes us
+// step aside instead of calling it with too few arguments.
+struct UCSBlockDescriptor { unsigned long reserved; unsigned long size; void *rest[]; };
+struct UCSBlockLiteral { void *isa; int flags; int reserved; void *invoke; struct UCSBlockDescriptor *descriptor; };
+enum { UCSBlockHasCopyDispose = 1 << 25, UCSBlockHasSignature = 1 << 30 };
+
+static NSString *UCSBlockSignature(id block) {
+    struct UCSBlockLiteral *literal = (__bridge struct UCSBlockLiteral *)block;
+    if (!literal || !(literal->flags & UCSBlockHasSignature) || !literal->descriptor) return nil;
+    const char *types = (const char *)literal->descriptor->rest[(literal->flags & UCSBlockHasCopyDispose) ? 2 : 0];
+    return types ? @(types) : nil;
+}
+
+// YES for `void (^)(id, id)`. A block without a signature cannot be checked; the RE'd shape
+// is trusted then (both clang and Swift normally emit one).
+static BOOL UCSCompletionIsTwoObjectBlock(id block) {
+    NSString *signature = UCSBlockSignature(block);
+    if (!signature) return YES;
+    @try {
+        NSMethodSignature *ms = [NSMethodSignature signatureWithObjCTypes:signature.UTF8String];
+        return ms.numberOfArguments == 3
+            && [ms getArgumentTypeAtIndex:1][0] == '@'
+            && [ms getArgumentTypeAtIndex:2][0] == '@';
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+// The RDKLink out of a success result (@{ @"link": ..., ... }); nil for anything else.
+static id UCSLinkFromResult(id result) {
+    if (![result isKindOfClass:[NSDictionary class]]) return nil;
+    id link = ((NSDictionary *)result)[@"link"];
+    return [link respondsToSelector:@selector(suggestedSort)] ? link : nil;
+}
+
+// MARK: - hooks
+//
+// The arm: the link-less CommentsViewController whose first comments fetch we want to see,
+// keyed by its post id (the `linkID` Swift String ivar — the very identifier loadComments
+// hands RDKClient). viewDidLoad arms it; the RDKClient hook consumes it on the first
+// main-thread fetch for that id. Normally that fetch is issued synchronously inside
+// viewDidLoad. With "Remember Subreddit Sort" on and a URL that named no subreddit, Apollo
+// first resolves the post (linkWithFullName:) to learn its subreddit and only then fetches
+// the comments, so the arm has to survive that gap — keyed by id, a fetch for any other
+// post passes straight through. The arm is dropped when its VC disappears (popped before
+// its load, cancelled interactive pop), replaced by the next link-less viewDidLoad, and
+// touched on the main thread only. Two live CommentsViewControllers for the same post id,
+// one of them still waiting on that deferred fetch, is the one case the id cannot tell
+// apart; the VC we act on is always the armed one (weakly held), never the fetch's caller.
+
+static __weak id sUCSArmedVC = nil;
+static NSString *sUCSArmedPostID = nil;
+
+static void UCSDisarm(void) {
+    sUCSArmedVC = nil;
+    sUCSArmedPostID = nil;
+}
+
+// Bare post id ("1abcde"): loadComments passes the linkID ivar through as-is, but be
+// tolerant of a fullname in either place.
+static NSString *UCSBarePostID(NSString *identifier) {
+    return [identifier hasPrefix:@"t3_"] ? [identifier substringFromIndex:3] : identifier;
+}
+
+%hook _TtC6Apollo22CommentsViewController
+
+- (void)viewDidLoad {
+    if (!ApolloCommentsVCLink(self)) {   // URL-scheme / inbox open: no RDKLink until the first fetch returns
+        NSString *postID = UCSBarePostID(ApolloReadSwiftStringIvar(self, "linkID"));
+        NSString *commentID = ApolloReadSwiftStringIvar(self, "commentID");
+        if (commentID.length) {
+            // Comment permalink (context) open: loads through linkAndContext:..., which we
+            // leave alone — so no arm, nothing to linger.
+            ApolloLog(@"[URLOpenSort] %@: comment permalink open; leaving it to Apollo", postID ?: @"?");
+        } else if (postID.length) {
+            if (sUCSArmedPostID) ApolloLog(@"[URLOpenSort] replacing the arm for %@ (it never fetched)", sUCSArmedPostID);
+            sUCSArmedVC = self;
+            sUCSArmedPostID = [postID copy];
+        } else {
+            ApolloLog(@"[URLOpenSort] link-less open without a post id; leaving it to Apollo");
+        }
+    }
+    %orig;
+    if (sUCSArmedVC == self) ApolloLog(@"[URLOpenSort] %@: fetch deferred past viewDidLoad; arm kept", sUCSArmedPostID);
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    %orig;
+    if (sUCSArmedVC == self || !sUCSArmedVC) UCSDisarm();
+}
+
+%end
+
+%hook RDKClient
+
+- (id)linkAndCommentsForLinkWithIdentifier:(id)identifier commentSort:(long long)commentSort pagination:(id)pagination completion:(id)completion {
+    // Arm state lives on the main thread (viewDidLoad and the fetches loadComments issues);
+    // a fetch from any other thread can never be the one we are waiting for.
+    if (![NSThread isMainThread] || !sUCSArmedPostID) return %orig;
+    if (![identifier isKindOfClass:[NSString class]] ||
+        ![sUCSArmedPostID isEqualToString:UCSBarePostID(identifier)]) return %orig;   // another post's fetch; arm kept
+    id vc = sUCSArmedVC;
+    UCSDisarm();   // one shot
+    if (!vc || !completion) return %orig;
+    if (!UCSCompletionIsTwoObjectBlock(completion)) {
+        ApolloLog(@"[URLOpenSort] unexpected completion signature %@; leaving the fetch alone", UCSBlockSignature(completion));
+        return %orig;
+    }
+
+    int64_t preRaw = 0;
+    if (!ApolloCommentsVCReadCurrentSort(vc, &preRaw)) preRaw = commentSort;
+    NSString *postID = [identifier copy];
+    __weak id weakVC = vc;
+    RDKClient *client = self;
+    void (^original)(id, id) = [completion copy];
+    ApolloLog(@"[URLOpenSort] link-less open of %@ fetching on %@ (net %lld, block %@)",
+              postID, ApolloCommentSortName(preRaw), commentSort, UCSBlockSignature(completion) ?: @"unsigned");
+
+    void (^wrapped)(id, id) = ^(id result, id error) {
+        id strongVC = weakVC;
+        id link = UCSLinkFromResult(result);
+        if (error || !link || !strongVC) {
+            original(result, error);
+            return;
+        }
+        int64_t nowRaw = 0;
+        if (!ApolloCommentsVCReadCurrentSort(strongVC, &nowRaw) || nowRaw != preRaw) {
+            // The user picked a sort while the load was in flight; Apollo already re-fetched.
+            ApolloLog(@"[URLOpenSort] %@: sort changed to %@ while loading; not touching it", postID, ApolloCommentSortName(nowRaw));
+            original(result, error);
+            return;
+        }
+        NSString *reason = nil;
+        int64_t desired = UCSDesiredSort(link, postID, &reason);
+        if (desired == preRaw) {
+            ApolloLog(@"[URLOpenSort] %@: %@ already matches %@", postID, ApolloCommentSortName(preRaw), reason);
+            original(result, error);
+            return;
+        }
+        if (!ApolloCommentsVCWriteCurrentSort(strongVC, desired)) {
+            ApolloLog(@"[URLOpenSort] %@: could not write currentSort; leaving %@", postID, ApolloCommentSortName(preRaw));
+            original(result, error);
+            return;
+        }
+        UCSRedrawSortButton(strongVC, desired);
+        long long netSort = desired == UCSSortLive ? UCSSortNew : desired;
+        ApolloLog(@"[URLOpenSort] %@: %@ -> %@ (%@), refetching", postID,
+                  ApolloCommentSortName(preRaw), ApolloCommentSortName(desired), reason);
+        [client linkAndCommentsForLinkWithIdentifier:postID commentSort:netSort pagination:pagination completion:^(id result2, id error2) {
+            if (error2 || !UCSLinkFromResult(result2)) {
+                // Corrected fetch failed: show the first response, and put the sort back so the
+                // icon and menu describe the comments that are actually on screen.
+                id vc2 = weakVC;
+                if (vc2 && ApolloCommentsVCWriteCurrentSort(vc2, preRaw)) UCSRedrawSortButton(vc2, preRaw);
+                ApolloLog(@"[URLOpenSort] %@: refetch on %@ failed (%@); showing the %@ response",
+                          postID, ApolloCommentSortName(desired), [error2 isKindOfClass:[NSError class]] ? ((NSError *)error2).localizedDescription : @"no link",
+                          ApolloCommentSortName(preRaw));
+                original(result, error);
+                return;
+            }
+            ApolloLog(@"[URLOpenSort] %@: delivered %@ comments", postID, ApolloCommentSortName(desired));
+            original(result2, error2);
+        }];
+    };
+    return %orig(identifier, commentSort, pagination, (id)wrapped);
+}
+
+%end
+
+%ctor {
+    %init;
+    ApolloLog(@"[URLOpenSort] ctor: hooks installed (CommentsViewController.viewDidLoad, RDKClient.linkAndCommentsForLinkWithIdentifier:commentSort:pagination:completion:)");
+}


### PR DESCRIPTION
Fixes #1082. Same report on r/ApolloReborn: https://www.reddit.com/r/ApolloReborn/comments/1wd7fhf/subreddit_default_post_sort_not_being_respected/

Fixes the sort a post opens on when it is reached through a URL rather than a feed tap: Community Highlights cards, deep links, Recently Read, Floating Post Tabs, AI summary links, and any other `apollo://` route.

## What was happening

Apollo builds `CommentsViewController` two ways. A feed tap uses `init(link:)`, which picks the initial comment sort from the post it is handed: the post's suggested sort (unless "Ignore Suggested Sort"), then "Remember Subreddit Sort", then "Default Sort". Every `apollo://` open uses `init(linkID:commentID:subreddit:…)` instead. There is no post object yet, so that init can only pick the per-subreddit memory or Default Sort, and nothing revisits the choice once the post arrives. In the binary, `suggestedSort` is only read by `init(link:)` and the sort menu, never by `loadComments()` or its completion.

So a post whose subreddit sets its suggested sort to New opens on New from the feed but on the user's Default Sort from a highlights card. "Remember Post Sort" had the same gap for URL opens, since its viewDidLoad write needs the post to look the saved sort up.

## The fix

New module `src/ApolloURLOpenCommentSort.xm`:

- `viewDidLoad` on a link-less `CommentsViewController` arms a one-shot keyed by the post id (the `linkID` ivar). Comment-permalink opens (context views) are skipped on purpose; they load through a different call and stay stock.
- The `RDKClient` comments fetch hook (`linkAndCommentsForLinkWithIdentifier:commentSort:pagination:completion:`) consumes that arm for the matching post id and wraps the completion. When the response's post asks for a different sort than the one fetched (evaluated with the same chain `init(link:)` uses, "Remember Post Sort" on top), it writes `currentSort`, re-issues the identical fetch on the corrected sort, and hands that response to Apollo's completion. Apollo renders once, already on the right sort. The second round-trip only happens when the two sorts differ; if it fails, the first response is shown and the sort is put back.
- The nav-bar sort icon was already drawn from the pre-fetch sort, so it is redrawn the way Apollo's own updater does it (`option-sort-<name>` asset plus the "Sort by …" accessibility label). Live goes to the network as New, exactly as `loadComments` sends it.
- `ApolloPerPostCommentSort.xm` exports its `currentSort`/`link` ivar helpers and the saved-sort lookup through a new `ApolloPerPostCommentSort.h`, so the layout knowledge stays in one place. Its header note about URL opens keeping native behaviour is updated.

Arm bookkeeping is main-thread only and keyed by id: a fetch for any other post passes straight through, the arm is dropped when its controller disappears (popped before the load, cancelled swipe-back) or replaced by the next link-less open, and it survives Apollo's own deferred load (with "Remember Subreddit Sort" on and a URL that names no subreddit, Apollo resolves the post first and fetches comments afterwards).

## Verification

- Clean synthetic merge (`git merge-tree`) on current `apollo-reborn/main` (e3e584c), `git diff --check` clean, `make package` with the pinned iOS 26.0 SDK builds. Sibling PRs #1099/#1060/#1048 merge cleanly with this branch; #1062/#1057/#1055/#1054 conflict on files this PR does not touch (same conflicts exist against plain main).
- Simulator launch shows `[URLOpenSort] ctor: hooks installed (CommentsViewController.viewDidLoad, RDKClient.linkAndCommentsForLinkWithIdentifier:commentSort:pagination:completion:)`; the fetch completion signature logged at runtime is `v24@?0@"NSDictionary"8@"NSError"16`, matching the RE.
- Hopper-verified against the Apollo binary: `init(link:)` (sub_100725044) vs `init(linkID:…)` (sub_100722458) sort chains, `loadComments` (sub_100722d24) and its "No sort set, setting to top" fallback plus the deferred `linkWithFullName:` path, the RDKClient completion shape (sub_100039680 / sub_100039788), the sort-icon updater (sub_1006feeb4, `option-sort-*` assets and "Sort by …" labels), `DefaultCommentsSort` string map (sub_100441058), `RedditCommentsSortMapping` reader (sub_10044395c), ivars `link` / `linkID` / `commentID` / `currentSort` / `sortBarButtonItem`. `suggestedSort` is referenced only by `init(link:)` and the sort menu.
- Sim A/B on r/soccer's Daily Discussion (suggested sort New, Default Sort Top): main opens the highlights card on Top; this branch opens it on New, icon and menu agree, comments are in New order. Feed tap of a normal post logs no arm and stays stock.
- Launch-argument matrix: Ignore Suggested Sort on → stays on Default Sort, no re-fetch; Default Sort = new → matches, no re-fetch; Remember Post Sort with a saved Best → opens on Best; Remember Subreddit Sort (soccer=Best) with the `r/` URL → Apollo already picked Best, no re-fetch; same with the subreddit-less `reddit.com/comments/<id>` URL → Apollo's deferred two-step load is caught and corrected to New (or kept on Best with Ignore Suggested Sort on); comment permalink URL → skipped ("comment permalink open; leaving it to Apollo").
- Modes matrix: API-key account (Apollo-SBar, glass), keyless web-session account (Apollo-Gallery, `RemZeroBestGirl` cookie session active: same Top → New correction), non-glass simulator shell (Apollo's own nav bar, icon redraw verified), cancelled swipe-back on a corrected post (pop animator finished cancelled=1, view intact, no stale arm).
- Not run: the corrected-fetch failure path (code-read only: first response delivered, sort restored); no iPad; no physical device yet (no WebKit, memory or account-switching surface in this change).

